### PR TITLE
docs(adr): add ADR-006 sync SQLAlchemy decision

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -83,3 +83,4 @@ See `notes/decisions/` for Architecture Decision Records:
 - [ADR-002](notes/decisions/ADR-002-postgresql-with-sqlite-dev.md) - PostgreSQL + SQLite dev
 - [ADR-003](notes/decisions/ADR-003-react-typescript-frontend.md) - React + TypeScript
 - [ADR-004](notes/decisions/ADR-004-docker-compose-deployment.md) - Docker Compose deployment
+- [ADR-006](notes/decisions/ADR-006-sync-sqlalchemy-for-mvp.md) - Synchronous SQLAlchemy for MVP

--- a/notes/decisions/ADR-001-fastapi-over-flask-django.md
+++ b/notes/decisions/ADR-001-fastapi-over-flask-django.md
@@ -12,14 +12,14 @@ The Guard Proxy system requires a backend API for the policy management panel. T
 - Trigger HAProxy graceful reloads via the Runtime API
 - Handle concurrent requests from the React frontend
 
-The backend needs to be async-capable (HAProxy Runtime API calls, config file I/O), type-safe (complex policy schemas), and provide auto-generated API documentation (thesis deliverable).
+The backend needs to be type-safe (complex policy schemas), provide auto-generated API documentation (thesis deliverable), and keep async-capable options available for future runtime and I/O-heavy paths.
 
 ## Decision
 Use **FastAPI** (Python 3.11+) as the backend web framework.
 
 ## Rationale
 
-1. **Native async/await** -- FastAPI is built on Starlette with first-class async support. This matters for non-blocking HAProxy Runtime API calls and concurrent config generation
+1. **Native async/await option** -- FastAPI is built on Starlette with first-class async support, which keeps an async path open for future HAProxy Runtime API and concurrent I/O workloads. The MVP currently uses synchronous SQLAlchemy (see ADR-006)
 2. **Pydantic v2 integration** -- Request/response validation is built-in. Policy schemas (paranoia levels 1-4, IP whitelists, anomaly thresholds) get validated automatically with clear error messages
 3. **OpenAPI auto-generation** -- Swagger UI and ReDoc are generated automatically. This is directly useful for the thesis (API documentation chapter) and frontend development
 4. **Performance** -- Comparable to Node.js/Go for I/O-bound workloads. Won't be a bottleneck given the HAProxy proxy layer handles the high-RPS traffic
@@ -47,7 +47,7 @@ Use **FastAPI** (Python 3.11+) as the backend web framework.
 ### Positive
 - Clean, type-safe codebase with minimal boilerplate
 - Auto-generated API docs reduce thesis documentation effort
-- Async support future-proofs the architecture
+- Async support future-proofs the architecture (not yet adopted in the current SQLAlchemy session model, see ADR-006)
 - Large community means most problems are already solved on StackOverflow/GitHub
 
 ### Negative
@@ -57,7 +57,7 @@ Use **FastAPI** (Python 3.11+) as the backend web framework.
 
 ### Neutral
 - Choosing FastAPI locks us into the ASGI ecosystem (uvicorn/hypercorn)
-- SQLAlchemy 2.0 async support works well with FastAPI but requires careful session management
+- SQLAlchemy 2.0 supports both sync and async session models; the current project uses synchronous sessions for MVP scope (see ADR-006)
 
 ## Validation
 This decision is correct if:
