### PR TITLE
feat(ci): add GitHub quality gates workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+- Describe the user-facing or developer-facing change.
+- Link the related issue, for example: `Closes #96`.
+
+## Testing
+
+- [ ] `cd src/backend && uv run pytest --cov=app`
+- [ ] `cd src/backend && uv run mypy app/`
+- [ ] `cd src/backend && uv run ruff check app/`
+- [ ] `cd src/frontend && pnpm run type-check`
+- [ ] `cd src/frontend && pnpm run lint`
+
+## Main Branch Protection
+
+- [ ] In GitHub, open `Settings` -> `Branches` -> branch protection for `main`.
+- [ ] Require status checks to pass before merging.
+- [ ] Add `backend` and `frontend` as required checks for `main`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Cache uv packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('src/backend/pyproject.toml', 'src/backend/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install backend dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run backend tests with coverage
+        run: uv run pytest --cov=app
+
+      - name: Run mypy
+        run: uv run mypy app/
+
+      - name: Run ruff
+        run: uv run ruff check app/
+
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: src/frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run frontend type-check
+        run: pnpm run type-check
+
+      - name: Run frontend lint
+        run: pnpm run lint


### PR DESCRIPTION
## Summary
- add a `CI` GitHub Actions workflow with `backend` and `frontend` jobs for the existing quality gates
- cache `~/.cache/uv` and the pnpm store, and run each toolchain from its project subdirectory
- add a PR template that documents the manual `main` branch protection step and the required `backend` and `frontend` checks
- use `uv sync --frozen --extra dev` because plain `uv sync` does not install the backend dev tools required for `pytest`, `mypy`, and `ruff`

## Test plan
- [x] `cd src/backend && uv sync --extra dev && uv run pytest --cov=app && uv run mypy app/ && uv run ruff check app/`
- [x] `cd src/frontend && pnpm install --frozen-lockfile && pnpm run type-check && pnpm run lint`
- [x] Verified the workflow triggers on `pull_request` and on pushes to `main` by inspecting `.github/workflows/ci.yml`

## Notes
- `pnpm run type-check` currently fails on a clean branch from `origin/main` before these `.github` changes due to an existing missing `@/lib/theme` import in `src/frontend/src/components/layout/NavBar.tsx`.
- In GitHub, open `Settings` -> `Branches` -> branch protection for `main`, require status checks to pass before merging, and add `backend` and `frontend` as required checks.
- Closes #96