### PR TITLE
feat(vhosts): extract VHostService from vhosts router

### DIFF
--- a/src/backend/app/routers/vhosts.py
+++ b/src/backend/app/routers/vhosts.py
@@ -1,50 +1,22 @@
 """Router VHosts API — CRUD wirtualnych hostów."""
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
-from app.models.policy import Policy
 from app.models.user import User
 from app.models.vhost import VHost
 from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
+from app.services.vhost_service import (
+    VHostDomainAlreadyExistsError,
+    VHostFieldCannotBeNullError,
+    VHostNotFoundError,
+    VHostPolicyNotFoundError,
+    VHostService,
+)
 
 router = APIRouter(prefix="/vhosts", tags=["vhosts"])
-
-NON_NULLABLE_PATCH_FIELDS = {
-    "domain",
-    "backend_url",
-    "ssl_enabled",
-    "is_active",
-}
-
-
-def _is_vhost_domain_unique_violation(error: IntegrityError) -> bool:
-    """Sprawdza, czy IntegrityError dotyczy unikalnej domeny vhosta."""
-    error_text = str(error.orig).lower()
-    return "unique" in error_text and "domain" in error_text
-
-
-def _get_vhost_or_404(db: Session, vhost_id: int) -> VHost:
-    """Zwraca vhost po ID albo 404 gdy nie istnieje."""
-    vhost = db.get(VHost, vhost_id)
-    if vhost is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="VHost not found",
-        )
-    return vhost
-
-
-def _ensure_policy_exists(db: Session, policy_id: int | None) -> None:
-    """Waliduje policy_id, jeśli request wskazuje konkretną politykę."""
-    if policy_id is not None and db.get(Policy, policy_id) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Policy not found",
-        )
 
 
 @router.post("", response_model=VHostResponse, status_code=status.HTTP_201_CREATED)
@@ -54,32 +26,28 @@ def create_vhost(
     current_user: User = Depends(require_admin),
 ) -> VHost:
     """Tworzy nowy vhost (tylko admin)."""
-    _ensure_policy_exists(db, body.policy_id)
-
-    vhost = VHost(
-        domain=body.domain,
-        backend_url=body.backend_url,
-        description=body.description,
-        ssl_enabled=body.ssl_enabled,
-        is_active=body.is_active,
-        policy_id=body.policy_id,
-        created_by=current_user.id,
-    )
-    db.add(vhost)
+    service = VHostService(db)
 
     try:
-        db.commit()
-    except IntegrityError as error:
-        db.rollback()
-        if _is_vhost_domain_unique_violation(error):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="VHost domain already exists",
-            )
-        raise
-
-    db.refresh(vhost)
-    return vhost
+        return service.create_vhost(
+            domain=body.domain,
+            backend_url=body.backend_url,
+            description=body.description,
+            ssl_enabled=body.ssl_enabled,
+            is_active=body.is_active,
+            policy_id=body.policy_id,
+            created_by=current_user.id,
+        )
+    except VHostPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except VHostDomainAlreadyExistsError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="VHost domain already exists",
+        ) from error
 
 
 @router.get("", response_model=list[VHostResponse])
@@ -88,7 +56,8 @@ def list_vhosts(
     _: User = Depends(get_current_user),
 ) -> list[VHost]:
     """Zwraca listę vhostów (admin i viewer)."""
-    return db.query(VHost).order_by(VHost.id.asc()).all()
+    service = VHostService(db)
+    return service.list_vhosts()
 
 
 @router.get("/{vhost_id}", response_model=VHostDetail)
@@ -98,18 +67,14 @@ def get_vhost(
     _: User = Depends(get_current_user),
 ) -> VHost:
     """Zwraca szczegóły vhosta razem z pełną polityką."""
-    vhost = (
-        db.query(VHost)
-        .options(selectinload(VHost.policy))
-        .filter(VHost.id == vhost_id)
-        .first()
-    )
-    if vhost is None:
+    service = VHostService(db)
+    try:
+        return service.get_vhost(vhost_id)
+    except VHostNotFoundError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="VHost not found",
-        )
-    return vhost
+        ) from error
 
 
 @router.patch("/{vhost_id}", response_model=VHostResponse)
@@ -120,35 +85,30 @@ def update_vhost(
     _: User = Depends(require_admin),
 ) -> VHost:
     """Aktualizuje wskazane pola vhosta (tylko admin)."""
