### PR TITLE
feat(66/rule-overrides): add rule overrides CRUD API

### DIFF
--- a/src/backend/alembic/versions/1f4a7f0f9a11_add_rule_override_unique_constraint.py
+++ b/src/backend/alembic/versions/1f4a7f0f9a11_add_rule_override_unique_constraint.py
@@ -1,0 +1,36 @@
+"""add unique constraint for rule overrides
+
+Revision ID: 1f4a7f0f9a11
+Revises: 7e0f9c2c9e62
+Create Date: 2026-04-10 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1f4a7f0f9a11"
+down_revision: Union[str, Sequence[str], None] = "7e0f9c2c9e62"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("rule_overrides") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_rule_overrides_policy_id_rule_id",
+            ["policy_id", "rule_id"],
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("rule_overrides") as batch_op:
+        batch_op.drop_constraint(
+            "uq_rule_overrides_policy_id_rule_id",
+            type_="unique",
+        )

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -5,8 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.routers import auth, logs, policies, vhosts
-
+from app.routers import auth, logs, policies, rule_overrides, vhosts
 
 
 @asynccontextmanager
@@ -34,6 +33,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(logs.router)
 app.include_router(policies.router)
+app.include_router(rule_overrides.router)
 app.include_router(vhosts.router)
 
 

--- a/src/backend/app/models/rule_override.py
+++ b/src/backend/app/models/rule_override.py
@@ -1,4 +1,4 @@
-"""RuleOverride model — nadpisania reguł OWASP CRS w ramach polityki WAF."""
+"""RuleOverride model for OWASP CRS rule overrides within a WAF policy."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import enum
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Integer, Text, func
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, Text, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 
 
 class RuleAction(enum.StrEnum):
-    """Akcja nadpisania reguły CRS.
+    """Action applied to a CRS rule override.
 
-    enable  — włącz regułę (jeśli była wyłączona na niższym paranoia level)
-    disable — wyłącz regułę (np. powoduje false positives w Twojej aplikacji)
+    enable  — turn the rule on
+    disable — turn the rule off
     """
 
     enable = "enable"
@@ -27,42 +27,48 @@ class RuleAction(enum.StrEnum):
 
 
 class RuleOverride(Base):
-    """Tabela rule_overrides — nadpisania konkretnych reguł CRS w polityce.
+    """rule_overrides table storing policy-specific CRS rule overrides.
 
-    Przykład użycia:
-    - Polityka "Default" ma paranoia_level=2
-    - Reguła 942100 (SQL injection) powoduje false positives w Twojej apce
-    - Dodajesz RuleOverride(rule_id=942100, action=disable) dla tej polityki
-    - Guard Proxy wygeneruje konfigurację HAProxy z wyłączoną tą regułą
+    Example:
+    - The "Default" policy has paranoia_level=2
+    - Rule 942100 (SQL injection) produces false positives
+    - You add RuleOverride(rule_id=942100, action=disable) for that policy
+    - Guard Proxy can then generate config with that rule disabled
     """
 
     __tablename__ = "rule_overrides"
