### PR TITLE
fix(paranoia_level_schema): use explicit paranoia constraints

### DIFF
--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.schemas.rule_override import RuleOverrideResponse
 
@@ -12,16 +12,8 @@ class PolicyCreate(BaseModel):
 
     name: str
     description: str | None = None
-    paranoia_level: int = 1
+    paranoia_level: int = Field(default=1, ge=1, le=4)
     anomaly_threshold: int = 5
-
-    @field_validator("paranoia_level")
-    @classmethod
-    def paranoia_level_range(cls, v: int) -> int:
-        """Paranoia level musi być między 1 a 4 (standard OWASP CRS)."""
-        if v < 1 or v > 4:
-            raise ValueError("Paranoia level must be between 1 and 4")
-        return v
 
     @field_validator("anomaly_threshold")
     @classmethod
@@ -40,16 +32,9 @@ class PolicyUpdate(BaseModel):
 
     name: str | None = None
     description: str | None = None
-    paranoia_level: int | None = None
+    paranoia_level: int | None = Field(default=None, ge=1, le=4)
     anomaly_threshold: int | None = None
     is_active: bool | None = None
-
-    @field_validator("paranoia_level")
-    @classmethod
-    def paranoia_level_range(cls, v: int | None) -> int | None:
-        if v is not None and (v < 1 or v > 4):
-            raise ValueError("Paranoia level must be between 1 and 4")
-        return v
 
     @field_validator("anomaly_threshold")
     @classmethod

--- a/src/backend/tests/integration/test_policies_router.py
+++ b/src/backend/tests/integration/test_policies_router.py
@@ -98,6 +98,22 @@ def test_create_policy_duplicate_name_returns_409(
     assert resp.json()["detail"] == "Policy name already exists"
 
 
+def test_create_policy_invalid_paranoia_level_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Out-of-range paranoia_level should be rejected at router validation."""
+    resp = client.post(
+        "/policies",
+        headers=admin_token,
+        json={
+            "name": "Invalid paranoia",
+            "paranoia_level": 5,
+            "anomaly_threshold": 5,
+        },
+    )
+    assert resp.status_code == 422
+
+
 # ---------------------------------------------------------------------------
 # GET /policies
 # ---------------------------------------------------------------------------
@@ -277,6 +293,21 @@ def test_patch_policy_paranoia_level_null_returns_422(
     )
     assert resp.status_code == 422
     assert resp.json()["detail"] == "Field 'paranoia_level' cannot be null"
+
+
+def test_patch_policy_invalid_paranoia_level_returns_422(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Out-of-range paranoia_level should be rejected before service update."""
+    created = _create_policy(client, admin_token, name="Invalid Patch Paranoia")
+
+    resp = client.patch(
+        f"/policies/{created['id']}",
+        headers=admin_token,
+        json={"paranoia_level": 0},
+    )
+    assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -99,13 +99,13 @@ def test_policy_create_valid() -> None:
 
 def test_policy_create_paranoia_level_zero() -> None:
     """Paranoia level 0 is outside the allowed 1-4 range."""
-    with pytest.raises(ValidationError, match="between 1 and 4"):
+    with pytest.raises(ValidationError):
         PolicyCreate(name="x", paranoia_level=0)
 
 
 def test_policy_create_paranoia_level_five() -> None:
     """Paranoia level 5 is outside the allowed 1-4 range."""
-    with pytest.raises(ValidationError, match="between 1 and 4"):
+    with pytest.raises(ValidationError):
         PolicyCreate(name="x", paranoia_level=5)
 
 
@@ -144,13 +144,30 @@ def test_policy_update_paranoia_none_valid() -> None:
 
 
 def test_policy_update_paranoia_invalid() -> None:
-    with pytest.raises(ValidationError, match="between 1 and 4"):
+    with pytest.raises(ValidationError):
         PolicyUpdate(paranoia_level=99)
 
 
 def test_policy_update_anomaly_zero_invalid() -> None:
     with pytest.raises(ValidationError, match="at least 1"):
         PolicyUpdate(anomaly_threshold=0)
+
+
+def test_policy_create_schema_exposes_paranoia_level_bounds() -> None:
+    schema = PolicyCreate.model_json_schema()
+    paranoia_schema = schema["properties"]["paranoia_level"]
+
+    assert paranoia_schema["minimum"] == 1
+    assert paranoia_schema["maximum"] == 4
+
+
+def test_policy_update_schema_exposes_paranoia_level_bounds() -> None:
+    schema = PolicyUpdate.model_json_schema()
+    paranoia_schema = schema["properties"]["paranoia_level"]
+    int_schema = next(item for item in paranoia_schema["anyOf"] if item.get("type") == "integer")
+
+    assert int_schema["minimum"] == 1
+    assert int_schema["maximum"] == 4
 
 
 def test_policy_update_name_null_is_allowed_by_schema() -> None:


### PR DESCRIPTION
## Summary
- replace validator-only `paranoia_level` range checks with explicit Pydantic field constraints (`ge=1`, `le=4`) in create and update schemas
- keep PATCH semantics intact while preserving existing null-handling behavior at router/service level
- extend unit tests to assert JSON Schema metadata (`minimum`/`maximum`) and integration tests to assert `422` for out-of-range POST/PATCH payloads

## Test plan
- [x] `uv run pytest tests/unit/test_schemas.py` (from `src/backend`)
- [x] `uv run pytest tests/integration/test_policies_router.py` (from `src/backend`)
- [x] `uv run pytest --cov=app` (from `src/backend`)
- [x] `uv run mypy app/` (from `src/backend`)
- [x] `uv run ruff check app/` (from `src/backend`)
- [x] `pnpm run type-check` (from `src/frontend`)
- [x] `pnpm run lint` (from `src/frontend`)
- [x] `haproxy -c -f configs/haproxy/haproxy.cfg` (not run: file not present)