### PR TITLE
feat(ci): add alembic drift and migration checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,19 +38,14 @@ jobs:
       - name: Install backend dependencies
         run: uv sync --frozen --extra dev
 
-      - name: Apply migrations on fresh SQLite DB
+      - name: Verify Alembic migrations and model drift
         env:
           JWT_SECRET_KEY: ci-jwt-secret-key-not-used-at-runtime
           LOG_INGEST_SHARED_SECRET: ci-log-ingest-secret-not-used-at-runtime
           DATABASE_URL: sqlite:///./ci_alembic_check.db
-        run: uv run alembic upgrade heads
-
-      - name: Check model/migration drift
-        env:
-          JWT_SECRET_KEY: ci-jwt-secret-key-not-used-at-runtime
-          LOG_INGEST_SHARED_SECRET: ci-log-ingest-secret-not-used-at-runtime
-          DATABASE_URL: sqlite:///./ci_alembic_check.db
-        run: uv run alembic check
+        run: |
+          uv run alembic upgrade heads
+          uv run alembic check
 
       - name: Run backend tests with coverage
         run: uv run pytest --cov=app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ jobs:
       - name: Install backend dependencies
         run: uv sync --frozen --extra dev
 
+      - name: Apply migrations on fresh SQLite DB
+        env:
+          JWT_SECRET_KEY: ci-jwt-secret-key-not-used-at-runtime
+          LOG_INGEST_SHARED_SECRET: ci-log-ingest-secret-not-used-at-runtime
+          DATABASE_URL: sqlite:///./ci_alembic_check.db
+        run: uv run alembic upgrade heads
+
+      - name: Check model/migration drift
+        env:
+          JWT_SECRET_KEY: ci-jwt-secret-key-not-used-at-runtime
+          LOG_INGEST_SHARED_SECRET: ci-log-ingest-secret-not-used-at-runtime
+          DATABASE_URL: sqlite:///./ci_alembic_check.db
+        run: uv run alembic check
+
       - name: Run backend tests with coverage
         run: uv run pytest --cov=app
 

--- a/README.commands.md
+++ b/README.commands.md
@@ -22,9 +22,9 @@ ruff format app/
 ## Database (Alembic)
 
 ```bash
-uv run alembic upgrade heads                          # Apply all migrations (CI smoke test on fresh SQLite)
-uv run alembic check                                  # Fail when models drift from the latest migration
-uv run alembic revision --autogenerate -m "message"  # Generate a migration for model changes
+uv run alembic -c src/backend/alembic.ini upgrade heads                          # Apply all migrations (CI smoke test on fresh SQLite)
+uv run alembic -c src/backend/alembic.ini check                                  # Fail when models drift from the latest migration
+uv run alembic -c src/backend/alembic.ini revision --autogenerate -m "message"  # Generate a migration for model changes
 ```
 
 ## TypeScript (Frontend)

--- a/README.commands.md
+++ b/README.commands.md
@@ -19,6 +19,14 @@ ruff check app/
 ruff format app/
 ```
 
+## Database (Alembic)
+
+```bash
+uv run alembic upgrade heads                          # Apply all migrations (CI smoke test on fresh SQLite)
+uv run alembic check                                  # Fail when models drift from the latest migration
+uv run alembic revision --autogenerate -m "message"  # Generate a migration for model changes
+```
+
 ## TypeScript (Frontend)
 
 ```bash


### PR DESCRIPTION
## Summary
- add backend CI step to run `uv run alembic upgrade heads` against a fresh SQLite database
- add backend CI step to run `uv run alembic check` so model/migration drift fails CI
- document Alembic verification commands in `README.commands.md`

Closes #97.

## Test plan
- [x] `uv run alembic upgrade heads && uv run alembic check` (with CI env vars and SQLite file)
- [x] `uv run pytest --cov=app`
- [x] `uv run mypy app/`
- [x] `uv run ruff check app/`
- [x] `pnpm run type-check`
- [x] `pnpm run lint`