### PR TITLE
feat(policy): extract PolicyService from policies router

### DIFF
--- a/src/backend/app/routers/policies.py
+++ b/src/backend/app/routers/policies.py
@@ -1,40 +1,21 @@
 """Router Policies API — CRUD polityk WAF."""
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
 from app.models.policy import Policy
 from app.models.user import User
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
+from app.services.policy_service import (
+    PolicyFieldCannotBeNullError,
+    PolicyNameAlreadyExistsError,
+    PolicyNotFoundError,
+    PolicyService,
+)
 
 router = APIRouter(prefix="/policies", tags=["policies"])
-
-NON_NULLABLE_PATCH_FIELDS = {
-    "name",
-    "paranoia_level",
-    "anomaly_threshold",
-    "is_active",
-}
-
-
-def _is_policy_name_unique_violation(error: IntegrityError) -> bool:
-    """Sprawdza, czy IntegrityError dotyczy unikalnej nazwy policy."""
-    error_text = str(error.orig).lower()
-    return "unique" in error_text and "name" in error_text
-
-
-def _get_policy_or_404(db: Session, policy_id: int) -> Policy:
-    """Zwraca politykę po ID albo 404 gdy nie istnieje."""
-    policy = db.get(Policy, policy_id)
-    if policy is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Policy not found",
-        )
-    return policy
 
 
 @router.post("", response_model=PolicyResponse, status_code=status.HTTP_201_CREATED)
@@ -44,25 +25,21 @@ def create_policy(
     current_user: User = Depends(require_admin),
 ) -> Policy:
     """Tworzy nową politykę WAF (tylko admin)."""
-    policy = Policy(
-        name=body.name,
-        description=body.description,
-        paranoia_level=body.paranoia_level,
-        anomaly_threshold=body.anomaly_threshold,
-        is_active=True,
-        created_by=current_user.id,
-    )
-    db.add(policy)
+    service = PolicyService(db)
+
     try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
+        return service.create_policy(
+            name=body.name,
+            description=body.description,
+            paranoia_level=body.paranoia_level,
+            anomaly_threshold=body.anomaly_threshold,
+            created_by=current_user.id,
+        )
+    except PolicyNameAlreadyExistsError as error:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Policy name already exists",
-        )
-    db.refresh(policy)
-    return policy
+        ) from error
 
 
 @router.get("", response_model=list[PolicyResponse])
@@ -71,7 +48,8 @@ def list_policies(
     _: User = Depends(get_current_user),
 ) -> list[Policy]:
     """Zwraca listę polityk WAF (admin i viewer)."""
-    return db.query(Policy).order_by(Policy.id.asc()).all()
+    service = PolicyService(db)
+    return service.list_policies()
 
 
 @router.get("/{policy_id}", response_model=PolicyDetail)
@@ -81,18 +59,14 @@ def get_policy(
     _: User = Depends(get_current_user),
 ) -> Policy:
     """Zwraca szczegóły polityki razem z rule_overrides (admin i viewer)."""
-    policy = (
-        db.query(Policy)
-        .options(selectinload(Policy.rule_overrides))
-        .filter(Policy.id == policy_id)
-        .first()
-    )
-    if policy is None:
+    service = PolicyService(db)
+    try:
+        return service.get_policy(policy_id)
+    except PolicyNotFoundError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Policy not found",
-        )
-    return policy
+        ) from error
 
 
 @router.patch("/{policy_id}", response_model=PolicyResponse)
@@ -103,31 +77,28 @@ def update_policy(
     _: User = Depends(require_admin),
 ) -> Policy:
     """Aktualizuje wskazane pola polityki (tylko admin)."""
-    policy = _get_policy_or_404(db, policy_id)
-    patch_data = body.model_dump(exclude_unset=True)
-
-    for field in NON_NULLABLE_PATCH_FIELDS:
-        if field in patch_data and patch_data[field] is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Field '{field}' cannot be null",
-            )
-
-    for field, value in patch_data.items():
-        setattr(policy, field, value)
+    service = PolicyService(db)
 
     try:
-        db.commit()
-    except IntegrityError as error:
-        db.rollback()
-        if _is_policy_name_unique_violation(error):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Policy name already exists",
-            )
-        raise
-    db.refresh(policy)
-    return policy
+        return service.update_policy(
+            policy_id,
+            body.model_dump(exclude_unset=True),
+        )
+    except PolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except PolicyFieldCannotBeNullError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+    except PolicyNameAlreadyExistsError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Policy name already exists",
+        ) from error
 
 
 @router.delete("/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -137,7 +108,13 @@ def delete_policy(
     _: User = Depends(require_admin),
 ) -> Response:
     """Usuwa politykę po ID (tylko admin)."""
