### PR TITLE
fix(scaffold): address remaining review findings

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -35,7 +35,7 @@ sequenceDiagram
 
 | Component | Role | Location |
 |-----------|------|----------|
-| **HAProxy** | Reverse proxy, HTTPS termination, vhost routing, SPOE | `configs/haproxy/` |
+| **HAProxy** | Reverse proxy, HTTPS termination, vhost routing, SPOE | `configs/haproxy/` *(planned)* |
 | **Coraza SPOA** | WAF engine, OWASP CRS, anomaly scoring, per-vhost rules | *(planned)* |
 | **FastAPI Backend** | Policy management API, config generation | `src/backend/` |
 | **React Frontend** | Admin panel UI, policy editor | `src/frontend/` *(planned)* |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ graph TB
 
 - **Proxy**: HAProxy 2.8+ with SPOE
 - **WAF**: Coraza 3.x + OWASP CRS 4.x
-- **Backend**: Python 3.12, FastAPI, SQLAlchemy, PostgreSQL
+- **Backend**: Python 3.13, FastAPI, SQLAlchemy, PostgreSQL
 - **Frontend**: React, TypeScript, Tailwind CSS
 - **Infrastructure**: Docker Compose, Prometheus, Grafana
 

--- a/src/backend/alembic/versions/13e761207c57_create_initial_tables.py
+++ b/src/backend/alembic/versions/13e761207c57_create_initial_tables.py
@@ -137,6 +137,7 @@ def downgrade() -> None:
     # ### end Alembic commands ###
 
     # PostgreSQL creates enum types as separate DB objects — drop them explicitly.
-    # SQLite ignores these statements (no native enum types).
-    op.execute("DROP TYPE IF EXISTS userrole")
-    op.execute("DROP TYPE IF EXISTS ruleaction")
+    # SQLite has no native enum type, so this block must be skipped there.
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS userrole")
+        op.execute("DROP TYPE IF EXISTS ruleaction")


### PR DESCRIPTION
- guard DROP TYPE in downgrade() to PostgreSQL only (SQLite has no native enum types)
- mark configs/haproxy/ as planned in README.architecture (directory is empty)
- update Python version to 3.13 in README