### PR TITLE
chore(ci): pin uv version and improve PR testing checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,11 @@
 
 ## Testing
 
+- [ ] `cd src/backend && uv sync --frozen --extra dev`
 - [ ] `cd src/backend && uv run pytest --cov=app`
 - [ ] `cd src/backend && uv run mypy app/`
 - [ ] `cd src/backend && uv run ruff check app/`
+- [ ] `cd src/frontend && pnpm install --frozen-lockfile`
 - [ ] `cd src/frontend && pnpm run type-check`
 - [ ] `cd src/frontend && pnpm run lint`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
+        with:
+          uv-version: "0.11.6"
 
       - name: Cache uv packages
         uses: actions/cache@v4
@@ -65,7 +67,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
-
           cache: pnpm
           cache-dependency-path: src/frontend/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- Pin `uv` to `0.11.6` in `setup-uv@v6` for reproducible CI builds.
- Add `uv sync --frozen --extra dev` and `pnpm install --frozen-lockfile` steps to the PR template testing checklist so reviewers run dependency install before checks.
- Fix stray blank line in `ci.yml` `node-version-file` block.

## Testing

- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`