### PR TITLE
fix(ci): use setup-uv@v6 version input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
-          uv-version: "0.11.6"
+          version: "0.11.6"
 
       - name: Cache uv packages
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ graph TB
 - **WAF**: Coraza 3.x + OWASP CRS 4.x
 - **Backend**: Python 3.13, FastAPI, SQLAlchemy, PostgreSQL
 - **Frontend**: React, TypeScript, Vite, Tailwind CSS, pnpm
-- **Infrastructure**: Docker Compose, Prometheus, Grafana
+- **Infrastructure (MVP)**: Docker Compose
+- **Observability (Post-MVP / optional)**: Prometheus, Grafana, Loki
 
 ## Project Status
 


### PR DESCRIPTION
## Changes

- **CI**: `astral-sh/setup-uv@v6` expects the `version` input (see [setup-uv v6 release notes](https://github.com/astral-sh/setup-uv/releases)); `uv-version` is ignored, so the pinned uv version was not actually enforced.
- **README**: Clarify Docker Compose as MVP infrastructure and list Prometheus, Grafana, and Loki as post-MVP / optional observability.

## Checks

Backend `pytest` / `mypy` / `ruff` and frontend `pnpm run type-check` / `pnpm run lint` were run locally on this branch.