-    policy = _get_policy_or_404(db, policy_id)
-    db.delete(policy)
-    db.commit()
+    service = PolicyService(db)
+    try:
+        service.delete_policy(policy_id)
+    except PolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -1,0 +1,136 @@
+"""Policy service for WAF policy domain logic."""
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.policy import Policy
+
+NON_NULLABLE_PATCH_FIELDS = {
+    "name",
+    "paranoia_level",
+    "anomaly_threshold",
+    "is_active",
+}
+
+
+class PolicyError(Exception):
+    """Base class for policy domain errors."""
+
+
+class PolicyNotFoundError(PolicyError):
+    """Raised when a policy does not exist."""
+
+
+class PolicyNameAlreadyExistsError(PolicyError):
+    """Raised when a policy name conflicts with an existing row."""
+
+
+class PolicyFieldCannotBeNullError(PolicyError):
+    """Raised when PATCH sets a non-nullable field to null."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be null")
+
+
+class PolicyService:
+    """Encapsulates policy CRUD business rules.
+
+    In simple terms:
+    - the router should deal with HTTP and auth
+    - this service should deal with policy rules and database changes
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_policy(
+        self,
+        *,
+        name: str,
+        description: str | None,
+        paranoia_level: int,
+        anomaly_threshold: int,
+        created_by: int | None,
+    ) -> Policy:
+        """Create and persist a new policy."""
+        policy = Policy(
+            name=name,
+            description=description,
+            paranoia_level=paranoia_level,
+            anomaly_threshold=anomaly_threshold,
+            is_active=True,
+            created_by=created_by,
+        )
+        self.db.add(policy)
+
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if self._is_policy_name_unique_violation(error):
+                raise PolicyNameAlreadyExistsError from error
+            raise
+
+        self.db.refresh(policy)
+        return policy
+
+    def list_policies(self) -> list[Policy]:
+        """Return all policies sorted by ID."""
+        return self.db.query(Policy).order_by(Policy.id.asc()).all()
+
+    def get_policy(self, policy_id: int) -> Policy:
+        """Return one policy with related rule overrides loaded."""
+        policy = (
+            self.db.query(Policy)
+            .options(selectinload(Policy.rule_overrides))
+            .filter(Policy.id == policy_id)
+            .first()
+        )
+        if policy is None:
+            raise PolicyNotFoundError
+        return policy
+
+    def update_policy(self, policy_id: int, patch_data: dict[str, object]) -> Policy:
+        """Update selected policy fields."""
+        policy = self._get_policy_or_raise(policy_id)
+        self._validate_patch_data(patch_data)
+
+        for field, value in patch_data.items():
+            setattr(policy, field, value)
+
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if self._is_policy_name_unique_violation(error):
+                raise PolicyNameAlreadyExistsError from error
+            raise
+
+        self.db.refresh(policy)
+        return policy
+
+    def delete_policy(self, policy_id: int) -> None:
+        """Delete a policy if it exists."""
+        policy = self._get_policy_or_raise(policy_id)
+        self.db.delete(policy)
+        self.db.commit()
+
+    def _get_policy_or_raise(self, policy_id: int) -> Policy:
+        """Return a policy by primary key or raise a domain error."""
+        policy = self.db.get(Policy, policy_id)
+        if policy is None:
+            raise PolicyNotFoundError
+        return policy
+
+    def _validate_patch_data(self, patch_data: dict[str, object]) -> None:
+        """Reject nulls for fields that must always keep a real value."""
+        for field in NON_NULLABLE_PATCH_FIELDS:
+            if field in patch_data and patch_data[field] is None:
+                raise PolicyFieldCannotBeNullError(field)
+
+    @staticmethod
+    def _is_policy_name_unique_violation(error: IntegrityError) -> bool:
+        """Detect whether IntegrityError comes from duplicate policy name."""
+        error_text = str(error.orig).lower()
+        return "unique" in error_text and "name" in error_text