@@ -68,3 +68,4 @@ This decision is correct if:
 ## References
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 - [FastAPI vs Flask vs Django comparison](https://testdriven.io/blog/moving-from-flask-to-fastapi/)
+- [ADR-006: Synchronous SQLAlchemy for MVP](ADR-006-sync-sqlalchemy-for-mvp.md)

--- a/notes/decisions/ADR-006-sync-sqlalchemy-for-mvp.md
+++ b/notes/decisions/ADR-006-sync-sqlalchemy-for-mvp.md
@@ -1,0 +1,70 @@
+---
+date: 2026-04-16
+tags: [decision, architecture, backend, database]
+---
+
+# ADR-006: Synchronous SQLAlchemy for MVP
+
+## Context
+ADR-001 selected FastAPI partly for native async support, but the current backend implementation is fully synchronous.
+
+Current backend database shape:
+- `src/backend/app/database.py` uses `create_engine(...)` and `sessionmaker(class_=Session)`
+- `get_db()` yields a synchronous `Session`
+- Routers in `src/backend/app/routers/` use `def` endpoints with `db: Session = Depends(get_db)`
+
+The contract between ADR-001 and the codebase is therefore inconsistent. We must decide whether to align code with async SQLAlchemy now, or align ADRs with synchronous SQLAlchemy for the MVP.
+
+## Decision
+Use **synchronous SQLAlchemy 2.0** (`Session` + `create_engine`) for the MVP.
+
+FastAPI supports this model by running synchronous path operations in a threadpool, so blocking database calls do not block the event loop directly. We keep async SQLAlchemy as a possible future migration when a concrete workload requires it.
+
+## Rationale
+
+1. **Code reality and low-risk alignment** -- The current backend is already built around synchronous session usage. Choosing sync for MVP aligns decisions with implementation without broad refactors.
+2. **MVP-first scope control** -- Migrating to async SQLAlchemy now would touch every router, service, dependency, and many tests. That cost does not unlock critical MVP functionality today.
+3. **Team familiarity and test simplicity** -- Current patterns, fixtures, and endpoint structure are built around synchronous SQLAlchemy. Keeping this model reduces immediate complexity.
+4. **Future path remains open** -- FastAPI and SQLAlchemy support async migration later. Deferring now does not block a focused migration if runtime characteristics demand it.
+
+## Alternatives Considered
+
+### Alternative 1: Migrate now to async SQLAlchemy
+- **Pros**: Matches the original async framing in ADR-001; better fit for high-concurrency and I/O-heavy request paths
+- **Cons**: Requires large, cross-cutting changes to routers, services, dependency wiring, and tests during MVP build-out
+- **Rejected because**: The migration effort is high relative to current MVP needs, and there is no measured bottleneck requiring it yet
+
+## Consequences
+
+### Positive
+- ADRs align with actual backend implementation
+- No broad backend refactor is required in M0
+- Tests and developer workflows stay straightforward
+- Team can continue with known SQLAlchemy patterns
+
+### Negative
+- Sync DB operations still consume threadpool workers under heavy concurrency
+- If runtime/API interactions become highly concurrent, async migration pressure increases
+- Future migration will still require coordinated refactoring work
+
+### Neutral
+- SQLAlchemy 2.0 supports both sync and async session models
+- The project can reevaluate this decision later based on profiling and production-like load tests
+
+## When To Revisit
+Reopen this decision when one or more of the following conditions appear:
+- Request concurrency increases enough to show threadpool saturation
+- HAProxy runtime/control-plane interactions become a hot-path I/O workload
+- Load tests show database access as a measurable throughput bottleneck
+
+## Validation
+This decision is correct if:
+- ADR-001 no longer claims that async SQLAlchemy is already adopted
+- Backend documentation and code remain consistent on sync session usage
+- MVP work proceeds without async migration blocking product milestones
+
+## References
+- [ADR-001: FastAPI over Flask/Django](ADR-001-fastapi-over-flask-django.md)
+- [ADR-002: PostgreSQL for Production, SQLite for Development](ADR-002-postgresql-with-sqlite-dev.md)
+- [Issue #98: ADR-006 sync vs async SQLAlchemy decision](https://github.com/bihius/guard-proxy/issues/98)
+- [FastAPI: Concurrency and async / await](https://fastapi.tiangolo.com/async/)


### PR DESCRIPTION
## Summary
- Add ADR-006 to explicitly choose synchronous SQLAlchemy for MVP and document sync-vs-async trade-offs
- Amend ADR-001 so it no longer claims async SQLAlchemy is already adopted, and cross-link ADR-006
- Link ADR-006 from the architecture README ADR index

## Test plan
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`

Closes #98