-    vhost = _get_vhost_or_404(db, vhost_id)
-    patch_data = body.model_dump(exclude_unset=True)
-
-    for field in NON_NULLABLE_PATCH_FIELDS:
-        if field in patch_data and patch_data[field] is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=f"Field '{field}' cannot be null",
-            )
-
-    if "policy_id" in patch_data:
-        _ensure_policy_exists(db, patch_data["policy_id"])
-
-    for field, value in patch_data.items():
-        setattr(vhost, field, value)
+    service = VHostService(db)
 
     try:
-        db.commit()
-    except IntegrityError as error:
-        db.rollback()
-        if _is_vhost_domain_unique_violation(error):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="VHost domain already exists",
-            )
-        raise
-
-    db.refresh(vhost)
-    return vhost
+        return service.update_vhost(vhost_id, body.model_dump(exclude_unset=True))
+    except VHostNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        ) from error
+    except VHostPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except VHostFieldCannotBeNullError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+    except VHostDomainAlreadyExistsError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="VHost domain already exists",
+        ) from error
 
 
 @router.delete("/{vhost_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -158,7 +118,13 @@ def delete_vhost(
     _: User = Depends(require_admin),
 ) -> Response:
     """Usuwa vhost po ID (tylko admin)."""
-    vhost = _get_vhost_or_404(db, vhost_id)
-    db.delete(vhost)
-    db.commit()
+    service = VHostService(db)
+    try:
+        service.delete_vhost(vhost_id)
+    except VHostNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        ) from error
+
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/services/vhost_service.py
+++ b/src/backend/app/services/vhost_service.py
@@ -1,0 +1,149 @@
+"""VHost service for vhost domain logic."""
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.policy import Policy
+from app.models.vhost import VHost
+
+NON_NULLABLE_PATCH_FIELDS = {
+    "domain",
+    "backend_url",
+    "ssl_enabled",
+    "is_active",
+}
+
+
+class VHostError(Exception):
+    """Base class for vhost domain errors."""
+
+
+class VHostNotFoundError(VHostError):
+    """Raised when a vhost does not exist."""
+
+
+class VHostDomainAlreadyExistsError(VHostError):
+    """Raised when a vhost domain conflicts with an existing row."""
+
+
+class VHostFieldCannotBeNullError(VHostError):
+    """Raised when PATCH sets a non-nullable field to null."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be null")
+
+
+class VHostPolicyNotFoundError(VHostError):
+    """Raised when a referenced policy does not exist."""
+
+
+class VHostService:
+    """Encapsulates vhost CRUD business rules."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_vhost(
+        self,
+        *,
+        domain: str,
+        backend_url: str,
+        description: str | None,
+        ssl_enabled: bool,
+        is_active: bool,
+        policy_id: int | None,
+        created_by: int | None,
+    ) -> VHost:
+        """Create and persist a new vhost."""
+        self._ensure_policy_exists(policy_id)
+
+        vhost = VHost(
+            domain=domain,
+            backend_url=backend_url,
+            description=description,
+            ssl_enabled=ssl_enabled,
+            is_active=is_active,
+            policy_id=policy_id,
+            created_by=created_by,
+        )
+        self.db.add(vhost)
+
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if self._is_vhost_domain_unique_violation(error):
+                raise VHostDomainAlreadyExistsError from error
+            raise
+
+        self.db.refresh(vhost)
+        return vhost
+
+    def list_vhosts(self) -> list[VHost]:
+        """Return all vhosts sorted by ID."""
+        return self.db.query(VHost).order_by(VHost.id.asc()).all()
+
+    def get_vhost(self, vhost_id: int) -> VHost:
+        """Return one vhost with related policy loaded."""
+        vhost = (
+            self.db.query(VHost)
+            .options(selectinload(VHost.policy))
+            .filter(VHost.id == vhost_id)
+            .first()
+        )
+        if vhost is None:
+            raise VHostNotFoundError
+        return vhost
+
+    def update_vhost(self, vhost_id: int, patch_data: dict[str, object]) -> VHost:
+        """Update selected vhost fields."""
+        vhost = self._get_vhost_or_raise(vhost_id)
+        self._validate_patch_data(patch_data)
+
+        if "policy_id" in patch_data:
+            self._ensure_policy_exists(patch_data["policy_id"])
+
+        for field, value in patch_data.items():
+            setattr(vhost, field, value)
+
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if self._is_vhost_domain_unique_violation(error):
+                raise VHostDomainAlreadyExistsError from error
+            raise
+
+        self.db.refresh(vhost)
+        return vhost
+
+    def delete_vhost(self, vhost_id: int) -> None:
+        """Delete a vhost if it exists."""
+        vhost = self._get_vhost_or_raise(vhost_id)
+        self.db.delete(vhost)
+        self.db.commit()
+
+    def _get_vhost_or_raise(self, vhost_id: int) -> VHost:
+        """Return a vhost by primary key or raise a domain error."""
+        vhost = self.db.get(VHost, vhost_id)
+        if vhost is None:
+            raise VHostNotFoundError
+        return vhost
+
+    def _ensure_policy_exists(self, policy_id: object) -> None:
+        """Validate policy_id when request points at a concrete policy."""
+        if policy_id is not None and self.db.get(Policy, policy_id) is None:
+            raise VHostPolicyNotFoundError
+
+    def _validate_patch_data(self, patch_data: dict[str, object]) -> None:
+        """Reject nulls for fields that must always keep a real value."""
+        for field in NON_NULLABLE_PATCH_FIELDS:
+            if field in patch_data and patch_data[field] is None:
+                raise VHostFieldCannotBeNullError(field)
+
+    @staticmethod
+    def _is_vhost_domain_unique_violation(error: IntegrityError) -> bool:
+        """Detect whether IntegrityError comes from duplicate vhost domain."""
+        error_text = str(error.orig).lower()
+        return "unique" in error_text and "domain" in error_text

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -4,17 +4,13 @@ These tests use a real SQLAlchemy session with in-memory SQLite.
 That keeps the tests focused on service logic and ORM behavior.
 """
 
-import os
-
 import pytest
 from sqlalchemy.orm import Session
 
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
-
-from app.models.policy import Policy  # noqa: E402
-from app.models.user import User  # noqa: E402
-from app.models.vhost import VHost  # noqa: E402
-from app.services.vhost_service import (  # noqa: E402
+from app.models.policy import Policy
+from app.models.user import User
+from app.models.vhost import VHost
+from app.services.vhost_service import (
     VHostDomainAlreadyExistsError,
     VHostFieldCannotBeNullError,
     VHostNotFoundError,

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -1,0 +1,315 @@
+"""Unit tests for the vhost service.
+
+These tests use a real SQLAlchemy session with in-memory SQLite.
+That keeps the tests focused on service logic and ORM behavior.
+"""
+
+import os
+
+import pytest
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
+
+from app.models.policy import Policy  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.vhost import VHost  # noqa: E402
+from app.services.vhost_service import (  # noqa: E402
+    VHostDomainAlreadyExistsError,
+    VHostFieldCannotBeNullError,
+    VHostNotFoundError,
+    VHostPolicyNotFoundError,
+    VHostService,
+)
+
+
+def _create_policy_for_test(
+    db: Session,
+    *,
+    name: str = "Default Policy",
+    created_by: int | None = None,
+) -> Policy:
+    policy = Policy(
+        name=name,
+        description="Policy for vhost service tests",
+        paranoia_level=2,
+        anomaly_threshold=5,
+        is_active=True,
+        created_by=created_by,
+    )
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return policy
+
+
+def test_create_vhost_persists_values_and_created_by(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+
+    vhost = service.create_vhost(
+        domain="app.example.com",
+        backend_url="http://localhost:3000",
+        description="Main app",
+        ssl_enabled=True,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    assert vhost.id > 0
+    assert vhost.domain == "app.example.com"
+    assert vhost.backend_url == "http://localhost:3000"
+    assert vhost.description == "Main app"
+    assert vhost.ssl_enabled is True
+    assert vhost.is_active is True
+    assert vhost.policy_id is None
+    assert vhost.created_by == admin_user.id
+
+
+def test_create_vhost_with_existing_policy_succeeds(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+
+    vhost = service.create_vhost(
+        domain="policy.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=policy.id,
+        created_by=admin_user.id,
+    )
+
+    assert vhost.policy_id == policy.id
+
+
+def test_create_vhost_with_missing_policy_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+
+    with pytest.raises(VHostPolicyNotFoundError):
+        service.create_vhost(
+            domain="missing-policy.example.com",
+            backend_url="http://localhost:8080",
+            description=None,
+            ssl_enabled=False,
+            is_active=True,
+            policy_id=99999,
+            created_by=admin_user.id,
+        )
+
+
+def test_create_vhost_duplicate_domain_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    service.create_vhost(
+        domain="dup.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(VHostDomainAlreadyExistsError):
+        service.create_vhost(
+            domain="dup.example.com",
+            backend_url="http://localhost:9090",
+            description=None,
+            ssl_enabled=False,
+            is_active=True,
+            policy_id=None,
+            created_by=admin_user.id,
+        )
+
+
+def test_list_vhosts_returns_items_sorted_by_id(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    first = service.create_vhost(
+        domain="a.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    second = service.create_vhost(
+        domain="b.example.com",
+        backend_url="http://localhost:8081",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    vhosts = service.list_vhosts()
+
+    assert [vhost.id for vhost in vhosts] == [first.id, second.id]
+    assert [vhost.domain for vhost in vhosts] == ["a.example.com", "b.example.com"]
+
+
+def test_get_vhost_returns_existing_vhost(db: Session, admin_user: User) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, name="Nested Policy", created_by=admin_user.id)
+    created = service.create_vhost(
+        domain="detail.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=policy.id,
+        created_by=admin_user.id,
+    )
+
+    vhost = service.get_vhost(created.id)
+
+    assert vhost.id == created.id
+    assert vhost.domain == "detail.example.com"
+    assert vhost.policy is not None
+    assert vhost.policy.id == policy.id
+
+
+def test_get_vhost_missing_raises_not_found(db: Session) -> None:
+    service = VHostService(db)
+
+    with pytest.raises(VHostNotFoundError):
+        service.get_vhost(99999)
+
+
+def test_update_vhost_partial_update_changes_only_selected_fields(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    created = service.create_vhost(
+        domain="patch.example.com",
+        backend_url="http://localhost:8080",
+        description="Before",
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_vhost(
+        created.id,
+        {"backend_url": "https://backend.internal:443", "ssl_enabled": True},
+    )
+
+    assert updated.domain == "patch.example.com"
+    assert updated.description == "Before"
+    assert updated.backend_url == "https://backend.internal:443"
+    assert updated.ssl_enabled is True
+    assert updated.is_active is True
+
+
+def test_update_vhost_null_for_non_nullable_field_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    created = service.create_vhost(
+        domain="null.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(
+        VHostFieldCannotBeNullError,
+        match="Field 'domain' cannot be null",
+    ):
+        service.update_vhost(created.id, {"domain": None})
+
+
+def test_update_vhost_with_missing_policy_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    created = service.create_vhost(
+        domain="missing-patch.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(VHostPolicyNotFoundError):
+        service.update_vhost(created.id, {"policy_id": 99999})
+
+
+def test_update_vhost_duplicate_domain_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    service.create_vhost(
+        domain="alpha.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    second = service.create_vhost(
+        domain="beta.example.com",
+        backend_url="http://localhost:8081",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(VHostDomainAlreadyExistsError):
+        service.update_vhost(second.id, {"domain": "alpha.example.com"})
+
+
+def test_delete_vhost_removes_existing_vhost(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    created = service.create_vhost(
+        domain="delete.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    service.delete_vhost(created.id)
+
+    assert db.get(VHost, created.id) is None
+
+
+def test_delete_vhost_missing_raises_not_found(db: Session) -> None:
+    service = VHostService(db)
+
+    with pytest.raises(VHostNotFoundError):
+        service.delete_vhost(99999)


### PR DESCRIPTION
## Summary

This PR extracts a dedicated `VHostService` from the `/vhosts` router so vhost domain logic lives outside the FastAPI handler layer.

## What Changed

- added `VHostService` for vhost CRUD domain logic
- added domain exceptions for not found, duplicate domain, null patch fields, and missing policy
- moved vhost domain logic out of the router
- kept the `/vhosts` router focused on request/response handling and exception mapping
- added unit tests for `VHostService`
- preserved existing `/vhosts` API behavior

## Why

The vhosts router previously mixed HTTP concerns with business rules and database mutation logic. Extracting the service layer keeps the code easier to test, easier to extend, and more consistent with the existing `PolicyService` pattern.

## Validation

- `cd src/backend && uv run pytest --cov=app`
- `cd src/backend && uv run mypy app/`
- `cd src/backend && uv run ruff check app/`
- `cd src/frontend && pnpm run type-check`
- `cd src/frontend && pnpm run lint`

## Notes

- `configs/haproxy/haproxy.cfg` is not present yet, so HAProxy validation was not run.