### PR TITLE
feat(vhosts): add VHosts CRUD API with RBAC

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.config import settings
-from app.routers import auth, policies
+from app.routers import auth, policies, vhosts
 
 
 @asynccontextmanager
@@ -23,6 +23,7 @@ app = FastAPI(
 
 app.include_router(auth.router)
 app.include_router(policies.router)
+app.include_router(vhosts.router)
 
 
 @app.get("/health")

--- a/src/backend/app/routers/vhosts.py
+++ b/src/backend/app/routers/vhosts.py
@@ -1,0 +1,164 @@
+"""Router VHosts API — CRUD wirtualnych hostów."""
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from app.database import get_db
+from app.dependencies import get_current_user, require_admin
+from app.models.policy import Policy
+from app.models.user import User
+from app.models.vhost import VHost
+from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
+
+router = APIRouter(prefix="/vhosts", tags=["vhosts"])
+
+NON_NULLABLE_PATCH_FIELDS = {
+    "domain",
+    "backend_url",
+    "ssl_enabled",
+    "is_active",
+}
+
+
+def _is_vhost_domain_unique_violation(error: IntegrityError) -> bool:
+    """Sprawdza, czy IntegrityError dotyczy unikalnej domeny vhosta."""
+    error_text = str(error.orig).lower()
+    return "unique" in error_text and "domain" in error_text
+
+
+def _get_vhost_or_404(db: Session, vhost_id: int) -> VHost:
+    """Zwraca vhost po ID albo 404 gdy nie istnieje."""
+    vhost = db.get(VHost, vhost_id)
+    if vhost is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        )
+    return vhost
+
+
+def _ensure_policy_exists(db: Session, policy_id: int | None) -> None:
+    """Waliduje policy_id, jeśli request wskazuje konkretną politykę."""
+    if policy_id is not None and db.get(Policy, policy_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        )
+
+
+@router.post("", response_model=VHostResponse, status_code=status.HTTP_201_CREATED)
+def create_vhost(
+    body: VHostCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_admin),
+) -> VHost:
+    """Tworzy nowy vhost (tylko admin)."""
+    _ensure_policy_exists(db, body.policy_id)
+
+    vhost = VHost(
+        domain=body.domain,
+        backend_url=body.backend_url,
+        description=body.description,
+        ssl_enabled=body.ssl_enabled,
+        is_active=body.is_active,
+        policy_id=body.policy_id,
+        created_by=current_user.id,
+    )
+    db.add(vhost)
+
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        if _is_vhost_domain_unique_violation(error):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="VHost domain already exists",
+            )
+        raise
+
+    db.refresh(vhost)
+    return vhost
+
+
+@router.get("", response_model=list[VHostResponse])
+def list_vhosts(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[VHost]:
+    """Zwraca listę vhostów (admin i viewer)."""
+    return db.query(VHost).order_by(VHost.id.asc()).all()
+
+
+@router.get("/{vhost_id}", response_model=VHostDetail)
+def get_vhost(
+    vhost_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> VHost:
+    """Zwraca szczegóły vhosta razem z pełną polityką."""
+    vhost = (
+        db.query(VHost)
+        .options(selectinload(VHost.policy))
+        .filter(VHost.id == vhost_id)
+        .first()
+    )
+    if vhost is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        )
+    return vhost
+
+
+@router.patch("/{vhost_id}", response_model=VHostResponse)
+def update_vhost(
+    vhost_id: int,
+    body: VHostUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> VHost:
+    """Aktualizuje wskazane pola vhosta (tylko admin)."""
+    vhost = _get_vhost_or_404(db, vhost_id)
+    patch_data = body.model_dump(exclude_unset=True)
+
+    for field in NON_NULLABLE_PATCH_FIELDS:
+        if field in patch_data and patch_data[field] is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Field '{field}' cannot be null",
+            )
+
+    if "policy_id" in patch_data:
+        _ensure_policy_exists(db, patch_data["policy_id"])
+
+    for field, value in patch_data.items():
+        setattr(vhost, field, value)
+
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        if _is_vhost_domain_unique_violation(error):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="VHost domain already exists",
+            )
+        raise
+
+    db.refresh(vhost)
+    return vhost
+
+
+@router.delete("/{vhost_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_vhost(
+    vhost_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> Response:
+    """Usuwa vhost po ID (tylko admin)."""
+    vhost = _get_vhost_or_404(db, vhost_id)
+    db.delete(vhost)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/schemas/vhost.py
+++ b/src/backend/app/schemas/vhost.py
@@ -63,6 +63,28 @@ class VHostUpdate(BaseModel):
     is_active: bool | None = None
     policy_id: int | None = None
 
+    @field_validator("domain")
+    @classmethod
+    def domain_no_protocol(cls, v: str | None) -> str | None:
+        """Jeśli domain jest podane w PATCH, walidujemy je tak samo jak w POST."""
+        if v is None:
+            return None
+        v = v.strip().lower()
+        if v.startswith(("http://", "https://")):
+            raise ValueError("Domain should not include protocol (http:// or https://)")
+        return v
+
+    @field_validator("backend_url")
+    @classmethod
+    def backend_url_has_protocol(cls, v: str | None) -> str | None:
+        """Jeśli backend_url jest podane w PATCH, musi nadal mieć protokół."""
+        if v is None:
+            return None
+        v = v.strip()
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("Backend URL must start with http:// or https://")
+        return v
+
 
 class VHostResponse(BaseModel):
     """Response body dla GET /vhosts (lista) — BEZ zagnieżdżonej polityki."""

--- a/src/backend/tests/integration/test_vhosts_router.py
+++ b/src/backend/tests/integration/test_vhosts_router.py
@@ -1,0 +1,390 @@
+"""Testy integracyjne routera vhosts (CRUD + autoryzacja)."""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.models.user import User
+
+
+def _create_policy(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    name: str = "Default Policy",
+) -> dict[str, Any]:
+    """Pomocniczo tworzy politykę do przypisania vhostowi."""
+    resp = client.post(
+        "/policies",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Policy for vhosts",
+            "paranoia_level": 2,
+            "anomaly_threshold": 5,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_vhost(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    domain: str = "example.com",
+    backend_url: str = "http://localhost:8080",
+    description: str | None = "Primary site",
+    ssl_enabled: bool = False,
+    is_active: bool = True,
+    policy_id: int | None = None,
+) -> dict[str, Any]:
+    """Pomocniczo tworzy vhost i zwraca body JSON."""
+    resp = client.post(
+        "/vhosts",
+        headers=headers,
+        json={
+            "domain": domain,
+            "backend_url": backend_url,
+            "description": description,
+            "ssl_enabled": ssl_enabled,
+            "is_active": is_active,
+            "policy_id": policy_id,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /vhosts
+# ---------------------------------------------------------------------------
+
+
+def test_create_vhost_admin_returns_201(
+    client: TestClient,
+    admin_token: dict[str, str],
+    admin_user: User,
+) -> None:
+    """Admin może utworzyć vhost."""
+    policy = _create_policy(client, admin_token, name="Assigned")
+
+    resp = client.post(
+        "/vhosts",
+        headers=admin_token,
+        json={
+            "domain": "App.Example.com",
+            "backend_url": "http://localhost:3000",
+            "description": "Main app",
+            "ssl_enabled": True,
+            "is_active": True,
+            "policy_id": policy["id"],
+        },
+    )
+    assert resp.status_code == 201
+
+    body = resp.json()
+    assert body["id"] > 0
+    assert body["domain"] == "app.example.com"
+    assert body["backend_url"] == "http://localhost:3000"
+    assert body["description"] == "Main app"
+    assert body["ssl_enabled"] is True
+    assert body["is_active"] is True
+    assert body["policy_id"] == policy["id"]
+    assert body["created_by"] == admin_user.id
+
+
+def test_create_vhost_viewer_forbidden(
+    client: TestClient,
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer nie może tworzyć vhostów."""
+    resp = client.post(
+        "/vhosts",
+        headers=viewer_token,
+        json={
+            "domain": "viewer.example.com",
+            "backend_url": "http://localhost:3000",
+        },
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_create_vhost_duplicate_domain_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Drugi vhost z tą samą domeną -> 409."""
+    _create_vhost(client, admin_token, domain="dup.example.com")
+
+    resp = client.post(
+        "/vhosts",
+        headers=admin_token,
+        json={
+            "domain": "dup.example.com",
+            "backend_url": "http://localhost:4000",
+        },
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "VHost domain already exists"
+
+
+def test_create_vhost_with_missing_policy_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Nie można wskazać policy_id, które nie istnieje."""
+    resp = client.post(
+        "/vhosts",
+        headers=admin_token,
+        json={
+            "domain": "missing-policy.example.com",
+            "backend_url": "http://localhost:3000",
+            "policy_id": 99999,
+        },
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+# ---------------------------------------------------------------------------
+# GET /vhosts
+# ---------------------------------------------------------------------------
+
+
+def test_list_vhosts_admin_returns_200(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Admin może pobrać listę vhostów."""
+    _create_vhost(client, admin_token, domain="a.example.com")
+    _create_vhost(client, admin_token, domain="b.example.com")
+
+    resp = client.get("/vhosts", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 2
+    assert body[0]["domain"] == "a.example.com"
+    assert body[1]["domain"] == "b.example.com"
+
+
+def test_list_vhosts_viewer_returns_200(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer ma dostęp tylko do odczytu listy."""
+    _create_vhost(client, admin_token, domain="readable.example.com")
+
+    resp = client.get("/vhosts", headers=viewer_token)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_list_vhosts_requires_auth(client: TestClient) -> None:
+    """Brak tokena -> 401."""
+    resp = client.get("/vhosts")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /vhosts/{vhost_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_vhost_returns_detail_with_policy(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Szczegóły vhosta zawierają zagnieżdżoną politykę."""
+    policy = _create_policy(client, admin_token, name="Nested policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="detail.example.com",
+        policy_id=policy["id"],
+    )
+
+    resp = client.get(f"/vhosts/{created['id']}", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["id"] == created["id"]
+    assert body["domain"] == "detail.example.com"
+    assert body["policy"]["id"] == policy["id"]
+    assert body["policy"]["name"] == "Nested policy"
+
+
+def test_get_vhost_not_found_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Brak vhosta o danym ID -> 404."""
+    resp = client.get("/vhosts/99999", headers=admin_token)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "VHost not found"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /vhosts/{vhost_id}
+# ---------------------------------------------------------------------------
+
+
+def test_patch_vhost_admin_partial_update(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """PATCH aktualizuje tylko wskazane pola vhosta."""
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="patch.example.com",
+        backend_url="http://localhost:3000",
+        description="Before",
+        ssl_enabled=False,
+        is_active=True,
+    )
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=admin_token,
+        json={
+            "backend_url": "https://backend.internal:443",
+            "ssl_enabled": True,
+        },
+    )
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["domain"] == "patch.example.com"
+    assert body["description"] == "Before"
+    assert body["backend_url"] == "https://backend.internal:443"
+    assert body["ssl_enabled"] is True
+    assert body["is_active"] is True
+
+
+def test_patch_vhost_viewer_forbidden(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer nie może modyfikować vhosta."""
+    created = _create_vhost(client, admin_token, domain="no-patch.example.com")
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=viewer_token,
+        json={"domain": "blocked.example.com"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_patch_vhost_duplicate_domain_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Zmiana domeny na istniejącą -> 409."""
+    _create_vhost(client, admin_token, domain="alpha.example.com")
+    second = _create_vhost(client, admin_token, domain="beta.example.com")
+
+    resp = client.patch(
+        f"/vhosts/{second['id']}",
+        headers=admin_token,
+        json={"domain": "alpha.example.com"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "VHost domain already exists"
+
+
+def test_patch_vhost_with_missing_policy_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """PATCH nie pozwala przypisać nieistniejącej polityki."""
+    created = _create_vhost(client, admin_token, domain="missing-patch.example.com")
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=admin_token,
+        json={"policy_id": 99999},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_patch_vhost_domain_null_returns_422(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """PATCH z domain=null powinien być odrzucony jako 422."""
+    created = _create_vhost(client, admin_token, domain="null.example.com")
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=admin_token,
+        json={"domain": None},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Field 'domain' cannot be null"
+
+
+def test_patch_vhost_backend_url_without_protocol_returns_422(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """PATCH musi walidować backend_url tak samo jak POST."""
+    created = _create_vhost(client, admin_token, domain="invalid-url.example.com")
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=admin_token,
+        json={"backend_url": "backend.internal:443"},
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /vhosts/{vhost_id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_vhost_admin_returns_204(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Admin może usunąć vhost."""
+    created = _create_vhost(client, admin_token, domain="delete.example.com")
+
+    resp = client.delete(f"/vhosts/{created['id']}", headers=admin_token)
+    assert resp.status_code == 204
+    assert resp.text == ""
+
+    get_resp = client.get(f"/vhosts/{created['id']}", headers=admin_token)
+    assert get_resp.status_code == 404
+
+
+def test_delete_vhost_viewer_forbidden(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer nie może usuwać vhosta."""
+    created = _create_vhost(client, admin_token, domain="no-delete.example.com")
+
+    resp = client.delete(f"/vhosts/{created['id']}", headers=viewer_token)
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_delete_vhost_not_found_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """DELETE nieistniejącego vhosta -> 404."""
+    resp = client.delete("/vhosts/99999", headers=admin_token)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "VHost not found"


### PR DESCRIPTION
- add POST /vhosts and GET /vhosts endpoints with VHostResponse
- add GET /vhosts/{vhost_id} endpoint with VHostDetail
- add PATCH /vhosts/{vhost_id} endpoint for partial updates
- add DELETE /vhosts/{vhost_id} endpoint
- add VHostUpdate validation for domain and backend_url
- add integration tests for auth, create, list, detail, update, delete, and 404 cases