### PR TITLE
fix(frontend): restore tracked theme and auth helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ develop-eggs/
 eggs/
 .eggs/
 lib/
+!src/frontend/src/lib/
+!src/frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/src/frontend/src/features/auth/api.ts
+++ b/src/frontend/src/features/auth/api.ts
@@ -1,31 +1,35 @@
 import { apiRequest } from "@/lib/api-client";
 import type { CurrentUser, LoginRequest, TokenResponse } from "@/types/api";
 
-export function login(body: LoginRequest) {
+export function login(body: LoginRequest, signal?: AbortSignal) {
   return apiRequest<TokenResponse>("/auth/login", {
     method: "POST",
     body,
     credentials: "include",
+    signal,
   });
 }
 
-export function getCurrentUser(accessToken: string) {
+export function getCurrentUser(accessToken: string, signal?: AbortSignal) {
   return apiRequest<CurrentUser>("/auth/me", {
     token: accessToken,
+    signal,
   });
 }
 
-export function refreshSession() {
+export function refreshSession(signal?: AbortSignal) {
   return apiRequest<TokenResponse>("/auth/refresh", {
     method: "POST",
     credentials: "include",
+    signal,
   });
 }
 
-export function logout() {
+export function logout(signal?: AbortSignal) {
   return apiRequest<void>("/auth/logout", {
     method: "POST",
     credentials: "include",
     responseType: "empty",
+    signal,
   });
 }

--- a/src/frontend/src/features/auth/auth-context.test.tsx
+++ b/src/frontend/src/features/auth/auth-context.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useAuth } from "@/hooks/use-auth";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/lib/api-client";
 import type { CurrentUser } from "@/types/api";
+import type { TokenResponse } from "@/types/api";
 
 import { AuthProvider } from "./auth-context";
 
@@ -13,35 +15,113 @@ vi.mock("./api", () => ({
   refreshSession: vi.fn(),
 }));
 
-import { getCurrentUser, refreshSession } from "./api";
+import { getCurrentUser, login, logout, refreshSession } from "./api";
 
+const mockedLogin = vi.mocked(login);
+const mockedLogout = vi.mocked(logout);
 const mockedRefreshSession = vi.mocked(refreshSession);
 const mockedGetCurrentUser = vi.mocked(getCurrentUser);
-
-const currentUser: CurrentUser = {
-  id: 1,
+const credentials = {
   email: "admin@example.com",
-  full_name: "Admin User",
-  role: "admin",
-  is_active: true,
-  created_at: "2026-03-29T00:00:00Z",
-  updated_at: "2026-03-29T00:00:00Z",
+  password: "secret",
 };
 
+function createUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    id: 1,
+    email: "admin@example.com",
+    full_name: "Admin User",
+    role: "admin",
+    is_active: true,
+    created_at: "2026-03-29T00:00:00Z",
+    updated_at: "2026-03-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+
 function AuthConsumer() {
-  const { isAuthenticated, isLoading, user } = useAuth();
+  const {
+    accessToken,
+    isAuthenticated,
+    isLoading,
+    loginError,
+    refreshCurrentUser,
+    signIn,
+    signOut,
+    user,
+  } = useAuth();
 
   return (
     <>
-      <span>{isLoading ? "loading" : "ready"}</span>
-      <span>{isAuthenticated ? "authenticated" : "anonymous"}</span>
-      <span>{user?.email ?? "no-user"}</span>
+      <span data-testid="loading">{isLoading ? "loading" : "ready"}</span>
+      <span data-testid="auth">{isAuthenticated ? "authenticated" : "anonymous"}</span>
+      <span data-testid="user">{user?.email ?? "no-user"}</span>
+      <span data-testid="token">{accessToken ?? "no-token"}</span>
+      <span data-testid="error">{loginError ?? "no-error"}</span>
+      <button
+        type="button"
+        onClick={() => {
+          void signIn(credentials).catch(() => undefined);
+        }}
+      >
+        sign in
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void signOut().catch(() => undefined);
+        }}
+      >
+        sign out
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void refreshCurrentUser().catch(() => undefined);
+        }}
+      >
+        refresh user
+      </button>
     </>
   );
 }
 
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitForReady() {
+  await waitFor(() => {
+    expect(screen.getByTestId("loading")).toHaveTextContent("ready");
+  });
+}
+
 describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("restores a session through refresh and me calls", async () => {
+    const currentUser = createUser();
+
     mockedRefreshSession.mockResolvedValueOnce({
       access_token: "fresh-access",
       token_type: "bearer",
@@ -55,11 +135,12 @@ describe("AuthProvider", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("ready")).toBeInTheDocument();
+      expect(screen.getByTestId("loading")).toHaveTextContent("ready");
     });
 
-    expect(screen.getByText("authenticated")).toBeInTheDocument();
-    expect(screen.getByText(currentUser.email)).toBeInTheDocument();
+    expect(screen.getByTestId("auth")).toHaveTextContent("authenticated");
+    expect(screen.getByTestId("user")).toHaveTextContent(currentUser.email);
+    expect(screen.getByTestId("token")).toHaveTextContent("fresh-access");
   });
 
   it("falls back to anonymous when refresh fails", async () => {
@@ -72,10 +153,245 @@ describe("AuthProvider", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("ready")).toBeInTheDocument();
+      expect(screen.getByTestId("loading")).toHaveTextContent("ready");
     });
 
