### PR TITLE
feat(logs): redesign log event model and add ingest API

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -56,6 +56,13 @@ sequenceDiagram
 4. Backend generates HAProxy/Coraza config
 5. Backend reloads HAProxy (graceful, no dropped connections)
 
+### Runtime Event Ingestion
+1. Coraza or a proxy-side adapter produces a structured WAF event
+2. The producer sends the event to `POST /logs/ingest`
+3. FastAPI validates and normalizes the payload into the persisted log event model
+4. The backend stores the event as a historical snapshot in PostgreSQL
+5. `GET /logs` exposes the stored events to the future frontend log viewer
+
 ## Deployment
 
 ### Development (Docker Compose)

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -6,6 +6,7 @@
 # Generate a secret with:
 #   openssl rand -hex 32
 JWT_SECRET_KEY=replace-this-with-a-random-secret
+LOG_INGEST_SHARED_SECRET=replace-this-with-a-second-random-secret
 
 # Optional
 # Local file-based database:

--- a/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
+++ b/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
@@ -21,6 +21,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    # MVP note: this intentionally rebuilds the table instead of preserving old rows.
+    # The previous logs schema was a short-lived placeholder and current project
+    # scope does not require retaining existing historical data yet.
     op.drop_index(op.f("ix_logs_vhost"), table_name="logs")
     op.drop_index(op.f("ix_logs_severity"), table_name="logs")
     op.drop_index(op.f("ix_logs_logged_at"), table_name="logs")
