### PR TITLE
fix(frontend): harden api-client body handling and abort detection

### DIFF
--- a/src/frontend/src/features/auth/auth-context.test.tsx
+++ b/src/frontend/src/features/auth/auth-context.test.tsx
@@ -394,4 +394,26 @@ describe("AuthProvider", () => {
 
     expect(mockedGetCurrentUser).not.toHaveBeenCalled();
   });
+
+  it("treats non-Error abort-shaped rejections as aborts", async () => {
+    mockedRefreshSession.mockRejectedValueOnce(new Error("No session"));
+    mockedLogin.mockRejectedValueOnce({ name: "AbortError" });
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitForReady();
+
+    fireEvent.click(screen.getByRole("button", { name: "sign in" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("ready");
+    });
+
+    expect(screen.getByTestId("error")).toHaveTextContent("no-error");
+    expect(screen.getByTestId("auth")).toHaveTextContent("anonymous");
+  });
 });

--- a/src/frontend/src/features/auth/auth-context.tsx
+++ b/src/frontend/src/features/auth/auth-context.tsx
@@ -15,7 +15,12 @@ import { AuthContext } from "./auth-context.shared";
 import type { AuthContextValue } from "./auth-context.types";
 
 function isAbortError(error: unknown) {
-  return error instanceof Error && error.name === "AbortError";
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  );
 }
 
 export function AuthProvider({ children }: PropsWithChildren) {

--- a/src/frontend/src/lib/api-client.test.ts
+++ b/src/frontend/src/lib/api-client.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { InvalidResponseError, apiRequest } from "./api-client";
+
+describe("apiRequest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes ReadableStream bodies through without JSON serialization", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+
+    await apiRequest("/stream", {
+      method: "POST",
+      body: stream,
+      responseType: "text",
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+
+    expect(init?.body).toBe(stream);
+    expect(headers.has("Content-Type")).toBe(false);
+    expect(headers.get("Accept")).toBe("text/plain");
+  });
+
+  it("sets JSON headers and stringifies plain object bodies", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    await apiRequest("/json", {
+      method: "POST",
+      body: { hello: "world" },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    const headers = new Headers(init?.headers);
+
+    expect(init?.body).toBe(JSON.stringify({ hello: "world" }));
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("Accept")).toBe("application/json");
+  });
+
+  it("parses JSON responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(apiRequest<{ status: string }>("/health")).resolves.toEqual({
+      status: "ok",
+    });
+  });
+
+  it("supports empty responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+
+    await expect(
+      apiRequest<void>("/auth/logout", {
+        method: "POST",
+        responseType: "empty",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails clearly on unexpected success content type", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("plain text", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    await expect(apiRequest("/health")).rejects.toBeInstanceOf(
+      InvalidResponseError,
+    );
+  });
+
+  it("uses text fallback for non-json errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Backend exploded", {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    await expect(apiRequest("/health")).rejects.toMatchObject({
+      detail: "Backend exploded",
+      status: 500,
+    });
+  });
+});

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -45,19 +45,28 @@ function isJsonContentType(contentType: string | null) {
   );
 }
 
+function isReadableStreamBody(value: unknown): value is ReadableStream<unknown> {
+  return typeof ReadableStream !== "undefined" && value instanceof ReadableStream;
+}
+
+function isBodyInit(value: unknown): value is BodyInit {
+  return (
+    value instanceof FormData ||
+    value instanceof URLSearchParams ||
+    value instanceof Blob ||
+    ArrayBuffer.isView(value) ||
+    value instanceof ArrayBuffer ||
+    typeof value === "string" ||
+    isReadableStreamBody(value)
+  );
+}
+
 function buildBody(body: ApiClientOptions["body"]) {
   if (body == null) {
     return undefined;
   }
 
-  if (
-    body instanceof FormData ||
-    body instanceof URLSearchParams ||
-    body instanceof Blob ||
-    ArrayBuffer.isView(body) ||
-    body instanceof ArrayBuffer ||
-    typeof body === "string"
-  ) {
+  if (isBodyInit(body)) {
     return body;
   }
 
@@ -70,15 +79,7 @@ export async function apiRequest<T>(
 ): Promise<T> {
   const headers = new Headers(options.headers);
 
-  if (
-    options.body != null &&
-    !(options.body instanceof FormData) &&
-    !(options.body instanceof URLSearchParams) &&
-    !(options.body instanceof Blob) &&
-    !(ArrayBuffer.isView(options.body)) &&
-    !(options.body instanceof ArrayBuffer) &&
-    typeof options.body !== "string"
-  ) {
+  if (options.body != null && !isBodyInit(options.body)) {
     headers.set("Content-Type", "application/json");
   }
 
@@ -86,8 +87,12 @@ export async function apiRequest<T>(
     headers.set("Authorization", `Bearer ${options.token}`);
   }
 
-  if (options.responseType !== "empty" && !headers.has("Accept")) {
-    headers.set("Accept", "application/json");
+  if (!headers.has("Accept")) {
+    if (options.responseType === "text") {
+      headers.set("Accept", "text/plain");
+    } else if (options.responseType !== "empty") {
+      headers.set("Accept", "application/json");
+    }
   }
 
   const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -51,9 +51,10 @@ function isReadableStreamBody(value: unknown): value is ReadableStream<unknown> 
 
 function isBodyInit(value: unknown): value is BodyInit {
   return (
-    value instanceof FormData ||
-    value instanceof URLSearchParams ||
-    value instanceof Blob ||
+    (typeof FormData !== "undefined" && value instanceof FormData) ||
+    (typeof URLSearchParams !== "undefined" &&
+      value instanceof URLSearchParams) ||
+    (typeof Blob !== "undefined" && value instanceof Blob) ||
     ArrayBuffer.isView(value) ||
     value instanceof ArrayBuffer ||
     typeof value === "string" ||


### PR DESCRIPTION
## Summary

- Widen `isAbortError()` in `auth-context.tsx` from `instanceof Error` to duck-typing so it catches plain `{name: "AbortError"}` objects thrown by some fetch polyfills.
- Extract `isBodyInit()` / `isReadableStreamBody()` type guards in `api-client.ts`, removing duplicated `instanceof` chains in `buildBody()` and `apiRequest()`. Adds `ReadableStream` body support.
- Set `Accept: text/plain` when `responseType` is `"text"` instead of defaulting to `application/json`.
- Add 6 unit tests for `apiRequest` (ReadableStream pass-through, JSON stringify, JSON parse, empty response, invalid content type, plain-text error) and 1 auth-context test for non-Error abort-shaped rejections.

## Testing

- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`
- [x] `cd src/frontend && pnpm run test` (21 tests pass)