-    expect(screen.getByText("anonymous")).toBeInTheDocument();
-    expect(screen.getByText("no-user")).toBeInTheDocument();
+    expect(screen.getByTestId("auth")).toHaveTextContent("anonymous");
+    expect(screen.getByTestId("user")).toHaveTextContent("no-user");
+    expect(screen.getByTestId("token")).toHaveTextContent("no-token");
+  });
+
+  it("lets sign in replace an in-flight session restore", async () => {
+    const refreshDeferred = createDeferred<TokenResponse>();
+    const signedInUser = createUser({
+      email: "signed-in@example.com",
+      full_name: "Signed In User",
+    });
+
+    mockedRefreshSession.mockReturnValueOnce(refreshDeferred.promise);
+    mockedLogin.mockResolvedValueOnce({
+      access_token: "login-access",
+      token_type: "bearer",
+    });
+    mockedGetCurrentUser.mockResolvedValueOnce(signedInUser);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "sign in" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("ready");
+      expect(screen.getByTestId("auth")).toHaveTextContent("authenticated");
+    });
+
+    const restoreSignal = mockedRefreshSession.mock.calls[0]?.[0];
+    expect(restoreSignal).toBeInstanceOf(AbortSignal);
+    expect(restoreSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      refreshDeferred.resolve({
+        access_token: "restored-access",
+        token_type: "bearer",
+      });
+    });
+    await flushPromises();
+
+    expect(mockedGetCurrentUser).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("user")).toHaveTextContent(signedInUser.email);
+    expect(screen.getByTestId("token")).toHaveTextContent("login-access");
+  });
+
+  it("keeps logout as the winner over a stale login response", async () => {
+    const loginUserDeferred = createDeferred<CurrentUser>();
+
+    mockedRefreshSession.mockRejectedValueOnce(new Error("No session"));
+    mockedLogin.mockResolvedValueOnce({
+      access_token: "login-access",
+      token_type: "bearer",
+    });
+    mockedGetCurrentUser.mockReturnValueOnce(loginUserDeferred.promise);
+    mockedLogout.mockResolvedValueOnce(undefined);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitForReady();
+
+    fireEvent.click(screen.getByRole("button", { name: "sign in" }));
+
+    await waitFor(() => {
+      expect(mockedGetCurrentUser).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "sign out" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth")).toHaveTextContent("anonymous");
+      expect(screen.getByTestId("user")).toHaveTextContent("no-user");
+    });
+
+    const loginSignal = mockedGetCurrentUser.mock.calls[0]?.[1];
+    expect(loginSignal).toBeInstanceOf(AbortSignal);
+    expect(loginSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      loginUserDeferred.resolve(
+        createUser({
+          email: "late-login@example.com",
+        }),
+      );
+    });
+    await flushPromises();
+
+    expect(screen.getByTestId("auth")).toHaveTextContent("anonymous");
+    expect(screen.getByTestId("user")).toHaveTextContent("no-user");
+    expect(screen.getByTestId("token")).toHaveTextContent("no-token");
+  });
+
+  it("applies only the latest overlapping refreshCurrentUser result", async () => {
+    const restoredUser = createUser();
+    const staleRefreshDeferred = createDeferred<CurrentUser>();
+    const latestRefreshDeferred = createDeferred<CurrentUser>();
+    const latestUser = createUser({
+      email: "latest@example.com",
+      full_name: "Latest User",
+    });
+
+    mockedRefreshSession.mockResolvedValueOnce({
+      access_token: "session-access",
+      token_type: "bearer",
+    });
+    mockedGetCurrentUser
+      .mockResolvedValueOnce(restoredUser)
+      .mockReturnValueOnce(staleRefreshDeferred.promise)
+      .mockReturnValueOnce(latestRefreshDeferred.promise);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitForReady();
+
+    fireEvent.click(screen.getByRole("button", { name: "refresh user" }));
+    fireEvent.click(screen.getByRole("button", { name: "refresh user" }));
+
+    await waitFor(() => {
+      expect(mockedGetCurrentUser).toHaveBeenCalledTimes(3);
+    });
+
+    const staleRefreshSignal = mockedGetCurrentUser.mock.calls[1]?.[1];
+    const latestRefreshSignal = mockedGetCurrentUser.mock.calls[2]?.[1];
+    expect(staleRefreshSignal?.aborted).toBe(true);
+    expect(latestRefreshSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      staleRefreshDeferred.resolve(
+        createUser({
+          email: "stale@example.com",
+        }),
+      );
+    });
+    await flushPromises();
+
+    expect(screen.getByTestId("user")).toHaveTextContent(restoredUser.email);
+
+    await act(async () => {
+      latestRefreshDeferred.resolve(latestUser);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent(latestUser.email);
+    });
+  });
+
+  it("ignores a stale refresh failure after a newer refresh succeeds", async () => {
+    const restoredUser = createUser();
+    const staleRefreshDeferred = createDeferred<CurrentUser>();
+    const latestRefreshDeferred = createDeferred<CurrentUser>();
+    const latestUser = createUser({
+      email: "updated@example.com",
+      full_name: "Updated User",
+    });
+
+    mockedRefreshSession.mockResolvedValueOnce({
+      access_token: "session-access",
+      token_type: "bearer",
+    });
+    mockedGetCurrentUser
+      .mockResolvedValueOnce(restoredUser)
+      .mockReturnValueOnce(staleRefreshDeferred.promise)
+      .mockReturnValueOnce(latestRefreshDeferred.promise);
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitForReady();
+
+    fireEvent.click(screen.getByRole("button", { name: "refresh user" }));
+    fireEvent.click(screen.getByRole("button", { name: "refresh user" }));
+
+    await waitFor(() => {
+      expect(mockedGetCurrentUser).toHaveBeenCalledTimes(3);
+    });
+
+    await act(async () => {
+      latestRefreshDeferred.resolve(latestUser);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent(latestUser.email);
+    });
+
+    await act(async () => {
+      staleRefreshDeferred.reject(new ApiError(401, "Session expired"));
+    });
+    await flushPromises();
+
+    expect(screen.getByTestId("auth")).toHaveTextContent("authenticated");
+    expect(screen.getByTestId("user")).toHaveTextContent(latestUser.email);
+    expect(screen.getByTestId("token")).toHaveTextContent("session-access");
+    expect(screen.getByTestId("error")).toHaveTextContent("no-error");
+  });
+
+  it("aborts restore requests on unmount", async () => {
+    const refreshDeferred = createDeferred<TokenResponse>();
+
+    mockedRefreshSession.mockReturnValueOnce(refreshDeferred.promise);
+
+    const { unmount } = render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    const restoreSignal = mockedRefreshSession.mock.calls[0]?.[0];
+    expect(restoreSignal).toBeInstanceOf(AbortSignal);
+    expect(restoreSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(restoreSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      refreshDeferred.resolve({
+        access_token: "restored-access",
+        token_type: "bearer",
+      });
+    });
+    await flushPromises();
+
+    expect(mockedGetCurrentUser).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/features/auth/auth-context.tsx
+++ b/src/frontend/src/features/auth/auth-context.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type PropsWithChildren,
 } from "react";
@@ -13,29 +14,71 @@ import { getCurrentUser, login, logout, refreshSession } from "./api";
 import { AuthContext } from "./auth-context.shared";
 import type { AuthContextValue } from "./auth-context.types";
 
+function isAbortError(error: unknown) {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export function AuthProvider({ children }: PropsWithChildren) {
   const [user, setUser] = useState<CurrentUser | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loginError, setLoginError] = useState<string | null>(null);
+  const isMountedRef = useRef(false);
+  const currentOperationRef = useRef(0);
+  const currentAbortControllerRef = useRef<AbortController | null>(null);
+
+  const isCurrentOperation = useCallback((operationId: number) => {
+    return isMountedRef.current && currentOperationRef.current === operationId;
+  }, []);
+
+  const finishOperation = useCallback(
+    (operationId: number) => {
+      if (isCurrentOperation(operationId)) {
+        setIsLoading(false);
+      }
+    },
+    [isCurrentOperation]
+  );
+
+  const beginOperation = useCallback(() => {
+    currentAbortControllerRef.current?.abort();
+
+    const operationId = currentOperationRef.current + 1;
+    const abortController = new AbortController();
+
+    currentOperationRef.current = operationId;
+    currentAbortControllerRef.current = abortController;
+
+    return {
+      operationId,
+      signal: abortController.signal,
+    };
+  }, []);
 
   useEffect(() => {
-    let isMounted = true;
+    isMountedRef.current = true;
 
     async function restoreSession() {
-      try {
-        const tokens = await refreshSession();
-        const currentUser = await getCurrentUser(tokens.access_token);
+      const { operationId, signal } = beginOperation();
 
-        if (!isMounted) {
+      try {
+        const tokens = await refreshSession(signal);
+
+        if (signal.aborted || !isCurrentOperation(operationId)) {
+          return;
+        }
+
+        const currentUser = await getCurrentUser(tokens.access_token, signal);
+
+        if (!isCurrentOperation(operationId)) {
           return;
         }
 
         setAccessToken(tokens.access_token);
         setUser(currentUser);
         setLoginError(null);
-      } catch {
-        if (!isMounted) {
+      } catch (error) {
+        if (isAbortError(error) || !isCurrentOperation(operationId)) {
           return;
         }
 
@@ -43,64 +86,100 @@ export function AuthProvider({ children }: PropsWithChildren) {
         setUser(null);
         setLoginError(null);
       } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+        finishOperation(operationId);
       }
     }
 
     void restoreSession();
 
     return () => {
-      isMounted = false;
+      isMountedRef.current = false;
+      currentOperationRef.current += 1;
+      currentAbortControllerRef.current?.abort();
+      currentAbortControllerRef.current = null;
     };
-  }, []);
+  }, [beginOperation, finishOperation, isCurrentOperation]);
 
   const signIn = useCallback(async (credentials: LoginRequest) => {
+    const { operationId, signal } = beginOperation();
+
     setLoginError(null);
-    let tokens;
 
     try {
-      tokens = await login(credentials);
-    } catch (error) {
-      if (error instanceof ApiError) {
-        setLoginError(error.detail);
-      } else {
-        setLoginError("Could not sign in");
+      let tokens;
+
+      try {
+        tokens = await login(credentials, signal);
+      } catch (error) {
+        if (isAbortError(error) || !isCurrentOperation(operationId)) {
+          return;
+        }
+
+        if (error instanceof ApiError) {
+          setLoginError(error.detail);
+        } else {
+          setLoginError("Could not sign in");
+        }
+
+        throw error;
       }
 
-      throw error;
-    }
-
-    setAccessToken(tokens.access_token);
-
-    try {
-      const currentUser = await getCurrentUser(tokens.access_token);
-      setUser(currentUser);
-      setLoginError(null);
-    } catch (error) {
-      setAccessToken(null);
-      setUser(null);
-
-      if (error instanceof ApiError) {
-        setLoginError(error.detail);
-      } else {
-        setLoginError("Could not load current user");
+      if (signal.aborted || !isCurrentOperation(operationId)) {
+        return;
       }
 
-      throw error;
+      try {
+        const currentUser = await getCurrentUser(tokens.access_token, signal);
+
+        if (!isCurrentOperation(operationId)) {
+          return;
+        }
+
+        setAccessToken(tokens.access_token);
+        setUser(currentUser);
+        setLoginError(null);
+      } catch (error) {
+        if (isAbortError(error) || !isCurrentOperation(operationId)) {
+          return;
+        }
+
+        setAccessToken(null);
+        setUser(null);
+
+        if (error instanceof ApiError) {
+          setLoginError(error.detail);
+        } else {
+          setLoginError("Could not load current user");
+        }
+
+        throw error;
+      }
+    } finally {
+      finishOperation(operationId);
     }
-  }, []);
+  }, [beginOperation, finishOperation, isCurrentOperation]);
 
   const signOut = useCallback(async () => {
+    const { operationId, signal } = beginOperation();
+
     try {
-      await logout();
+      await logout(signal);
+    } catch (error) {
+      if (isAbortError(error) || !isCurrentOperation(operationId)) {
+        return;
+      }
+
+      throw error;
     } finally {
-      setAccessToken(null);
-      setUser(null);
-      setLoginError(null);
+      if (isCurrentOperation(operationId)) {
+        setAccessToken(null);
+        setUser(null);
+        setLoginError(null);
+      }
+
+      finishOperation(operationId);
     }
-  }, []);
+  }, [beginOperation, finishOperation, isCurrentOperation]);
 
   const hasRole = useCallback(
     (role: UserRole | UserRole[]) => {
@@ -118,19 +197,36 @@ export function AuthProvider({ children }: PropsWithChildren) {
   );
 
   const refreshCurrentUser = useCallback(async () => {
-    if (!accessToken) {
-      setUser(null);
-      setLoginError(null);
+    const { operationId, signal } = beginOperation();
+    const token = accessToken;
+
+    if (!token) {
+      if (isCurrentOperation(operationId)) {
+        setAccessToken(null);
+        setUser(null);
+        setLoginError(null);
+      }
+
+      finishOperation(operationId);
       return;
     }
 
     setLoginError(null);
 
     try {
-      const currentUser = await getCurrentUser(accessToken);
+      const currentUser = await getCurrentUser(token, signal);
+
+      if (!isCurrentOperation(operationId)) {
+        return;
+      }
+
       setUser(currentUser);
       setLoginError(null);
     } catch (error) {
+      if (isAbortError(error) || !isCurrentOperation(operationId)) {
+        return;
+      }
+
       setAccessToken(null);
       setUser(null);
 
@@ -141,8 +237,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
       }
 
       throw error;
+    } finally {
+      finishOperation(operationId);
     }
-  }, [accessToken]);
+  }, [accessToken, beginOperation, finishOperation, isCurrentOperation]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -1,14 +1,15 @@
 const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
 
-export type ApiResponseType = "json" | "empty";
+export type ApiResponseType = "json" | "text" | "empty";
 
 export type ApiClientOptions = {
   method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
-  body?: unknown;
+  body?: BodyInit | Record<string, unknown> | null;
   token?: string | null;
   headers?: HeadersInit;
   credentials?: RequestCredentials;
   responseType?: ApiResponseType;
+  signal?: AbortSignal;
 };
 
 export class ApiError extends Error {
@@ -44,13 +45,40 @@ function isJsonContentType(contentType: string | null) {
   );
 }
 
+function buildBody(body: ApiClientOptions["body"]) {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof Blob ||
+    ArrayBuffer.isView(body) ||
+    body instanceof ArrayBuffer ||
+    typeof body === "string"
+  ) {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
 export async function apiRequest<T>(
   path: string,
   options: ApiClientOptions = {}
 ): Promise<T> {
   const headers = new Headers(options.headers);
 
-  if (options.body !== undefined) {
+  if (
+    options.body != null &&
+    !(options.body instanceof FormData) &&
+    !(options.body instanceof URLSearchParams) &&
+    !(options.body instanceof Blob) &&
+    !(ArrayBuffer.isView(options.body)) &&
+    !(options.body instanceof ArrayBuffer) &&
+    typeof options.body !== "string"
+  ) {
     headers.set("Content-Type", "application/json");
   }
 
@@ -58,11 +86,16 @@ export async function apiRequest<T>(
     headers.set("Authorization", `Bearer ${options.token}`);
   }
 
-  const response = await fetch(`${getApiBaseUrl()}${path}`, {
+  if (options.responseType !== "empty" && !headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {
     method: options.method ?? "GET",
     headers,
-    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    body: buildBody(options.body),
     credentials: options.credentials,
+    signal: options.signal,
   });
 
   if (!response.ok) {
@@ -85,6 +118,10 @@ export async function apiRequest<T>(
 
   if (options.responseType === "empty" || response.status === 204) {
     return undefined as T;
+  }
+
+  if (options.responseType === "text") {
+    return (await response.text()) as T;
   }
 
   const contentType = response.headers.get("content-type");

--- a/src/frontend/src/lib/theme.ts
+++ b/src/frontend/src/lib/theme.ts
@@ -1,0 +1,17 @@
+const DEFAULT_THEME_STORAGE_KEY = "guard-proxy-theme";
+
+export const THEME_STORAGE_META_SELECTOR =
+  'meta[name="guard-proxy-theme-storage-key"]';
+
+export const THEMES = ["emerald", "frost"] as const;
+
+export type Theme = (typeof THEMES)[number];
+
+export function getThemeStorageKey() {
+  return (
+    document
+      .querySelector(THEME_STORAGE_META_SELECTOR)
+      ?.getAttribute("content")
+      ?.trim() || DEFAULT_THEME_STORAGE_KEY
+  );
+}


### PR DESCRIPTION
## Summary
- unignore `src/frontend/src/lib/` and add the shared theme helper so `NavBar` can resolve `@/lib/theme` in CI
- extend the shared frontend API client and auth API wrappers to support abortable requests and response handling needed by the auth flow
- harden the auth context and tests against stale overlapping requests so frontend type-check and tests pass consistently

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm test`