### PR TITLE
chore(gitignore): scope SQLite ignores for backend dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,12 @@ secrets/
 *.password
 
 # ===== Database =====
-*.db
+# SQLite dev files under backend (default DATABASE_URL). Scoped to this
+# directory so binary DB fixtures under tests/ can still be tracked if needed.
+src/backend/guard_proxy.db
+src/backend/*.db
+# Stray SQLite at repository root (misconfigured tools / local experiments)
+/*.db
 *.sqlite
 *.sqlite3
 *.dump


### PR DESCRIPTION
## Summary

- Replaces the repository-wide `*.db` ignore rule with scoped patterns: `src/backend/guard_proxy.db`, `src/backend/*.db`, and `/*.db`.
- Rationale: keep local SQLite from the default `DATABASE_URL` out of git, while still allowing a future committed binary SQLite fixture under e.g. `src/backend/tests/**/` (those paths are not matched by `src/backend/*.db`).

## Issue #99 checklist

- `src/backend/guard_proxy.db` is not tracked on `main` in this repository state (`git ls-files` shows no `.db` files). No `git rm --cached` was required for a clean tree; contributors who still have an old tracked copy should run `git rm --cached src/backend/guard_proxy.db` once locally.
- Tests use in-memory SQLite via `conftest.py`; nothing depends on a committed `guard_proxy.db`.

## After merge

Contributors who relied on a previously committed dev database should recreate schema locally with:

`uv run alembic -c src/backend/alembic.ini upgrade head`

Closes #99