### PR TITLE
fix(backend): harden env loading and secret validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ thesis/
 
 # ===== Keep Empty Directories =====
 !.gitkeep
+notes/github-issues-plan.md

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,6 +1,9 @@
 # Copy this file to `.env` and adjust the values for your local setup.
 #
 #   cp .env.example .env
+#
+# This file is a template only. The backend loads `.env`, not `.env.example`.
+# Replace all placeholder secrets before starting the app.
 
 # Required
 # Generate a secret with:
@@ -8,9 +11,12 @@
 JWT_SECRET_KEY=replace-this-with-a-random-secret
 LOG_INGEST_SHARED_SECRET=replace-this-with-a-second-random-secret
 
-# Optional
-# Local file-based database:
+# Optional runtime settings
+# Local file-based database (default):
 DATABASE_URL=sqlite:///./guard_proxy.db
+#
+# Enable SQLAlchemy debug logging:
+# DEBUG=false
 #
 # Docker Compose / Postgres example:
 # POSTGRES_USER=postgres
@@ -19,6 +25,17 @@ DATABASE_URL=sqlite:///./guard_proxy.db
 # DATABASE_URL=postgresql://postgres:postgres@postgres:5432/guard_proxy
 DEBUG=false
 
+# Optional auth cookie settings
+# AUTH_REFRESH_COOKIE_NAME=guard_proxy_refresh_token
+# AUTH_REFRESH_COOKIE_SECURE=false
+# AUTH_REFRESH_COOKIE_SAMESITE=lax
+#
+# If AUTH_REFRESH_COOKIE_SAMESITE=none, then AUTH_REFRESH_COOKIE_SECURE must be true.
+
+# Optional frontend origins for local development
+# CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
 # Optional: used by scripts/seed_admin.py
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASSWORD=change-me-please
+# ADMIN_FULL_NAME=Administrator

--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -18,13 +18,15 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from app.config import settings
+from app.config import get_database_settings
 from app.database import Base
 from app.models import *  # noqa: F403 — importuje wszystkie modele
 
+database_settings = get_database_settings()
+
 # Nadpisz URL z .env (settings.database_url) zamiast hardcoded z alembic.ini
 # Dzięki temu: dev=SQLite, prod=PostgreSQL — automatycznie z DATABASE_URL w .env
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", database_settings.database_url)
 
 target_metadata = Base.metadata
 

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -27,7 +27,7 @@ def _validate_secret(value: str, field_name: str) -> str:
 def _validate_database_url(value: str) -> str:
     """Reject empty database URL values."""
     if not value.strip():
-        raise ValueError("DATABASE_URL must not be empty.")
+        raise ValueError("DATABASE_URL must not be empty")
     return value
 
 

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -1,21 +1,59 @@
+from functools import lru_cache
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+_PLACEHOLDER_SECRET_VALUES = {
+    "replace-this-with-a-random-secret",
+    "replace-this-with-a-second-random-secret",
+    "change-me",
+    "changeme",
+}
 
-class Settings(BaseSettings):
-    """Application settings loaded from environment variables."""
+
+def _validate_secret(value: str, field_name: str) -> str:
+    """Reject empty or template placeholder secrets."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be empty.")
+    if normalized.lower() in _PLACEHOLDER_SECRET_VALUES:
+        raise ValueError(
+            f"{field_name} must be replaced with a real secret before startup."
+        )
+    return value
+
+
+class EnvFileSettings(BaseSettings):
+    """Base settings loaded from the real runtime environment."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        extra="ignore",
     )
+
+
+class DatabaseSettings(EnvFileSettings):
+    """Database settings shared by the application and tooling."""
+
+    database_url: str = "sqlite:///./guard_proxy.db"
+    debug: bool = False
+
+    @field_validator("database_url")
+    @classmethod
+    def database_url_must_not_be_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("DATABASE_URL must not be empty.")
+        return value
+
+
+class Settings(EnvFileSettings):
+    """Application runtime settings."""
 
     # Application
     app_name: str = "Guard Proxy API"