+    __table_args__ = (
+        UniqueConstraint(
+            "policy_id",
+            "rule_id",
+            name="uq_rule_overrides_policy_id_rule_id",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    # Relacja do Policy — nadpisanie należy do konkretnej polityki
-    # ondelete="CASCADE" — jeśli polityka zostanie usunięta, usuń też jej nadpisania
-    #                      (w przeciwieństwie do vhosts gdzie SET NULL ma sens)
+    # Relationship to Policy: every override belongs to one policy.
+    # ondelete="CASCADE" means overrides are removed when the policy is deleted.
     policy_id: Mapped[int] = mapped_column(
         ForeignKey("policies.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,  # często będziemy pytać "jakie nadpisania ma polityka X?"
+        index=True,  # We often query "which overrides belong to policy X?"
     )
 
-    # Numer reguły OWASP CRS — np. 941100 (XSS), 942100 (SQLi)
+    # OWASP CRS rule number, for example 941100 (XSS) or 942100 (SQLi).
     rule_id: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    # Co zrobić z regułą
+    # Desired action for that rule.
     action: Mapped[RuleAction] = mapped_column(Enum(RuleAction), nullable=False)
 
-    # Opcjonalny komentarz — dlaczego wyłączasz/włączasz tę regułę
+    # Optional note explaining why the rule is enabled or disabled.
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
     )
 
-    # Relacja ORM do Policy (druga strona relacji z policy.rule_overrides)
+    # ORM relationship back to Policy (the other side is policy.rule_overrides).
     policy: Mapped[Policy] = relationship(  # noqa: F821
         "Policy",
         back_populates="rule_overrides",

--- a/src/backend/app/routers/rule_overrides.py
+++ b/src/backend/app/routers/rule_overrides.py
@@ -1,0 +1,171 @@
+"""Rule Overrides API router for CRUD operations within a policy."""
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user, require_admin
+from app.models.policy import Policy
+from app.models.rule_override import RuleOverride
+from app.models.user import User
+from app.schemas.rule_override import (
+    RuleOverrideCreate,
+    RuleOverrideResponse,
+    RuleOverrideUpdate,
+)
+
+router = APIRouter(prefix="/policies/{policy_id}/rules", tags=["rule-overrides"])
+
+
+def _is_rule_override_unique_violation(error: IntegrityError) -> bool:
+    """Check whether an IntegrityError comes from a duplicate rule override."""
+    error_text = str(error.orig).lower()
+    return (
+        "unique" in error_text
+        and "rule_overrides" in error_text
+        and "rule_id" in error_text
+        and "policy_id" in error_text
+    )
+
+
+def _get_policy_or_404(db: Session, policy_id: int) -> Policy:
+    """Return a policy by ID or raise 404 if it does not exist."""
+    policy = db.get(Policy, policy_id)
+    if policy is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        )
+    return policy
+
+
+def _get_rule_override_or_404(
+    db: Session, policy_id: int, rule_override_id: int
+) -> RuleOverride:
+    """Return an override scoped to a policy or raise 404 if missing."""
+    rule_override = (
+        db.query(RuleOverride)
+        .filter(
+            RuleOverride.policy_id == policy_id,
+            RuleOverride.id == rule_override_id,
+        )
+        .first()
+    )
+    if rule_override is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rule override not found",
+        )
+    return rule_override
+
+
+@router.post(
+    "",
+    response_model=RuleOverrideResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_rule_override(
+    policy_id: int,
+    body: RuleOverrideCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> RuleOverride:
+    """Create a CRS rule override for the given policy (admin only)."""
+    _get_policy_or_404(db, policy_id)
+
+    rule_override = RuleOverride(
+        policy_id=policy_id,
+        rule_id=body.rule_id,
+        action=body.action,
+        comment=body.comment,
+    )
+    db.add(rule_override)
+
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        if _is_rule_override_unique_violation(error):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Rule override already exists",
+            )
+        raise
+
+    db.refresh(rule_override)
+    return rule_override
+
+
+@router.get("", response_model=list[RuleOverrideResponse])
+def list_rule_overrides(
+    policy_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[RuleOverride]:
+    """Return all rule overrides for the given policy."""
+    _get_policy_or_404(db, policy_id)
+    return (
+        db.query(RuleOverride)
+        .filter(RuleOverride.policy_id == policy_id)
+        .order_by(RuleOverride.id.asc())
+        .all()
+    )
+
+
+@router.get("/{rule_override_id}", response_model=RuleOverrideResponse)
+def get_rule_override(
+    policy_id: int,
+    rule_override_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> RuleOverride:
+    """Return a single rule override scoped to the given policy."""
+    _get_policy_or_404(db, policy_id)
+    return _get_rule_override_or_404(db, policy_id, rule_override_id)
+
+
+@router.patch("/{rule_override_id}", response_model=RuleOverrideResponse)
+def update_rule_override(
+    policy_id: int,
+    rule_override_id: int,
+    body: RuleOverrideUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> RuleOverride:
+    """Update selected fields of a rule override (admin only)."""
+    _get_policy_or_404(db, policy_id)
+    rule_override = _get_rule_override_or_404(db, policy_id, rule_override_id)
+    patch_data = body.model_dump(exclude_unset=True)
+
+    for field, value in patch_data.items():
+        setattr(rule_override, field, value)
+
+    try:
+        db.commit()
+    except IntegrityError as error:
+        db.rollback()
+        if _is_rule_override_unique_violation(error):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Rule override already exists",
+            )
+        raise
+
+    db.refresh(rule_override)
+    return rule_override
+
+
+@router.delete("/{rule_override_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_rule_override(
+    policy_id: int,
+    rule_override_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> Response:
+    """Delete a rule override from a policy (admin only)."""
+    _get_policy_or_404(db, policy_id)
+    rule_override = _get_rule_override_or_404(db, policy_id, rule_override_id)
+    db.delete(rule_override)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/routers/rule_overrides.py
+++ b/src/backend/app/routers/rule_overrides.py
@@ -25,9 +25,10 @@ _UNIQUE_CONSTRAINT = "uq_rule_overrides_policy_id_rule_id"
 def _is_rule_override_unique_violation(error: IntegrityError) -> bool:
     """Check whether an IntegrityError comes from a duplicate rule override."""
     error_text = str(error.orig).lower()
-    # PostgreSQL includes the constraint name; SQLite reports column names instead
+    # PostgreSQL includes the constraint name; SQLite includes column names instead
     return _UNIQUE_CONSTRAINT in error_text or (
         "unique" in error_text
+        and "rule_overrides" in error_text
         and "rule_id" in error_text
         and "policy_id" in error_text
     )

--- a/src/backend/app/routers/rule_overrides.py
+++ b/src/backend/app/routers/rule_overrides.py
@@ -17,13 +17,17 @@ from app.schemas.rule_override import (
 
 router = APIRouter(prefix="/policies/{policy_id}/rules", tags=["rule-overrides"])
 
+NON_NULLABLE_PATCH_FIELDS = {"rule_id", "action"}
+
+_UNIQUE_CONSTRAINT = "uq_rule_overrides_policy_id_rule_id"
+
 
 def _is_rule_override_unique_violation(error: IntegrityError) -> bool:
     """Check whether an IntegrityError comes from a duplicate rule override."""
     error_text = str(error.orig).lower()
-    return (
+    # PostgreSQL includes the constraint name; SQLite reports column names instead
+    return _UNIQUE_CONSTRAINT in error_text or (
         "unique" in error_text
-        and "rule_overrides" in error_text
         and "rule_id" in error_text
         and "policy_id" in error_text
     )
@@ -137,6 +141,13 @@ def update_rule_override(
     _get_policy_or_404(db, policy_id)
     rule_override = _get_rule_override_or_404(db, policy_id, rule_override_id)
     patch_data = body.model_dump(exclude_unset=True)
+
+    for field in NON_NULLABLE_PATCH_FIELDS:
+        if field in patch_data and patch_data[field] is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Field '{field}' cannot be null",
+            )
 
     for field, value in patch_data.items():
         setattr(rule_override, field, value)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -1,10 +1,13 @@
-"""Schematy Pydantic — walidacja requestów i serializacja odpowiedzi API."""
+"""Pydantic schemas used for request validation and API serialization."""
 
-from app.schemas.auth import AccessTokenResponse, LoginRequest, TokenData, LoginRequest
+from app.schemas.auth import AccessTokenResponse, LoginRequest, TokenData
 from app.schemas.log import LogListResponse, LogResponse
-
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
-from app.schemas.rule_override import RuleOverrideCreate, RuleOverrideResponse
+from app.schemas.rule_override import (
+    RuleOverrideCreate,
+    RuleOverrideResponse,
+    RuleOverrideUpdate,
+)
 from app.schemas.user import UserCreate, UserResponse, UserUpdate
 from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
 
@@ -30,7 +33,8 @@ __all__ = [
     "VHostUpdate",
     "VHostResponse",
     "VHostDetail",
-    # Rule Overrides
+    # Rule overrides
     "RuleOverrideCreate",
     "RuleOverrideResponse",
+    "RuleOverrideUpdate",
 ]

--- a/src/backend/app/schemas/rule_override.py
+++ b/src/backend/app/schemas/rule_override.py
@@ -1,22 +1,46 @@
-"""Schematy Pydantic dla nadpisań reguł WAF (rule overrides)."""
+"""Pydantic schemas for WAF rule overrides."""
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from app.models.rule_override import RuleAction
 
 
 class RuleOverrideCreate(BaseModel):
-    """Request body dla POST /policies/{id}/rules."""
+    """Request body for POST /policies/{id}/rules."""
 
-    rule_id: int  # numer reguły OWASP CRS, np. 942100
-    action: RuleAction  # "enable" lub "disable"
+    rule_id: int  # OWASP CRS rule number, for example 942100.
+    action: RuleAction  # Allowed values: "enable" or "disable".
     comment: str | None = None
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_must_be_positive(cls, value: int) -> int:
+        """Require the rule ID to be a positive integer."""
+        if value <= 0:
+            raise ValueError("Rule ID must be greater than 0")
+        return value
+
+
+class RuleOverrideUpdate(BaseModel):
+    """Request body for PATCH /policies/{id}/rules/{rule_override_id}."""
+
+    rule_id: int | None = None
+    action: RuleAction | None = None
+    comment: str | None = None
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_must_be_positive(cls, value: int | None) -> int | None:
+        """If rule_id is provided, it must be positive."""
+        if value is not None and value <= 0:
+            raise ValueError("Rule ID must be greater than 0")
+        return value
 
 
 class RuleOverrideResponse(BaseModel):
-    """Response body dla GET /policies/{id}/rules."""
+    """Response body for GET /policies/{id}/rules."""
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/backend/tests/integration/test_policies_router.py
+++ b/src/backend/tests/integration/test_policies_router.py
@@ -1,7 +1,8 @@
 """Testy integracyjne routera policies (CRUD + autoryzacja)."""
 
-from fastapi.testclient import TestClient
 from typing import Any
+
+from fastapi.testclient import TestClient
 
 from app.models.user import User
 

--- a/src/backend/tests/integration/test_rule_overrides_router.py
+++ b/src/backend/tests/integration/test_rule_overrides_router.py
@@ -271,6 +271,40 @@ def test_patch_rule_override_missing_override_returns_404(
     assert resp.json()["detail"] == "Rule override not found"
 
 
+def test_patch_rule_override_null_rule_id_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting rule_id to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null rule_id")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+        json={"rule_id": None},
+    )
+
+    assert resp.status_code == 422
+    assert "rule_id" in resp.json()["detail"]
+
+
+def test_patch_rule_override_null_action_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting action to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null action")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+        json={"action": None},
+    )
+
+    assert resp.status_code == 422
+    assert "action" in resp.json()["detail"]
+
+
 def test_delete_rule_override_admin_returns_204(
     client: TestClient, admin_token: dict[str, str]
 ) -> None:

--- a/src/backend/tests/integration/test_rule_overrides_router.py
+++ b/src/backend/tests/integration/test_rule_overrides_router.py
@@ -1,0 +1,309 @@
+"""Integration tests for the rule overrides router."""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+def _create_policy(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    name: str = "Policy for rules",
+) -> dict[str, Any]:
+    """Helper that creates a policy for rule override tests."""
+    resp = client.post(
+        "/policies",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Policy used in rule override tests",
+            "paranoia_level": 2,
+            "anomaly_threshold": 5,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_rule_override(
+    client: TestClient,
+    headers: dict[str, str],
+    policy_id: int,
+    *,
+    rule_id: int = 942100,
+    action: str = "disable",
+    comment: str | None = "False positive on search form",
+) -> dict[str, Any]:
+    """Helper that creates a rule override for the given policy."""
+    resp = client.post(
+        f"/policies/{policy_id}/rules",
+        headers=headers,
+        json={"rule_id": rule_id, "action": action, "comment": comment},
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_create_rule_override_admin_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can add a rule override to an existing policy."""
+    policy = _create_policy(client, admin_token)
+
+    resp = client.post(
+        f"/policies/{policy['id']}/rules",
+        headers=admin_token,
+        json={
+            "rule_id": 942100,
+            "action": "disable",
+            "comment": "False positive on search form",
+        },
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["policy_id"] == policy["id"]
+    assert body["rule_id"] == 942100
+    assert body["action"] == "disable"
+    assert body["comment"] == "False positive on search form"
+
+
+def test_create_rule_override_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot create a rule override."""
+    policy = _create_policy(client, admin_token, name="Viewer blocked")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/rules",
+        headers=viewer_token,
+        json={"rule_id": 942100, "action": "disable"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_create_rule_override_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Creating an override for a missing policy returns 404."""
+    resp = client.post(
+        "/policies/99999/rules",
+        headers=admin_token,
+        json={"rule_id": 942100, "action": "disable"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_create_rule_override_duplicate_returns_409(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """The same rule_id cannot be added twice to one policy."""
+    policy = _create_policy(client, admin_token, name="Duplicate policy")
+    _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.post(
+        f"/policies/{policy['id']}/rules",
+        headers=admin_token,
+        json={"rule_id": 942100, "action": "enable"},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Rule override already exists"
+
+
+def test_list_rule_overrides_admin_and_viewer_return_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """Admins and viewers can list overrides assigned to a policy."""
+    policy = _create_policy(client, admin_token, name="List policy")
+    _create_rule_override(
+        client, admin_token, policy["id"], rule_id=941100, action="enable"
+    )
+    _create_rule_override(
+        client, admin_token, policy["id"], rule_id=942100, action="disable"
+    )
+
+    admin_resp = client.get(f"/policies/{policy['id']}/rules", headers=admin_token)
+    viewer_resp = client.get(f"/policies/{policy['id']}/rules", headers=viewer_token)
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert [item["rule_id"] for item in admin_resp.json()] == [941100, 942100]
+    assert [item["rule_id"] for item in viewer_resp.json()] == [941100, 942100]
+
+
+def test_list_rule_overrides_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Listing overrides requires an existing policy."""
+    resp = client.get("/policies/99999/rules", headers=admin_token)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_get_rule_override_returns_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A single override can be read by both admin and viewer."""
+    policy = _create_policy(client, admin_token, name="Detail policy")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    admin_resp = client.get(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+    )
+    viewer_resp = client.get(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert admin_resp.json()["id"] == created["id"]
+    assert viewer_resp.json()["id"] == created["id"]
+
+
+def test_get_rule_override_not_found_for_other_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An override from another policy cannot be read under the wrong policy ID."""
+    policy_one = _create_policy(client, admin_token, name="Policy one")
+    policy_two = _create_policy(client, admin_token, name="Policy two")
+    created = _create_rule_override(client, admin_token, policy_one["id"])
+
+    resp = client.get(
+        f"/policies/{policy_two['id']}/rules/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Rule override not found"
+
+
+def test_patch_rule_override_admin_partial_update(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH updates only the specified override fields."""
+    policy = _create_policy(client, admin_token, name="Patch policy")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+        json={"action": "enable", "comment": None},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rule_id"] == 942100
+    assert body["action"] == "enable"
+    assert body["comment"] is None
+
+
+def test_patch_rule_override_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot edit an override."""
+    policy = _create_policy(client, admin_token, name="Patch blocked")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=viewer_token,
+        json={"action": "enable"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_patch_rule_override_duplicate_rule_id_returns_409(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH cannot change rule_id to one already used in the same policy."""
+    policy = _create_policy(client, admin_token, name="Patch duplicate")
+    first = _create_rule_override(client, admin_token, policy["id"], rule_id=941100)
+    second = _create_rule_override(client, admin_token, policy["id"], rule_id=942100)
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/{second['id']}",
+        headers=admin_token,
+        json={"rule_id": first["rule_id"]},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Rule override already exists"
+
+
+def test_patch_rule_override_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH requires an existing policy."""
+    resp = client.patch(
+        "/policies/99999/rules/1",
+        headers=admin_token,
+        json={"action": "enable"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_patch_rule_override_missing_override_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH on a missing override returns 404."""
+    policy = _create_policy(client, admin_token, name="Patch missing override")
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/rules/99999",
+        headers=admin_token,
+        json={"action": "enable"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Rule override not found"
+
+
+def test_delete_rule_override_admin_returns_204(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can delete an override and it can no longer be fetched."""
+    policy = _create_policy(client, admin_token, name="Delete policy")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    delete_resp = client.delete(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+    )
+    get_resp = client.get(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert delete_resp.status_code == 204
+    assert delete_resp.text == ""
+    assert get_resp.status_code == 404
+    assert get_resp.json()["detail"] == "Rule override not found"
+
+
+def test_delete_rule_override_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot delete an override."""
+    policy = _create_policy(client, admin_token, name="Delete blocked")
+    created = _create_rule_override(client, admin_token, policy["id"])
+
+    resp = client.delete(
+        f"/policies/{policy['id']}/rules/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -1,8 +1,8 @@
-"""Testy jednostkowe schematów Pydantic.
+"""Unit tests for Pydantic schemas.
 
-Testujemy walidację danych wejściowych — bez bazy danych, bez HTTP.
-Pydantic waliduje dane przy tworzeniu obiektu, więc wystarczy sprawdzić
-czy ValidationError jest rzucany przy złych danych.
+These tests focus on input validation without a database or HTTP layer.
+Pydantic validates data when the object is created, so it is enough to
+check whether ValidationError is raised for invalid input.
 """
 
 import os
@@ -12,7 +12,12 @@ from pydantic import ValidationError
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
+from app.models.rule_override import RuleAction  # noqa: E402
 from app.schemas.policy import PolicyCreate, PolicyUpdate  # noqa: E402
+from app.schemas.rule_override import (  # noqa: E402
+    RuleOverrideCreate,
+    RuleOverrideUpdate,
+)
 from app.schemas.user import UserCreate, UserUpdate  # noqa: E402
 from app.schemas.vhost import VHostCreate  # noqa: E402
 
@@ -27,25 +32,25 @@ def test_user_create_valid() -> None:
 
 
 def test_user_create_password_too_short() -> None:
-    """Hasło krótsze niż 12 znaków powinno rzucić ValidationError."""
+    """A password shorter than 12 characters should raise ValidationError."""
     with pytest.raises(ValidationError, match="at least 12 characters"):
         UserCreate(email="jan@example.com", password="short", full_name="Jan")
 
 
 def test_user_create_password_exactly_12() -> None:
-    """Dokładnie 12 znaków to minimum — powinno przejść."""
+    """Exactly 12 characters is the minimum and should pass."""
     u = UserCreate(email="jan@example.com", password="a" * 12, full_name="Jan")
     assert len(u.password) == 12
 
 
 def test_user_create_invalid_email() -> None:
-    """Niepoprawny adres email powinien rzucić ValidationError."""
+    """An invalid email address should raise ValidationError."""
     with pytest.raises(ValidationError):
         UserCreate(email="not-an-email", password="supersecret123", full_name="Jan")
 
 
 def test_user_create_default_role_is_viewer() -> None:
-    """Domyślna rola to viewer — nie admin."""
+    """The default role should be viewer, not admin."""
     from app.models.user import UserRole
 
     u = UserCreate(email="jan@example.com", password="supersecret123", full_name="Jan")
@@ -58,20 +63,20 @@ def test_user_create_default_role_is_viewer() -> None:
 
 
 def test_user_update_all_none_is_valid() -> None:
-    """PATCH bez żadnych pól to poprawny request."""
+    """PATCH with no fields is a valid request."""
     u = UserUpdate()
     assert u.password is None
     assert u.email is None
 
 
 def test_user_update_password_none_is_valid() -> None:
-    """Brak zmiany hasła (None) nie powinien rzucać błędu."""
+    """Not changing the password (None) should not raise an error."""
     u = UserUpdate(full_name="Nowe Imię")
     assert u.password is None
 
 
 def test_user_update_password_too_short() -> None:
-    """Jeśli podano hasło, też musi mieć minimum 12 znaków."""
+    """If a password is provided, it must still be at least 12 characters."""
     with pytest.raises(ValidationError, match="at least 12 characters"):
         UserUpdate(password="tooshort")
 
@@ -92,19 +97,19 @@ def test_policy_create_valid() -> None:
 
 
 def test_policy_create_paranoia_level_zero() -> None:
-    """Paranoia level 0 jest poza zakresem 1–4."""
+    """Paranoia level 0 is outside the allowed 1-4 range."""
     with pytest.raises(ValidationError, match="between 1 and 4"):
         PolicyCreate(name="x", paranoia_level=0)
 
 
 def test_policy_create_paranoia_level_five() -> None:
-    """Paranoia level 5 jest poza zakresem 1–4."""
+    """Paranoia level 5 is outside the allowed 1-4 range."""
     with pytest.raises(ValidationError, match="between 1 and 4"):
         PolicyCreate(name="x", paranoia_level=5)
 
 
 def test_policy_create_paranoia_level_boundaries() -> None:
-    """Granice zakresu 1 i 4 powinny przejść walidację."""
+    """Boundary values 1 and 4 should pass validation."""
     p1 = PolicyCreate(name="x", paranoia_level=1)
     p4 = PolicyCreate(name="x", paranoia_level=4)
     assert p1.paranoia_level == 1
@@ -112,7 +117,7 @@ def test_policy_create_paranoia_level_boundaries() -> None:
 
 
 def test_policy_create_anomaly_threshold_zero() -> None:
-    """Próg anomalii 0 jest niepoprawny — musi być co najmniej 1."""
+    """An anomaly threshold of 0 is invalid; it must be at least 1."""
     with pytest.raises(ValidationError, match="at least 1"):
         PolicyCreate(name="x", anomaly_threshold=0)
 
@@ -128,7 +133,7 @@ def test_policy_create_anomaly_threshold_one_valid() -> None:
 
 
 # ---------------------------------------------------------------------------
-# PolicyUpdate — pola opcjonalne, ale walidowane gdy podane
+# PolicyUpdate: optional fields, but still validated when provided
 # ---------------------------------------------------------------------------
 
 
@@ -148,9 +153,44 @@ def test_policy_update_anomaly_zero_invalid() -> None:
 
 
 def test_policy_update_name_null_is_allowed_by_schema() -> None:
-    """Schema dopuszcza null; odrzucenie robi router (422)."""
+    """The schema allows null; the router rejects it with 422."""
     p = PolicyUpdate(name=None)
     assert p.name is None
+
+
+# ---------------------------------------------------------------------------
+# RuleOverride schemas
+# ---------------------------------------------------------------------------
+
+
+def test_rule_override_create_valid() -> None:
+    override = RuleOverrideCreate(
+        rule_id=942100,
+        action=RuleAction.disable,
+        comment=None,
+    )
+    assert override.rule_id == 942100
+    assert override.comment is None
+
+
+def test_rule_override_create_rule_id_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RuleOverrideCreate(rule_id=0, action=RuleAction.disable)
+
+
+def test_rule_override_update_valid() -> None:
+    override = RuleOverrideUpdate(
+        rule_id=941100,
+        action=RuleAction.enable,
+        comment=None,
+    )
+    assert override.rule_id == 941100
+    assert override.action == RuleAction.enable
+
+
+def test_rule_override_update_rule_id_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RuleOverrideUpdate(rule_id=-1)
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +205,7 @@ def test_vhost_create_valid() -> None:
 
 
 def test_vhost_create_domain_with_http_invalid() -> None:
-    """Domena nie powinna zawierać protokołu."""
+    """The domain should not include a protocol."""
     with pytest.raises(ValidationError, match="should not include protocol"):
         VHostCreate(domain="http://example.com", backend_url="http://localhost:8080")
 
@@ -176,19 +216,19 @@ def test_vhost_create_domain_with_https_invalid() -> None:
 
 
 def test_vhost_create_domain_lowercased() -> None:
-    """Domena jest normalizowana do lowercase."""
+    """The domain is normalized to lowercase."""
     v = VHostCreate(domain="EXAMPLE.COM", backend_url="http://localhost:8080")
     assert v.domain == "example.com"
 
 
 def test_vhost_create_domain_stripped() -> None:
-    """Spacje wokół domeny są usuwane przed walidacją."""
+    """Whitespace around the domain is stripped before validation."""
     v = VHostCreate(domain="  example.com  ", backend_url="http://localhost:8080")
     assert v.domain == "example.com"
 
 
 def test_vhost_create_backend_url_without_protocol_invalid() -> None:
-    """Backend URL bez protokołu jest niepoprawny."""
+    """A backend URL without a protocol is invalid."""
     with pytest.raises(ValidationError, match="must start with http"):
         VHostCreate(domain="example.com", backend_url="localhost:8080")
 
@@ -199,6 +239,6 @@ def test_vhost_create_backend_url_https_valid() -> None:
 
 
 def test_vhost_create_backend_url_stripped() -> None:
-    """Spacje wokół backend URL są usuwane."""
+    """Whitespace around the backend URL is stripped."""
     v = VHostCreate(domain="example.com", backend_url="  http://localhost:8080  ")
     assert v.backend_url == "http://localhost:8080"


### PR DESCRIPTION
## Summary

This PR adds the backend CRUD flow for policy-scoped rule overrides under `/policies/{policy_id}/rules`.

## What Changed

- add CRUD endpoints for policy rule overrides with admin/viewer permission checks
- add schema validation for `rule_id > 0` and patch payload support via `RuleOverrideUpdate`
- add duplicate protection for `(policy_id, rule_id)` in the API and database
- add Alembic migration for the unique constraint
- add integration and unit tests for router behavior and schema validation

## Why

The backend already had the data model for `rule_overrides`, but it was missing the API flow needed to manage CRS rule exceptions in real policy usage.

## Validation

- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- `haproxy` validation skipped because `configs/haproxy/` does not exist yet