--- a/src/backend/tests/unit/test_policy_service.py
+++ b/src/backend/tests/unit/test_policy_service.py
@@ -1,0 +1,211 @@
+"""Unit tests for the policy service.
+
+These tests use a real SQLAlchemy session with in-memory SQLite.
+That keeps the tests simple for a junior developer:
+- no HTTP layer
+- no FastAPI router
+- only service logic plus database behavior
+"""
+
+import os
+
+import pytest
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
+
+from app.models.policy import Policy  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.services.policy_service import (  # noqa: E402
+    PolicyFieldCannotBeNullError,
+    PolicyNameAlreadyExistsError,
+    PolicyNotFoundError,
+    PolicyService,
+)
+
+
+def test_create_policy_persists_values_and_created_by(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+
+    policy = service.create_policy(
+        name="Strict",
+        description="High protection",
+        paranoia_level=4,
+        anomaly_threshold=7,
+        created_by=admin_user.id,
+    )
+
+    assert policy.id > 0
+    assert policy.name == "Strict"
+    assert policy.description == "High protection"
+    assert policy.paranoia_level == 4
+    assert policy.anomaly_threshold == 7
+    assert policy.is_active is True
+    assert policy.created_by == admin_user.id
+
+
+def test_create_policy_duplicate_name_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    service.create_policy(
+        name="Duplicate",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyNameAlreadyExistsError):
+        service.create_policy(
+            name="Duplicate",
+            description=None,
+            paranoia_level=1,
+            anomaly_threshold=3,
+            created_by=admin_user.id,
+        )
+
+
+def test_list_policies_returns_items_sorted_by_id(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    first = service.create_policy(
+        name="Alpha",
+        description=None,
+        paranoia_level=1,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+    second = service.create_policy(
+        name="Beta",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=6,
+        created_by=admin_user.id,
+    )
+
+    policies = service.list_policies()
+
+    assert [policy.id for policy in policies] == [first.id, second.id]
+    assert [policy.name for policy in policies] == ["Alpha", "Beta"]
+
+
+def test_get_policy_returns_existing_policy(db: Session, admin_user: User) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Detail",
+        description="Read me",
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    policy = service.get_policy(created.id)
+
+    assert policy.id == created.id
+    assert policy.name == "Detail"
+    assert policy.rule_overrides == []
+
+
+def test_get_policy_missing_raises_not_found(db: Session) -> None:
+    service = PolicyService(db)
+
+    with pytest.raises(PolicyNotFoundError):
+        service.get_policy(99999)
+
+
+def test_update_policy_partial_update_changes_only_selected_fields(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Patch me",
+        description="Before",
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_policy(
+        created.id,
+        {"paranoia_level": 3, "is_active": False},
+    )
+
+    assert updated.name == "Patch me"
+    assert updated.description == "Before"
+    assert updated.paranoia_level == 3
+    assert updated.anomaly_threshold == 5
+    assert updated.is_active is False
+
+
+def test_update_policy_null_for_non_nullable_field_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Null check",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(
+        PolicyFieldCannotBeNullError,
+        match="Field 'name' cannot be null",
+    ):
+        service.update_policy(created.id, {"name": None})
+
+
+def test_update_policy_duplicate_name_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    service.create_policy(
+        name="Alpha",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+    second = service.create_policy(
+        name="Beta",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyNameAlreadyExistsError):
+        service.update_policy(second.id, {"name": "Alpha"})
+
+
+def test_delete_policy_removes_existing_policy(db: Session, admin_user: User) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Delete me",
+        description=None,
+        paranoia_level=2,
+        anomaly_threshold=5,
+        created_by=admin_user.id,
+    )
+
+    service.delete_policy(created.id)
+
+    assert db.get(Policy, created.id) is None
+
+
+def test_delete_policy_missing_raises_not_found(db: Session) -> None:
+    service = PolicyService(db)
+
+    with pytest.raises(PolicyNotFoundError):
+        service.delete_policy(99999)


### PR DESCRIPTION
## Summary

This PR extracts a dedicated `PolicyService` from the `/policies` router so policy domain logic lives outside the FastAPI handler layer.

## What Changed

- added `PolicyService` for policy CRUD domain logic
- added policy domain exceptions for not found, duplicate name, and null patch fields
- moved create, list, get, update, and delete policy logic out of the router
- kept the `/policies` router focused on request/response handling and exception mapping
- added unit tests for `PolicyService`
- preserved the existing `/policies` API behavior

## Why

The policies router previously mixed HTTP concerns with business rules and database mutation logic. Extracting the service layer makes the code easier to test, easier to extend, and clearer to reason about as policy orchestration grows.

## Validation

- `cd src/backend && uv run pytest --cov=app`
- `cd src/backend && uv run mypy app/`
- `cd src/backend && uv run ruff check app/`
- `cd src/frontend && pnpm run type-check`
- `cd src/frontend && pnpm run lint`

## Notes

- `configs/haproxy/haproxy.cfg` is not present yet, so HAProxy validation was not run.
- `src/backend/.env.example` was intentionally left out of this PR because it is unrelated to issue 74.