-    debug: bool = False
     cors_origins: list[str] = [
         "http://localhost:3000",
         "http://127.0.0.1:3000",
@@ -27,6 +65,7 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str = "sqlite:///./guard_proxy.db"
+    debug: bool = False
 
     # JWT
     jwt_secret_key: str
@@ -41,13 +80,7 @@ class Settings(BaseSettings):
     @field_validator("jwt_secret_key")
     @classmethod
     def jwt_secret_key_must_not_be_empty(cls, v: str) -> str:
-        """Ensure JWT secret key is set — an empty key would be a security hole."""
-        if not v.strip():
-            raise ValueError(
-                "JWT_SECRET_KEY must not be empty. "
-                "Set it in .env or as an environment variable."
-            )
-        return v
+        return _validate_secret(v, "JWT_SECRET_KEY")
 
     @field_validator("auth_refresh_cookie_name")
     @classmethod
@@ -59,9 +92,7 @@ class Settings(BaseSettings):
     @field_validator("log_ingest_shared_secret")
     @classmethod
     def log_ingest_shared_secret_must_not_be_empty(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("LOG_INGEST_SHARED_SECRET must not be empty.")
-        return v
+        return _validate_secret(v, "LOG_INGEST_SHARED_SECRET")
 
     @field_validator("cors_origins", mode="before")
     @classmethod
@@ -84,5 +115,34 @@ class Settings(BaseSettings):
 
         return value
 
+    @model_validator(mode="after")
+    def validate_cookie_settings(self) -> "Settings":
+        if (
+            self.auth_refresh_cookie_samesite == "none"
+            and not self.auth_refresh_cookie_secure
+        ):
+            raise ValueError(
+                "AUTH_REFRESH_COOKIE_SECURE must be true when "
+                "AUTH_REFRESH_COOKIE_SAMESITE is 'none'."
+            )
+        return self
 
-settings = Settings()
+
+def validate_runtime_settings(settings_obj: Settings) -> Settings:
+    """Run explicit runtime validation during application startup."""
+    return settings_obj
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return cached runtime settings."""
+    return Settings()
+
+
+@lru_cache
+def get_database_settings() -> DatabaseSettings:
+    """Return cached database settings for tooling and runtime DB setup."""
+    return DatabaseSettings()
+
+
+settings = get_settings()

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -130,7 +130,7 @@ class Settings(EnvFileSettings):
 
 def validate_runtime_settings(settings_obj: Settings) -> Settings:
     """Run explicit runtime validation during application startup."""
-    return settings_obj
+    return Settings()
 
 
 @lru_cache

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -27,7 +27,7 @@ def _validate_secret(value: str, field_name: str) -> str:
 def _validate_database_url(value: str) -> str:
     """Reject empty database URL values."""
     if not value.strip():
-        raise ValueError("DATABASE_URL must not be empty")
+        raise ValueError("DATABASE_URL must not be empty.")
     return value
 
 

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -21,7 +21,7 @@ def _validate_secret(value: str, field_name: str) -> str:
         raise ValueError(
             f"{field_name} must be replaced with a real secret before startup."
         )
-    return value
+    return normalized
 
 
 class EnvFileSettings(BaseSettings):

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -24,6 +24,13 @@ def _validate_secret(value: str, field_name: str) -> str:
     return normalized
 
 
+def _validate_database_url(value: str) -> str:
+    """Reject empty database URL values."""
+    if not value.strip():
+        raise ValueError("DATABASE_URL must not be empty.")
+    return value
+
+
 class EnvFileSettings(BaseSettings):
     """Base settings loaded from the real runtime environment."""
 
@@ -44,9 +51,7 @@ class DatabaseSettings(EnvFileSettings):
     @field_validator("database_url")
     @classmethod
     def database_url_must_not_be_empty(cls, value: str) -> str:
-        if not value.strip():
-            raise ValueError("DATABASE_URL must not be empty.")
-        return value
+        return _validate_database_url(value)
 
 
 class Settings(EnvFileSettings):
@@ -66,6 +71,11 @@ class Settings(EnvFileSettings):
     # Database
     database_url: str = "sqlite:///./guard_proxy.db"
     debug: bool = False
+
+    @field_validator("database_url")
+    @classmethod
+    def database_url_must_not_be_empty(cls, value: str) -> str:
+        return _validate_database_url(value)
 
     # JWT
     jwt_secret_key: str

--- a/src/backend/app/database.py
+++ b/src/backend/app/database.py
@@ -4,23 +4,25 @@ from collections.abc import Iterator
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-from app.config import settings
+from app.config import get_database_settings
+
+database_settings = get_database_settings()
 
 # Dla SQLite potrzebujemy connect_args, dla PostgreSQL nie
 connect_args = {}
-if settings.database_url.startswith("sqlite"):
+if database_settings.database_url.startswith("sqlite"):
     connect_args = {"check_same_thread": False}
 
 engine = create_engine(
-    settings.database_url,
+    database_settings.database_url,
     connect_args=connect_args,
-    echo=settings.debug,
+    echo=database_settings.debug,
 )
 
 # SQLite domyślnie ignoruje klucze obce — PRAGMA włącza ich sprawdzanie.
 # Musi być wysłane przy każdym nowym połączeniu (nie jest trwałe).
 # PostgreSQL tego nie potrzebuje — enforcuje FK natywnie.
-if settings.database_url.startswith("sqlite"):
+if database_settings.database_url.startswith("sqlite"):
 
     @event.listens_for(engine, "connect")
     def set_sqlite_pragma(dbapi_connection: sqlite3.Connection, _: object) -> None:

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.config import settings
+from app.config import settings, validate_runtime_settings
 from app.routers import auth, logs, policies, rule_overrides, vhosts
 
 
@@ -12,6 +12,7 @@ from app.routers import auth, logs, policies, rule_overrides, vhosts
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Application lifespan — startup and shutdown events."""
     # Startup
+    validate_runtime_settings(settings)
     yield
     # Shutdown
 

--- a/src/backend/app/passwords.py
+++ b/src/backend/app/passwords.py
@@ -1,0 +1,23 @@
+"""Password hashing helpers shared by runtime code and DB-only tooling."""
+
+import logging
+
+from passlib.context import CryptContext
+
+logger = logging.getLogger(__name__)
+
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password with bcrypt."""
+    return _pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Return whether a plaintext password matches the stored hash."""
+    try:
+        return bool(_pwd_context.verify(plain_password, hashed_password))
+    except ValueError:
+        logger.warning("Password verification failed: unrecognized or malformed hash")
+        return False

--- a/src/backend/app/services/auth_service.py
+++ b/src/backend/app/services/auth_service.py
@@ -1,53 +1,22 @@
 """Auth service — password hashing and JWT token management."""
 
-import logging
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import jwt
-from passlib.context import CryptContext
 
 from app.config import settings
+from app.passwords import hash_password, verify_password
 from app.schemas.auth import TokenData
 
-logger = logging.getLogger(__name__)
-
-# CryptContext konfiguruje bcrypt jako algorytm hashowania haseł.
-# deprecated="auto" oznacza że stare hashe będą automatycznie oznaczane
-# do re-hashowania gdy user się zaloguje (przydatne przy migracji algorytmu).
-_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-
-def hash_password(password: str) -> str:
-    """Zwraca bcrypt hash hasła.
-
-    Nigdy nie przechowujemy hasła w plaintext — tylko hash.
-    bcrypt automatycznie dodaje sól (salt) więc dwa razy zahashowane
-    to samo hasło da różne wyniki.
-    """
-    return _pwd_context.hash(password)
-
-
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Weryfikuje czy podane hasło zgadza się z hashem z bazy.
-
-    Zwraca True jeśli hasło poprawne, False jeśli nie.
-
-    ValueError (UnknownHashError) oznacza uszkodzony lub nieznany hash w bazie —
-    to błąd danych, logujemy jako WARNING i zwracamy False (fail closed).
-
-    RuntimeError (MissingBackendError, InternalBackendError) oznacza brak
-    backendu bcrypt lub błąd infrastruktury — propagujemy dalej, żeby FastAPI
-    zwrócił 500 zamiast maskować awarię jako 401.
-    """
-    try:
-        return bool(_pwd_context.verify(plain_password, hashed_password))
-    except ValueError:
-        # Hash nierozpoznany lub uszkodzony — dane w bazie są nieprawidłowe.
-        logger.warning("Password verification failed: unrecognized or malformed hash")
-        return False
-    # RuntimeError (MissingBackendError, InternalBackendError) celowo nie jest
-    # łapany — propaguje do warstwy API jako 500 Internal Server Error.
+__all__ = [
+    "hash_password",
+    "verify_password",
+    "create_access_token",
+    "create_refresh_token",
+    "decode_access_token",
+    "decode_refresh_token",
+]
 
 
 def create_access_token(user_id: int, role: str) -> str:

--- a/src/backend/scripts/seed_admin.py
+++ b/src/backend/scripts/seed_admin.py
@@ -5,49 +5,27 @@ Usage:
     uv run python scripts/seed_admin.py --email admin@example.com --password supersecretpw
 
 If --email / --password are not provided, the script reads
-ADMIN_EMAIL and ADMIN_PASSWORD from the environment (or .env file).
+ADMIN_EMAIL and ADMIN_PASSWORD from the environment (or `.env` file).
 
 The script is idempotent: if any admin user already exists in the database
 (regardless of email), it exits without making any changes.
 
 The password must be at least 12 characters long.
-
-Required environment variables (directly or through `.env`):
-- JWT_SECRET_KEY
-- LOG_INGEST_SHARED_SECRET
 """
 
 import argparse
 import os
 import sys
 
-from dotenv import load_dotenv
-
-# Ładujemy .env zanim cokolwiek zaimportujemy z app.* —
-# w przeciwnym razie os.getenv() nie widzi zmiennych z pliku .env,
-# a import app.config crashuje jeśli JWT_SECRET_KEY nie jest w środowisku.
-load_dotenv()
-
-_REQUIRED_ENV_VARS = ("JWT_SECRET_KEY", "LOG_INGEST_SHARED_SECRET")
-_missing_env_vars = [name for name in _REQUIRED_ENV_VARS if not os.getenv(name)]
-if _missing_env_vars:
-    print(
-        "Error: missing required environment variable(s): "
-        f"{', '.join(_missing_env_vars)}. "
-        "Set them in environment or .env before running seed_admin.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
-# Dodajemy katalog nadrzędny (src/backend/) do PYTHONPATH,
-# żeby importy "app.*" działały gdy uruchamiamy skrypt bezpośrednio.
+# Add the backend root (src/backend/) to PYTHONPATH so `app.*` imports work when
+# running this script directly.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy.exc import IntegrityError  # noqa: E402
 
 from app.database import SessionLocal  # noqa: E402
 from app.models.user import User, UserRole  # noqa: E402
-from app.services.auth_service import hash_password  # noqa: E402
+from app.passwords import hash_password  # noqa: E402
 
 
 def seed_admin(email: str, password: str, full_name: str = "Administrator") -> None:

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -9,6 +9,7 @@ instancję Settings bezpośrednio, nadpisując env tylko w scope testu.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -127,3 +128,65 @@ def test_log_ingest_shared_secret_empty_raises() -> None:
             JWT_SECRET_KEY="sekret",
             LOG_INGEST_SHARED_SECRET="",
         )
+
+
+def test_jwt_secret_key_placeholder_raises() -> None:
+    with pytest.raises(ValidationError, match="must be replaced"):
+        _make_settings(
+            JWT_SECRET_KEY="replace-this-with-a-random-secret",
+            LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+        )
+
+
+def test_log_ingest_shared_secret_placeholder_raises() -> None:
+    with pytest.raises(ValidationError, match="must be replaced"):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="replace-this-with-a-second-random-secret",
+        )
+
+
+def test_auth_refresh_cookie_samesite_none_requires_secure() -> None:
+    with pytest.raises(ValidationError, match="AUTH_REFRESH_COOKIE_SECURE must be true"):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            AUTH_REFRESH_COOKIE_SAMESITE="none",
+            AUTH_REFRESH_COOKIE_SECURE="false",
+        )
+
+
+def test_database_settings_accept_database_url_without_runtime_secrets() -> None:
+    from app.config import DatabaseSettings
+
+    original = dict(os.environ)
+    os.environ.pop("JWT_SECRET_KEY", None)
+    os.environ.pop("LOG_INGEST_SHARED_SECRET", None)
+    os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+    try:
+        settings = DatabaseSettings(_env_file=None)  # type: ignore[call-arg]
+    finally:
+        os.environ.clear()
+        os.environ.update(original)
+
+    assert settings.database_url == "sqlite:///./test.db"
+
+
+def test_settings_ignore_dot_env_example(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import Settings
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+    monkeypatch.delenv("LOG_INGEST_SHARED_SECRET", raising=False)
+    (tmp_path / ".env.example").write_text(
+        "\n".join(
+            [
+                "JWT_SECRET_KEY=replace-this-with-a-random-secret",
+                "LOG_INGEST_SHARED_SECRET=replace-this-with-a-second-random-secret",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        Settings()

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -187,6 +187,17 @@ def test_settings_ignore_dot_env_example(tmp_path: Path, monkeypatch: pytest.Mon
         ),
         encoding="utf-8",
     )
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "JWT_SECRET_KEY=real-secret-from-dot-env",
+                "LOG_INGEST_SHARED_SECRET=real-log-secret-from-dot-env",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
-    with pytest.raises(ValidationError):
-        Settings()
+    settings = Settings()
+
+    assert getattr(settings, "jwt_secret_key") == "real-secret-from-dot-env"
+    assert getattr(settings, "log_ingest_shared_secret") == "real-log-secret-from-dot-env"

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -172,6 +172,15 @@ def test_database_settings_accept_database_url_without_runtime_secrets() -> None
     assert settings.database_url == "sqlite:///./test.db"
 
 
+def test_settings_reject_empty_database_url() -> None:
+    with pytest.raises(ValidationError, match="DATABASE_URL must not be empty"):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            DATABASE_URL="   ",
+        )
+
+
 def test_settings_ignore_dot_env_example(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from app.config import Settings
 

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -173,7 +173,7 @@ def test_database_settings_accept_database_url_without_runtime_secrets() -> None
 
 
 def test_settings_reject_empty_database_url() -> None:
-    with pytest.raises(ValidationError, match="DATABASE_URL must not be empty"):
+    with pytest.raises(ValidationError, match="DATABASE_URL must not be empty\\."):
         _make_settings(
             JWT_SECRET_KEY="real-secret-value",
             LOG_INGEST_SHARED_SECRET="real-log-secret",


### PR DESCRIPTION
## Summary
- stop treating `src/backend/.env.example` as live runtime configuration and reject placeholder secrets during backend settings validation
- run explicit runtime settings validation at FastAPI startup and split database-only settings from full app runtime settings
- decouple Alembic and `seed_admin.py` from unrelated JWT/log-ingest secrets, refresh the backend env template, and add focused config tests

## Test plan
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`
- [x] `haproxy -c -f configs/haproxy/haproxy.cfg` (not run: `configs/haproxy/` does not exist in this repo)