@@ -62,16 +65,10 @@ def upgrade() -> None:
         sa.Column("message", sa.Text(), nullable=True),
         sa.Column("raw_context", sa.JSON(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("producer_event_id"),
+        sa.UniqueConstraint("producer_event_id", name="uq_logs_producer_event_id"),
     )
     op.create_index(op.f("ix_logs_action"), "logs", ["action"], unique=False)
     op.create_index(op.f("ix_logs_event_at"), "logs", ["event_at"], unique=False)
-    op.create_index(
-        op.f("ix_logs_producer_event_id"),
-        "logs",
-        ["producer_event_id"],
-        unique=True,
-    )
     op.create_index(op.f("ix_logs_rule_id"), "logs", ["rule_id"], unique=False)
     op.create_index(op.f("ix_logs_severity"), "logs", ["severity"], unique=False)
     op.create_index(op.f("ix_logs_source_ip"), "logs", ["source_ip"], unique=False)
@@ -84,7 +81,6 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_logs_source_ip"), table_name="logs")
     op.drop_index(op.f("ix_logs_severity"), table_name="logs")
     op.drop_index(op.f("ix_logs_rule_id"), table_name="logs")
-    op.drop_index(op.f("ix_logs_producer_event_id"), table_name="logs")
     op.drop_index(op.f("ix_logs_event_at"), table_name="logs")
     op.drop_index(op.f("ix_logs_action"), table_name="logs")
     op.drop_table("logs")

--- a/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
+++ b/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
@@ -1,0 +1,117 @@
+"""redesign logs table for event model
+
+Revision ID: c7a2e5b8f1d0
+Revises: 7e0f9c2c9e62
+Create Date: 2026-04-11 11:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c7a2e5b8f1d0"
+down_revision: Union[str, Sequence[str], None] = "7e0f9c2c9e62"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index(op.f("ix_logs_vhost"), table_name="logs")
+    op.drop_index(op.f("ix_logs_severity"), table_name="logs")
+    op.drop_index(op.f("ix_logs_logged_at"), table_name="logs")
+    op.drop_table("logs")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS logseverity")
+
+    op.create_table(
+        "logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("producer_event_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "event_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("vhost", sa.String(length=255), nullable=False),
+        sa.Column(
+            "action",
+            sa.Enum("allow", "deny", "monitor", name="logaction"),
+            nullable=False,
+        ),
+        sa.Column("source_ip", sa.String(length=45), nullable=False),
+        sa.Column("method", sa.String(length=16), nullable=False),
+        sa.Column("request_uri", sa.Text(), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=True),
+        sa.Column("rule_id", sa.Integer(), nullable=True),
+        sa.Column("rule_message", sa.Text(), nullable=True),
+        sa.Column("anomaly_score", sa.Integer(), nullable=True),
+        sa.Column("paranoia_level", sa.Integer(), nullable=True),
+        sa.Column(
+            "severity",
+            sa.Enum("info", "warning", "error", "critical", name="logseverity"),
+            nullable=False,
+        ),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("raw_context", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("producer_event_id"),
+    )
+    op.create_index(op.f("ix_logs_action"), "logs", ["action"], unique=False)
+    op.create_index(op.f("ix_logs_event_at"), "logs", ["event_at"], unique=False)
+    op.create_index(
+        op.f("ix_logs_producer_event_id"),
+        "logs",
+        ["producer_event_id"],
+        unique=True,
+    )
+    op.create_index(op.f("ix_logs_rule_id"), "logs", ["rule_id"], unique=False)
+    op.create_index(op.f("ix_logs_severity"), "logs", ["severity"], unique=False)
+    op.create_index(op.f("ix_logs_source_ip"), "logs", ["source_ip"], unique=False)
+    op.create_index(op.f("ix_logs_vhost"), "logs", ["vhost"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_logs_vhost"), table_name="logs")
+    op.drop_index(op.f("ix_logs_source_ip"), table_name="logs")
+    op.drop_index(op.f("ix_logs_severity"), table_name="logs")
+    op.drop_index(op.f("ix_logs_rule_id"), table_name="logs")
+    op.drop_index(op.f("ix_logs_producer_event_id"), table_name="logs")
+    op.drop_index(op.f("ix_logs_event_at"), table_name="logs")
+    op.drop_index(op.f("ix_logs_action"), table_name="logs")
+    op.drop_table("logs")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS logaction")
+        op.execute("DROP TYPE IF EXISTS logseverity")
+
+    op.create_table(
+        "logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "logged_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("vhost", sa.String(length=255), nullable=False),
+        sa.Column(
+            "severity",
+            sa.Enum("info", "warning", "error", "critical", name="logseverity"),
+            nullable=False,
+        ),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_logs_logged_at"), "logs", ["logged_at"], unique=False)
+    op.create_index(op.f("ix_logs_severity"), "logs", ["severity"], unique=False)
+    op.create_index(op.f("ix_logs_vhost"), "logs", ["vhost"], unique=False)

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     auth_refresh_cookie_name: str = "guard_proxy_refresh_token"
     auth_refresh_cookie_secure: bool = False
     auth_refresh_cookie_samesite: Literal["lax", "strict", "none"] = "lax"
+    log_ingest_shared_secret: str
 
     @field_validator("jwt_secret_key")
     @classmethod
@@ -53,6 +54,13 @@ class Settings(BaseSettings):
     def auth_refresh_cookie_name_must_not_be_empty(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("AUTH_REFRESH_COOKIE_NAME must not be empty.")
+        return v
+
+    @field_validator("log_ingest_shared_secret")
+    @classmethod
+    def log_ingest_shared_secret_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("LOG_INGEST_SHARED_SECRET must not be empty.")
         return v
 
     @field_validator("cors_origins", mode="before")

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -5,7 +5,7 @@ Alembic w env.py robi: from app.models import *
 Bez tego Alembic wygeneruje pustą migrację (nie zobaczy tabel).
 """
 
-from app.models.log import Log, LogSeverity
+from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.user import User, UserRole
@@ -17,6 +17,7 @@ __all__ = [
     "Policy",
     "VHost",
     "Log",
+    "LogAction",
     "LogSeverity",
     "RuleOverride",
     "RuleAction",

--- a/src/backend/app/models/log.py
+++ b/src/backend/app/models/log.py
@@ -1,20 +1,17 @@
-"""Log model — zdarzenia widoczne w panelu administracyjnym."""
+"""SQLAlchemy models for persisted WAF and proxy log events."""
 
 import enum
 from datetime import datetime
+from typing import Any
 
-from sqlalchemy import DateTime, Enum, String, Text, func
+from sqlalchemy import JSON, DateTime, Enum, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
 
 
 class LogSeverity(enum.StrEnum):
-    """Poziom ważności wpisu logu.
-
-    StrEnum sprawia, że API zwraca zwykły string, np. "error",
-    zamiast obiektu enum trudniejszego do użycia po stronie frontendu.
-    """
+    """Severity level assigned to an event."""
 
     info = "info"
     warning = "warning"
@@ -22,34 +19,56 @@ class LogSeverity(enum.StrEnum):
     critical = "critical"
 
 
-class Log(Base):
-    """Tabela logs — wpisy z WAF/proxy pokazywane w UI.
+class LogAction(enum.StrEnum):
+    """Outcome of request processing from the proxy or WAF perspective."""
 
-    Trzymamy dane zdenormalizowane:
-    - vhost jako string, bo log ma być historycznym snapshotem
-    - severity jako enum, żeby filtrowanie było bezpieczne i przewidywalne
-    - logged_at jako czas zdarzenia, nie czas wstawienia rekordu
-    """
+    allow = "allow"
+    deny = "deny"
+    monitor = "monitor"
+
+
+class Log(Base):
+    """Historical event snapshot stored for investigation and log viewer use."""
 
     __tablename__ = "logs"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    logged_at: Mapped[datetime] = mapped_column(
+    producer_event_id: Mapped[str | None] = mapped_column(
+        String(128),
+        nullable=True,
+        unique=True,
+        index=True,
+    )
+    event_at: Mapped[datetime] = mapped_column(
         DateTime,
         nullable=False,
         index=True,
         server_default=func.now(),
     )
     vhost: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    action: Mapped[LogAction] = mapped_column(
+        Enum(LogAction),
+        nullable=False,
+        index=True,
+    )
+    source_ip: Mapped[str] = mapped_column(String(45), nullable=False, index=True)
+    method: Mapped[str] = mapped_column(String(16), nullable=False)
+    request_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rule_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    rule_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    anomaly_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    paranoia_level: Mapped[int | None] = mapped_column(Integer, nullable=True)
     severity: Mapped[LogSeverity] = mapped_column(
         Enum(LogSeverity),
         nullable=False,
         index=True,
     )
-    message: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    raw_context: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     def __repr__(self) -> str:
         return (
-            f"<Log id={self.id} vhost={self.vhost!r} "
-            f"severity={self.severity} logged_at={self.logged_at.isoformat()}>"
+            f"<Log id={self.id} action={self.action} "
+            f"vhost={self.vhost!r} event_at={self.event_at.isoformat()}>"
         )

--- a/src/backend/app/models/log.py
+++ b/src/backend/app/models/log.py
@@ -37,7 +37,6 @@ class Log(Base):
         String(128),
         nullable=True,
         unique=True,
-        index=True,
     )
     event_at: Mapped[datetime] = mapped_column(
         DateTime,

--- a/src/backend/app/routers/logs.py
+++ b/src/backend/app/routers/logs.py
@@ -1,17 +1,43 @@
-"""Logs router — odczyt logów z filtrowaniem i paginacją."""
+"""Router for log event ingestion and read APIs."""
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import IPvAnyAddress
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user
-from app.models.log import Log, LogSeverity
+from app.models.log import Log, LogAction, LogSeverity
 from app.models.user import User
-from app.schemas.log import LogListResponse
+from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 
 router = APIRouter(prefix="/logs", tags=["logs"])
+
+
+@router.post("/ingest", response_model=LogResponse, status_code=status.HTTP_201_CREATED)
+def ingest_log_event(
+    body: LogIngestRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> Log:
+    """Persist a single WAF or proxy event for later investigation."""
+
+    if body.producer_event_id is not None:
+        existing = (
+            db.query(Log)
+            .filter(Log.producer_event_id == body.producer_event_id)
+            .one_or_none()
+        )
+        if existing is not None:
+            response.status_code = status.HTTP_200_OK
+            return existing
+
+    log = Log(**body.model_dump())
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log
 
 
 @router.get("", response_model=LogListResponse)
@@ -20,19 +46,18 @@ def list_logs(
     date_to: datetime | None = Query(default=None),
     vhost: str | None = Query(default=None, min_length=1, max_length=255),
     severity: LogSeverity | None = Query(default=None),
+    action: LogAction | None = Query(default=None),
+    source_ip: IPvAnyAddress | None = Query(default=None),
+    method: str | None = Query(default=None, min_length=1, max_length=16),
+    status_code: int | None = Query(default=None, ge=100, le=599),
+    rule_id: int | None = Query(default=None, gt=0),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ) -> LogListResponse:
-    """Zwraca logi z opcjonalnym filtrowaniem i paginacją.
+    """Return paginated log events with investigation-oriented filters."""
 
-    date_from / date_to:
-    filtrują po czasie zdarzenia.
-
-    page / page_size:
-    mówią które rekordy zwrócić, żeby nie wysyłać całej tabeli naraz.
-    """
     if date_from is not None and date_to is not None and date_from > date_to:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -42,17 +67,27 @@ def list_logs(
     query = db.query(Log)
 
     if date_from is not None:
-        query = query.filter(Log.logged_at >= date_from)
+        query = query.filter(Log.event_at >= date_from)
     if date_to is not None:
-        query = query.filter(Log.logged_at <= date_to)
+        query = query.filter(Log.event_at <= date_to)
     if vhost is not None:
-        query = query.filter(Log.vhost == vhost)
+        query = query.filter(Log.vhost == vhost.strip().lower())
     if severity is not None:
         query = query.filter(Log.severity == severity)
+    if action is not None:
+        query = query.filter(Log.action == action)
+    if source_ip is not None:
+        query = query.filter(Log.source_ip == _ip_to_string(source_ip))
+    if method is not None:
+        query = query.filter(Log.method == method.strip().upper())
+    if status_code is not None:
+        query = query.filter(Log.status_code == status_code)
+    if rule_id is not None:
+        query = query.filter(Log.rule_id == rule_id)
 
     total = query.count()
     items = (
-        query.order_by(Log.logged_at.desc(), Log.id.desc())
+        query.order_by(Log.event_at.desc(), Log.id.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
         .all()
@@ -64,3 +99,7 @@ def list_logs(
         page=page,
         page_size=page_size,
     )
+
+
+def _ip_to_string(address: IPvAnyAddress) -> str:
+    return str(address)

--- a/src/backend/app/routers/logs.py
+++ b/src/backend/app/routers/logs.py
@@ -1,11 +1,14 @@
 """Router for log event ingestion and read APIs."""
 
 from datetime import datetime
+from secrets import compare_digest
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
 from pydantic import IPvAnyAddress
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.database import get_db
 from app.dependencies import get_current_user
 from app.models.log import Log, LogAction, LogSeverity
@@ -14,11 +17,61 @@ from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 
 router = APIRouter(prefix="/logs", tags=["logs"])
 
+def require_log_ingest_secret(
+    x_guard_proxy_ingest_secret: str | None = Header(
+        default=None,
+        alias="X-Guard-Proxy-Ingest-Secret",
+    ),
+) -> None:
+    """Protect the ingest endpoint with a shared secret for runtime producers."""
+    if x_guard_proxy_ingest_secret is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing ingest secret",
+        )
+    if not compare_digest(
+        x_guard_proxy_ingest_secret,
+        settings.log_ingest_shared_secret,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid ingest secret",
+        )
+
+
+def _persist_log_event(
+    *,
+    db: Session,
+    log: Log,
+    producer_event_id: str | None,
+) -> tuple[Log, bool]:
+    """Persist a log event and preserve idempotency under write races."""
+    db.add(log)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if producer_event_id is None:
+            raise
+
+        existing = (
+            db.query(Log)
+            .filter(Log.producer_event_id == producer_event_id)
+            .one_or_none()
+        )
+        if existing is None:
+            raise
+        return existing, False
+
+    db.refresh(log)
+    return log, True
+
 
 @router.post("/ingest", response_model=LogResponse, status_code=status.HTTP_201_CREATED)
 def ingest_log_event(
     body: LogIngestRequest,
     response: Response,
+    _: None = Depends(require_log_ingest_secret),
     db: Session = Depends(get_db),
 ) -> Log:
     """Persist a single WAF or proxy event for later investigation."""
@@ -34,10 +87,14 @@ def ingest_log_event(
             return existing
 
     log = Log(**body.model_dump())
-    db.add(log)
-    db.commit()
-    db.refresh(log)
-    return log
+    persisted, created = _persist_log_event(
+        db=db,
+        log=log,
+        producer_event_id=body.producer_event_id,
+    )
+    if not created:
+        response.status_code = status.HTTP_200_OK
+    return persisted
 
 
 @router.get("", response_model=LogListResponse)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -1,7 +1,7 @@
 """Pydantic schemas used for request validation and API serialization."""
 
 from app.schemas.auth import AccessTokenResponse, LoginRequest, TokenData
-from app.schemas.log import LogListResponse, LogResponse
+from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
 from app.schemas.rule_override import (
     RuleOverrideCreate,
@@ -17,6 +17,7 @@ __all__ = [
     "AccessTokenResponse",
     "TokenData",
     # Logs
+    "LogIngestRequest",
     "LogResponse",
     "LogListResponse",
     # Users

--- a/src/backend/app/schemas/log.py
+++ b/src/backend/app/schemas/log.py
@@ -1,34 +1,94 @@
-"""Schematy Pydantic dla endpointu logów."""
+"""Pydantic schemas for log event ingestion and read APIs."""
 
 from datetime import datetime
+from ipaddress import ip_address
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.models.log import LogSeverity
+from app.models.log import LogAction, LogSeverity
 
 
 class LogResponse(BaseModel):
-    """Pojedynczy wpis logu zwracany przez API."""
+    """Single persisted event returned by the API."""
 
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    logged_at: datetime
+    producer_event_id: str | None
+    event_at: datetime
     vhost: str
+    action: LogAction
+    source_ip: str
+    method: str
+    request_uri: str
+    status_code: int | None
+    rule_id: int | None
+    rule_message: str | None
+    anomaly_score: int | None
+    paranoia_level: int | None
     severity: LogSeverity
-    message: str
+    message: str | None
+    raw_context: dict[str, Any] | None
 
 
 class LogListResponse(BaseModel):
-    """Strona wyników dla GET /logs.
-
-    Zwracamy listę plus metadane paginacji, żeby frontend wiedział:
-    - ile rekordów istnieje łącznie
-    - którą stronę właśnie dostał
-    - ile rekordów ma jedna strona
-    """
+    """Paginated response returned by GET /logs."""
 
     items: list[LogResponse]
     total: int
     page: int
     page_size: int
+
+
+class LogIngestRequest(BaseModel):
+    """Payload accepted from a future runtime log producer."""
+
+    producer_event_id: str | None = Field(default=None, min_length=1, max_length=128)
+    event_at: datetime
+    vhost: str = Field(min_length=1, max_length=255)
+    action: LogAction
+    source_ip: str = Field(min_length=1, max_length=45)
+    method: str = Field(min_length=1, max_length=16)
+    request_uri: str = Field(min_length=1)
+    status_code: int | None = Field(default=None, ge=100, le=599)
+    rule_id: int | None = Field(default=None, gt=0)
+    rule_message: str | None = None
+    anomaly_score: int | None = Field(default=None, ge=0)
+    paranoia_level: int | None = Field(default=None, ge=1, le=4)
+    severity: LogSeverity
+    message: str | None = None
+    raw_context: dict[str, Any] | None = None
+
+    @field_validator("producer_event_id", "rule_message", "message", mode="before")
+    @classmethod
+    def strip_optional_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+    @field_validator("vhost")
+    @classmethod
+    def normalize_vhost(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @field_validator("source_ip")
+    @classmethod
+    def validate_source_ip(cls, value: str) -> str:
+        normalized = value.strip()
+        ip_address(normalized)
+        return normalized
+
+    @field_validator("method")
+    @classmethod
+    def normalize_method(cls, value: str) -> str:
+        return value.strip().upper()
+
+    @field_validator("request_uri")
+    @classmethod
+    def normalize_request_uri(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("request_uri cannot be empty")
+        return normalized

--- a/src/backend/app/schemas/log.py
+++ b/src/backend/app/schemas/log.py
@@ -77,8 +77,7 @@ class LogIngestRequest(BaseModel):
     @classmethod
     def validate_source_ip(cls, value: str) -> str:
         normalized = value.strip()
-        ip_address(normalized)
-        return normalized
+        return str(ip_address(normalized))
 
     @field_validator("method")
     @classmethod

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Session, sessionmaker
 # Na potrzeby testów zawsze wymuszamy deterministyczną, testową wartość klucza,
 # niezależnie od tego, co jest ustawione w środowisku (hermetyczność testów).
 os.environ["JWT_SECRET_KEY"] = "test-secret-key-for-pytest-onlyx"
+os.environ["LOG_INGEST_SHARED_SECRET"] = "test-log-ingest-secret"
 os.environ["DEBUG"] = "false"
 
 from app.database import Base, get_db  # noqa: E402
@@ -198,3 +199,9 @@ def viewer_token(viewer_user: User) -> dict[str, str]:
 ADMIN_PASSWORD = _ADMIN_PASSWORD
 VIEWER_PASSWORD = _VIEWER_PASSWORD
 INACTIVE_PASSWORD = _INACTIVE_PASSWORD
+
+
+@pytest.fixture()
+def log_ingest_headers() -> dict[str, str]:
+    """Header used by the log producer ingest endpoint."""
+    return {"X-Guard-Proxy-Ingest-Secret": os.environ["LOG_INGEST_SHARED_SECRET"]}

--- a/src/backend/tests/integration/test_logs_router.py
+++ b/src/backend/tests/integration/test_logs_router.py
@@ -1,27 +1,49 @@
-"""Testy integracyjne routera logs (filtrowanie + paginacja)."""
+"""Integration tests for log ingestion and log listing APIs."""
 
 from datetime import datetime
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.models.log import Log, LogSeverity
+from app.models.log import Log, LogAction, LogSeverity
 
 
 def _create_log(
     db: Session,
     *,
-    logged_at: datetime,
-    vhost: str,
-    severity: LogSeverity,
-    message: str,
+    event_at: datetime,
+    vhost: str = "app.example.com",
+    action: LogAction = LogAction.allow,
+    source_ip: str = "203.0.113.10",
+    method: str = "GET",
+    request_uri: str = "/health",
+    status_code: int | None = 200,
+    rule_id: int | None = None,
+    rule_message: str | None = None,
+    anomaly_score: int | None = None,
+    paranoia_level: int | None = None,
+    severity: LogSeverity = LogSeverity.info,
+    message: str | None = None,
+    raw_context: dict[str, object] | None = None,
+    producer_event_id: str | None = None,
 ) -> Log:
-    """Pomocniczo zapisuje log w bazie testowej."""
+    """Persist a log event in the test database."""
     log = Log(
-        logged_at=logged_at,
+        producer_event_id=producer_event_id,
+        event_at=event_at,
         vhost=vhost,
+        action=action,
+        source_ip=source_ip,
+        method=method,
+        request_uri=request_uri,
+        status_code=status_code,
+        rule_id=rule_id,
+        rule_message=rule_message,
+        anomaly_score=anomaly_score,
+        paranoia_level=paranoia_level,
         severity=severity,
         message=message,
+        raw_context=raw_context,
     )
     db.add(log)
     db.commit()
@@ -29,25 +51,51 @@ def _create_log(
     return log
 
 
+def _ingest_payload(**overrides: object) -> dict[str, object]:
+    """Return a valid ingest payload that tests can tweak."""
+    payload: dict[str, object] = {
+        "producer_event_id": "coraza-event-1",
+        "event_at": "2026-04-11T10:30:00",
+        "vhost": "app.example.com",
+        "action": "deny",
+        "source_ip": "203.0.113.10",
+        "method": "post",
+        "request_uri": "/login?next=%2Fadmin",
+        "status_code": 403,
+        "rule_id": 942100,
+        "rule_message": "SQL injection attack detected",
+        "anomaly_score": 15,
+        "paranoia_level": 2,
+        "severity": "error",
+        "message": "Request blocked by Coraza",
+        "raw_context": {"engine": "coraza", "phase": "request"},
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_list_logs_returns_paginated_results_for_admin(
     client: TestClient,
     db: Session,
     admin_token: dict[str, str],
 ) -> None:
-    """Admin może pobrać logi, a odpowiedź ma metadane paginacji."""
+    """Admin can list rich log events and receives pagination metadata."""
     older = _create_log(
         db,
-        logged_at=datetime(2026, 3, 20, 10, 0, 0),
-        vhost="app.example.com",
+        event_at=datetime(2026, 3, 20, 10, 0, 0),
+        action=LogAction.monitor,
         severity=LogSeverity.warning,
         message="Older event",
     )
     newer = _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 10, 0, 0),
-        vhost="app.example.com",
+        event_at=datetime(2026, 3, 21, 10, 0, 0),
+        action=LogAction.deny,
+        status_code=403,
+        rule_id=949110,
         severity=LogSeverity.error,
         message="Newer event",
+        raw_context={"engine": "coraza"},
     )
 
     resp = client.get("/logs", headers=admin_token)
@@ -58,19 +106,22 @@ def test_list_logs_returns_paginated_results_for_admin(
     assert body["page"] == 1
     assert body["page_size"] == 20
     assert [item["id"] for item in body["items"]] == [newer.id, older.id]
+    assert body["items"][0]["action"] == "deny"
+    assert body["items"][0]["rule_id"] == 949110
+    assert body["items"][0]["raw_context"] == {"engine": "coraza"}
 
 
 def test_list_logs_viewer_has_read_access(
     client: TestClient,
     db: Session,
-    admin_token: dict[str, str],
     viewer_token: dict[str, str],
 ) -> None:
-    """Viewer ma dostęp read-only do logów."""
+    """Viewer still has read-only access to the log list."""
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 10, 0, 0),
+        event_at=datetime(2026, 3, 21, 10, 0, 0),
         vhost="frontend.example.com",
+        action=LogAction.allow,
         severity=LogSeverity.info,
         message="Rendered dashboard",
     )
@@ -81,36 +132,39 @@ def test_list_logs_viewer_has_read_access(
 
 
 def test_list_logs_requires_auth(client: TestClient) -> None:
-    """Brak tokena -> 401."""
+    """Listing logs without auth should fail."""
     resp = client.get("/logs")
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Not authenticated"
 
 
-def test_list_logs_filters_by_vhost_and_severity(
+def test_list_logs_filters_by_vhost_action_and_severity(
     client: TestClient,
     db: Session,
     admin_token: dict[str, str],
 ) -> None:
-    """API zwraca tylko rekordy pasujące do obu filtrów naraz."""
+    """The API should apply multiple exact-match filters at once."""
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 8, 0, 0),
+        event_at=datetime(2026, 3, 21, 8, 0, 0),
         vhost="api.example.com",
+        action=LogAction.deny,
         severity=LogSeverity.error,
         message="Matched",
     )
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 9, 0, 0),
+        event_at=datetime(2026, 3, 21, 9, 0, 0),
         vhost="api.example.com",
-        severity=LogSeverity.info,
-        message="Wrong severity",
+        action=LogAction.allow,
+        severity=LogSeverity.error,
+        message="Wrong action",
     )
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 10, 0, 0),
+        event_at=datetime(2026, 3, 21, 10, 0, 0),
         vhost="www.example.com",
+        action=LogAction.deny,
         severity=LogSeverity.error,
         message="Wrong vhost",
     )
@@ -118,13 +172,16 @@ def test_list_logs_filters_by_vhost_and_severity(
     resp = client.get(
         "/logs",
         headers=admin_token,
-        params={"vhost": "api.example.com", "severity": "error"},
+        params={
+            "vhost": "API.EXAMPLE.COM",
+            "action": "deny",
+            "severity": "error",
+        },
     )
     assert resp.status_code == 200
 
     body = resp.json()
     assert body["total"] == 1
-    assert len(body["items"]) == 1
     assert body["items"][0]["message"] == "Matched"
 
 
@@ -133,26 +190,20 @@ def test_list_logs_filters_by_date_range(
     db: Session,
     admin_token: dict[str, str],
 ) -> None:
-    """Zakres dat ogranicza wyniki do wpisów z wybranego przedziału."""
+    """Date filters should keep only events inside the selected range."""
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 19, 23, 59, 59),
-        vhost="api.example.com",
-        severity=LogSeverity.warning,
+        event_at=datetime(2026, 3, 19, 23, 59, 59),
         message="Too early",
     )
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 20, 12, 0, 0),
-        vhost="api.example.com",
-        severity=LogSeverity.warning,
+        event_at=datetime(2026, 3, 20, 12, 0, 0),
         message="In range",
     )
     _create_log(
         db,
-        logged_at=datetime(2026, 3, 22, 0, 0, 1),
-        vhost="api.example.com",
-        severity=LogSeverity.warning,
+        event_at=datetime(2026, 3, 22, 0, 0, 1),
         message="Too late",
     )
 
@@ -171,33 +222,115 @@ def test_list_logs_filters_by_date_range(
     assert body["items"][0]["message"] == "In range"
 
 
+def test_list_logs_filters_by_source_ip(
+    client: TestClient,
+    db: Session,
+    admin_token: dict[str, str],
+) -> None:
+    """The source IP filter should match a single address exactly."""
+    _create_log(
+        db,
+        event_at=datetime(2026, 3, 21, 10, 0, 0),
+        source_ip="198.51.100.8",
+        message="Matched IP",
+    )
+    _create_log(
+        db,
+        event_at=datetime(2026, 3, 21, 11, 0, 0),
+        source_ip="203.0.113.9",
+        message="Wrong IP",
+    )
+
+    resp = client.get(
+        "/logs",
+        headers=admin_token,
+        params={"source_ip": "198.51.100.8"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["message"] == "Matched IP"
+
+
+def test_list_logs_filters_by_method_status_code_and_rule_id(
+    client: TestClient,
+    db: Session,
+    admin_token: dict[str, str],
+) -> None:
+    """Method, status code, and rule id filters should all be usable."""
+    _create_log(
+        db,
+        event_at=datetime(2026, 3, 21, 8, 0, 0),
+        method="POST",
+        status_code=403,
+        rule_id=942100,
+        message="Matched event",
+    )
+    _create_log(
+        db,
+        event_at=datetime(2026, 3, 21, 9, 0, 0),
+        method="GET",
+        status_code=403,
+        rule_id=942100,
+        message="Wrong method",
+    )
+
+    resp = client.get(
+        "/logs",
+        headers=admin_token,
+        params={
+            "method": "post",
+            "status_code": 403,
+            "rule_id": 942100,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["message"] == "Matched event"
+
+
+def test_list_logs_serializes_nullable_fields(
+    client: TestClient,
+    db: Session,
+    admin_token: dict[str, str],
+) -> None:
+    """Optional investigation fields should serialize as null when absent."""
+    log = _create_log(
+        db,
+        event_at=datetime(2026, 3, 21, 8, 0, 0),
+        status_code=None,
+        rule_id=None,
+        rule_message=None,
+        anomaly_score=None,
+        paranoia_level=None,
+        message=None,
+        raw_context=None,
+    )
+
+    resp = client.get("/logs", headers=admin_token)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["items"][0]["id"] == log.id
+    assert body["items"][0]["status_code"] is None
+    assert body["items"][0]["rule_id"] is None
+    assert body["items"][0]["raw_context"] is None
+    assert body["items"][0]["message"] is None
+
+
 def test_list_logs_paginates_results(
     client: TestClient,
     db: Session,
     admin_token: dict[str, str],
 ) -> None:
-    """page i page_size wybierają właściwy wycinek wyniku."""
-    first = _create_log(
-        db,
-        logged_at=datetime(2026, 3, 21, 8, 0, 0),
-        vhost="api.example.com",
-        severity=LogSeverity.info,
-        message="First",
-    )
+    """Pagination should return the requested slice of the ordered result set."""
+    _create_log(db, event_at=datetime(2026, 3, 21, 8, 0, 0), message="First")
     second = _create_log(
         db,
-        logged_at=datetime(2026, 3, 21, 9, 0, 0),
-        vhost="api.example.com",
-        severity=LogSeverity.warning,
+        event_at=datetime(2026, 3, 21, 9, 0, 0),
         message="Second",
     )
-    third = _create_log(
-        db,
-        logged_at=datetime(2026, 3, 21, 10, 0, 0),
-        vhost="api.example.com",
-        severity=LogSeverity.error,
-        message="Third",
-    )
+    _create_log(db, event_at=datetime(2026, 3, 21, 10, 0, 0), message="Third")
 
     resp = client.get(
         "/logs",
@@ -210,15 +343,13 @@ def test_list_logs_paginates_results(
     assert body["total"] == 3
     assert len(body["items"]) == 1
     assert body["items"][0]["id"] == second.id
-    assert body["items"][0]["id"] != third.id
-    assert body["items"][0]["id"] != first.id
 
 
 def test_list_logs_rejects_invalid_date_range(
     client: TestClient,
     admin_token: dict[str, str],
 ) -> None:
-    """date_from późniejsze niż date_to -> 422."""
+    """date_from later than date_to should be rejected explicitly."""
     resp = client.get(
         "/logs",
         headers=admin_token,
@@ -229,3 +360,94 @@ def test_list_logs_rejects_invalid_date_range(
     )
     assert resp.status_code == 422
     assert resp.json()["detail"] == "date_from cannot be later than date_to"
+
+
+def test_ingest_log_event_persists_valid_payload(
+    client: TestClient,
+    db: Session,
+) -> None:
+    """A valid ingest request should store the event in the database."""
+    resp = client.post("/logs/ingest", json=_ingest_payload())
+    assert resp.status_code == 201
+
+    body = resp.json()
+    assert body["method"] == "POST"
+    assert body["vhost"] == "app.example.com"
+    assert body["producer_event_id"] == "coraza-event-1"
+
+    persisted = db.query(Log).filter(Log.producer_event_id == "coraza-event-1").one()
+    assert persisted.action == LogAction.deny
+    assert persisted.method == "POST"
+    assert persisted.raw_context == {"engine": "coraza", "phase": "request"}
+
+
+def test_ingest_log_event_rejects_invalid_payload(client: TestClient) -> None:
+    """Malformed ingest payloads should fail with 422 validation errors."""
+    resp = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(source_ip="not-an-ip", severity="fatal"),
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_log_event_allows_optional_fields_to_be_omitted(
+    client: TestClient,
+) -> None:
+    """Optional investigation fields should not be required on ingest."""
+    resp = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(
+            producer_event_id="coraza-event-2",
+            status_code=None,
+            rule_id=None,
+            rule_message=None,
+            anomaly_score=None,
+            paranoia_level=None,
+            message=None,
+            raw_context=None,
+        ),
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status_code"] is None
+    assert body["rule_id"] is None
+    assert body["raw_context"] is None
+
+
+def test_ingest_log_event_is_idempotent_when_producer_event_id_retries(
+    client: TestClient,
+    db: Session,
+) -> None:
+    """Retrying the same producer event id should return the existing record."""
+    first = client.post("/logs/ingest", json=_ingest_payload())
+    second = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(message="Changed body should still dedupe"),
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+    assert db.query(Log).count() == 1
+
+
+def test_ingest_then_list_logs_returns_persisted_event(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """An ingested event should be visible through the read API immediately."""
+    ingest = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(producer_event_id="coraza-event-3"),
+    )
+    assert ingest.status_code == 201
+
+    resp = client.get(
+        "/logs",
+        headers=admin_token,
+        params={"rule_id": 942100, "action": "deny"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["producer_event_id"] == "coraza-event-3"

--- a/src/backend/tests/integration/test_logs_router.py
+++ b/src/backend/tests/integration/test_logs_router.py
@@ -365,9 +365,10 @@ def test_list_logs_rejects_invalid_date_range(
 def test_ingest_log_event_persists_valid_payload(
     client: TestClient,
     db: Session,
+    log_ingest_headers: dict[str, str],
 ) -> None:
     """A valid ingest request should store the event in the database."""
-    resp = client.post("/logs/ingest", json=_ingest_payload())
+    resp = client.post("/logs/ingest", json=_ingest_payload(), headers=log_ingest_headers)
     assert resp.status_code == 201
 
     body = resp.json()
@@ -381,17 +382,40 @@ def test_ingest_log_event_persists_valid_payload(
     assert persisted.raw_context == {"engine": "coraza", "phase": "request"}
 
 
-def test_ingest_log_event_rejects_invalid_payload(client: TestClient) -> None:
+def test_ingest_log_event_requires_secret(client: TestClient) -> None:
+    """Missing shared secret should return 401."""
+    resp = client.post("/logs/ingest", json=_ingest_payload())
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing ingest secret"
+
+
+def test_ingest_log_event_rejects_invalid_secret(client: TestClient) -> None:
+    """Wrong shared secret should return 403."""
+    resp = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(),
+        headers={"X-Guard-Proxy-Ingest-Secret": "wrong-secret"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Invalid ingest secret"
+
+
+def test_ingest_log_event_rejects_invalid_payload(
+    client: TestClient,
+    log_ingest_headers: dict[str, str],
+) -> None:
     """Malformed ingest payloads should fail with 422 validation errors."""
     resp = client.post(
         "/logs/ingest",
         json=_ingest_payload(source_ip="not-an-ip", severity="fatal"),
+        headers=log_ingest_headers,
     )
     assert resp.status_code == 422
 
 
 def test_ingest_log_event_allows_optional_fields_to_be_omitted(
     client: TestClient,
+    log_ingest_headers: dict[str, str],
 ) -> None:
     """Optional investigation fields should not be required on ingest."""
     resp = client.post(
@@ -406,6 +430,7 @@ def test_ingest_log_event_allows_optional_fields_to_be_omitted(
             message=None,
             raw_context=None,
         ),
+        headers=log_ingest_headers,
     )
     assert resp.status_code == 201
     body = resp.json()
@@ -417,12 +442,14 @@ def test_ingest_log_event_allows_optional_fields_to_be_omitted(
 def test_ingest_log_event_is_idempotent_when_producer_event_id_retries(
     client: TestClient,
     db: Session,
+    log_ingest_headers: dict[str, str],
 ) -> None:
     """Retrying the same producer event id should return the existing record."""
-    first = client.post("/logs/ingest", json=_ingest_payload())
+    first = client.post("/logs/ingest", json=_ingest_payload(), headers=log_ingest_headers)
     second = client.post(
         "/logs/ingest",
         json=_ingest_payload(message="Changed body should still dedupe"),
+        headers=log_ingest_headers,
     )
 
     assert first.status_code == 201
@@ -434,11 +461,13 @@ def test_ingest_log_event_is_idempotent_when_producer_event_id_retries(
 def test_ingest_then_list_logs_returns_persisted_event(
     client: TestClient,
     admin_token: dict[str, str],
+    log_ingest_headers: dict[str, str],
 ) -> None:
     """An ingested event should be visible through the read API immediately."""
     ingest = client.post(
         "/logs/ingest",
         json=_ingest_payload(producer_event_id="coraza-event-3"),
+        headers=log_ingest_headers,
     )
     assert ingest.status_code == 201
 
@@ -451,3 +480,4 @@ def test_ingest_then_list_logs_returns_persisted_event(
     body = resp.json()
     assert body["total"] == 1
     assert body["items"][0]["producer_event_id"] == "coraza-event-3"
+

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 # JWT_SECRET_KEY musi być ustawiony zanim załaduje się settings singleton.
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
+os.environ.setdefault("LOG_INGEST_SHARED_SECRET", "test-log-ingest-secret")
 
 
 # ---------------------------------------------------------------------------
@@ -49,25 +50,37 @@ def _make_settings(**env_overrides: str) -> object:
 
 def test_jwt_secret_key_valid() -> None:
     """Poprawny klucz powinien być zaakceptowany."""
-    s = _make_settings(JWT_SECRET_KEY="moj-super-tajny-klucz")
+    s = _make_settings(
+        JWT_SECRET_KEY="moj-super-tajny-klucz",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
     assert getattr(s, "jwt_secret_key") == "moj-super-tajny-klucz"
 
 
 def test_jwt_secret_key_empty_raises() -> None:
     """Pusty klucz JWT to luka bezpieczeństwa — powinien rzucić ValidationError."""
     with pytest.raises(ValidationError, match="must not be empty"):
-        _make_settings(JWT_SECRET_KEY="")
+        _make_settings(
+            JWT_SECRET_KEY="",
+            LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+        )
 
 
 def test_jwt_secret_key_whitespace_only_raises() -> None:
     """Klucz złożony tylko ze spacji jest równoważny pustemu — powinien rzucić błąd."""
     with pytest.raises(ValidationError, match="must not be empty"):
-        _make_settings(JWT_SECRET_KEY="   ")
+        _make_settings(
+            JWT_SECRET_KEY="   ",
+            LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+        )
 
 
 def test_jwt_secret_key_with_spaces_valid() -> None:
     """Klucz z spacjami w środku (ale nie tylko spacje) jest poprawny."""
-    s = _make_settings(JWT_SECRET_KEY="klucz z spacjami w srodku")
+    s = _make_settings(
+        JWT_SECRET_KEY="klucz z spacjami w srodku",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
     assert getattr(s, "jwt_secret_key") == "klucz z spacjami w srodku"
 
 
@@ -77,15 +90,40 @@ def test_jwt_secret_key_with_spaces_valid() -> None:
 
 
 def test_default_algorithm_is_hs256() -> None:
-    s = _make_settings(JWT_SECRET_KEY="sekret")
+    s = _make_settings(
+        JWT_SECRET_KEY="sekret",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
     assert getattr(s, "jwt_algorithm") == "HS256"
 
 
 def test_default_access_token_expire_minutes() -> None:
-    s = _make_settings(JWT_SECRET_KEY="sekret")
+    s = _make_settings(
+        JWT_SECRET_KEY="sekret",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
     assert getattr(s, "jwt_access_token_expire_minutes") == 30
 
 
 def test_default_refresh_token_expire_days() -> None:
-    s = _make_settings(JWT_SECRET_KEY="sekret")
+    s = _make_settings(
+        JWT_SECRET_KEY="sekret",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
     assert getattr(s, "jwt_refresh_token_expire_days") == 7
+
+
+def test_log_ingest_shared_secret_valid() -> None:
+    s = _make_settings(
+        JWT_SECRET_KEY="sekret",
+        LOG_INGEST_SHARED_SECRET="another-secret",
+    )
+    assert getattr(s, "log_ingest_shared_secret") == "another-secret"
+
+
+def test_log_ingest_shared_secret_empty_raises() -> None:
+    with pytest.raises(ValidationError, match="must not be empty"):
+        _make_settings(
+            JWT_SECRET_KEY="sekret",
+            LOG_INGEST_SHARED_SECRET="",
+        )

--- a/src/backend/tests/unit/test_logs_router.py
+++ b/src/backend/tests/unit/test_logs_router.py
@@ -1,0 +1,61 @@
+"""Unit tests for log router helper functions."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.log import Log, LogAction, LogSeverity
+from app.routers.logs import _persist_log_event
+
+
+def _make_log(producer_event_id: str | None = "event-123") -> Log:
+    return Log(
+        producer_event_id=producer_event_id,
+        event_at=datetime(2026, 4, 11, 10, 30, 0),
+        vhost="app.example.com",
+        action=LogAction.deny,
+        source_ip="203.0.113.10",
+        method="POST",
+        request_uri="/login",
+        status_code=403,
+        rule_id=942100,
+        rule_message="SQL injection attack detected",
+        anomaly_score=15,
+        paranoia_level=2,
+        severity=LogSeverity.error,
+        message="Blocked by Coraza",
+        raw_context={"engine": "coraza"},
+    )
+
+
+def test_persist_log_event_returns_existing_on_integrity_error_retry() -> None:
+    db = MagicMock()
+    existing = _make_log("event-123")
+    db.commit.side_effect = IntegrityError("", {}, Exception())
+    db.query.return_value.filter.return_value.one_or_none.return_value = existing
+
+    persisted, created = _persist_log_event(
+        db=db,
+        log=_make_log("event-123"),
+        producer_event_id="event-123",
+    )
+
+    assert persisted is existing
+    assert created is False
+    db.add.assert_called_once()
+    db.rollback.assert_called_once()
+
+
+def test_persist_log_event_reraises_integrity_error_without_existing_row() -> None:
+    db = MagicMock()
+    db.commit.side_effect = IntegrityError("", {}, Exception())
+    db.query.return_value.filter.return_value.one_or_none.return_value = None
+
+    with pytest.raises(IntegrityError):
+        _persist_log_event(
+            db=db,
+            log=_make_log("event-123"),
+            producer_event_id="event-123",
+        )

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
 from app.models.rule_override import RuleAction  # noqa: E402
+from app.schemas.log import LogIngestRequest  # noqa: E402
 from app.schemas.policy import PolicyCreate, PolicyUpdate  # noqa: E402
 from app.schemas.rule_override import (  # noqa: E402
     RuleOverrideCreate,
@@ -242,3 +243,53 @@ def test_vhost_create_backend_url_stripped() -> None:
     """Whitespace around the backend URL is stripped."""
     v = VHostCreate(domain="example.com", backend_url="  http://localhost:8080  ")
     assert v.backend_url == "http://localhost:8080"
+
+
+def test_log_ingest_request_normalizes_vhost_method_and_optional_text() -> None:
+    log = LogIngestRequest(
+        producer_event_id=" event-123 ",
+        event_at="2026-04-11T10:30:00",
+        vhost=" API.EXAMPLE.COM ",
+        action="deny",
+        source_ip=" 203.0.113.10 ",
+        method=" post ",
+        request_uri=" /login ",
+        severity="error",
+        message=" blocked ",
+        rule_message=" attack detected ",
+    )
+
+    assert log.producer_event_id == "event-123"
+    assert log.vhost == "api.example.com"
+    assert log.source_ip == "203.0.113.10"
+    assert log.method == "POST"
+    assert log.request_uri == "/login"
+    assert log.message == "blocked"
+    assert log.rule_message == "attack detected"
+
+
+def test_log_ingest_request_rejects_invalid_ip() -> None:
+    with pytest.raises(ValidationError):
+        LogIngestRequest(
+            event_at="2026-04-11T10:30:00",
+            vhost="api.example.com",
+            action="deny",
+            source_ip="definitely-not-an-ip",
+            method="POST",
+            request_uri="/login",
+            severity="error",
+        )
+
+
+def test_log_ingest_request_rejects_invalid_paranoia_level() -> None:
+    with pytest.raises(ValidationError, match="less than or equal to 4"):
+        LogIngestRequest(
+            event_at="2026-04-11T10:30:00",
+            vhost="api.example.com",
+            action="deny",
+            source_ip="203.0.113.10",
+            method="POST",
+            request_uri="/login",
+            paranoia_level=5,
+            severity="error",
+        )


### PR DESCRIPTION
## Summary

This PR redesigns backend log storage around richer WAF/proxy event data and adds a protected runtime ingest endpoint on top of that model.

It:
- replaces the old minimal `logs` shape with an event-oriented schema
- expands `GET /logs` into an investigation-focused read API
- adds `POST /logs/ingest` with shared-secret protection and best-effort idempotency
- documents how runtime ingestion connects future Coraza/proxy integration with the log viewer flow

## What Changed

- rebuilt the `logs` table through Alembic around richer event data: action, source IP, method, request URI, status code, rule metadata, anomaly score, paranoia level, producer event ID, and raw context
- kept `vhost` as plain text so log rows remain historical snapshots instead of live foreign-key references
- added read-path indexes for the main filter dimensions
- redesigned log response and ingest schemas with normalization and validation rules
- normalized stored IP values to canonical form for consistent filtering
- protected `POST /logs/ingest` with `X-Guard-Proxy-Ingest-Secret` backed by `LOG_INGEST_SHARED_SECRET`
- preserved best-effort idempotent ingest behavior under write races by catching unique-constraint conflicts and returning the existing row
- removed redundant unique index duplication for `producer_event_id`
- added integration and unit tests for ingest auth, validation, retry behavior, and helper logic

## Migration Note

The `logs` migration intentionally rebuilds the table destructively. This is a conscious MVP decision because the previous schema was a short-lived placeholder and preserving existing log history is not required at this stage.

## Validation

- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- `haproxy -c -f configs/haproxy/haproxy.cfg` skipped because the config file does not exist yet