### PR TITLE
feat(backend): add DB constraints for policy and vhost invariants

### DIFF
--- a/src/backend/alembic/versions/2c9b5f4e8d31_add_policy_and_vhost_check_constraints.py
+++ b/src/backend/alembic/versions/2c9b5f4e8d31_add_policy_and_vhost_check_constraints.py
@@ -1,0 +1,47 @@
+"""add policy and vhost check constraints
+
+Revision ID: 2c9b5f4e8d31
+Revises: 1f4a7f0f9a11, c7a2e5b8f1d0
+Create Date: 2026-04-16 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2c9b5f4e8d31"
+down_revision: Union[str, Sequence[str], None] = ("1f4a7f0f9a11", "c7a2e5b8f1d0")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_policies_paranoia_level",
+            "paranoia_level BETWEEN 1 AND 4",
+        )
+        batch_op.create_check_constraint(
+            "ck_policies_anomaly_threshold",
+            "anomaly_threshold >= 0",
+        )
+
+    with op.batch_alter_table("vhosts") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_vhosts_domain_lowercase",
+            "domain = lower(domain)",
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("vhosts") as batch_op:
+        batch_op.drop_constraint("ck_vhosts_domain_lowercase", type_="check")
+
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.drop_constraint("ck_policies_anomaly_threshold", type_="check")
+        batch_op.drop_constraint("ck_policies_paranoia_level", type_="check")

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -25,6 +34,16 @@ class Policy(Base):
     """
 
     __tablename__ = "policies"
+    __table_args__ = (
+        CheckConstraint(
+            "paranoia_level BETWEEN 1 AND 4",
+            name="ck_policies_paranoia_level",
+        ),
+        CheckConstraint(
+            "anomaly_threshold >= 0",
+            name="ck_policies_anomaly_threshold",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
 

--- a/src/backend/app/models/vhost.py
+++ b/src/backend/app/models/vhost.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, func
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -21,9 +29,16 @@ class VHost(Base):
     - jest obsługiwana przez HAProxy (frontend → backend)
     - ma przypisaną politykę WAF (opcjonalnie)
     - może mieć włączony/wyłączony SSL
+
+    Database invariant: the stored domain must be lowercase. API schemas
+    normalize domains to lowercase and this check protects against raw SQL
+    inserts/migrations that bypass schema validation.
     """
 
     __tablename__ = "vhosts"
+    __table_args__ = (
+        CheckConstraint("domain = lower(domain)", name="ck_vhosts_domain_lowercase"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
 

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -1,0 +1,62 @@
+"""Database-level constraint tests for policy and vhost invariants."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.policy import Policy
+from app.models.vhost import VHost
+
+
+def test_policy_paranoia_level_above_max_raises_integrity_error(db: Session) -> None:
+    """DB must reject paranoia levels outside the 1..4 range."""
+    db.add(
+        Policy(
+            name="invalid-paranoia-level",
+            paranoia_level=5,
+            anomaly_threshold=5,
+            is_active=True,
+        )
+    )
+
+    with pytest.raises(IntegrityError, match="ck_policies_paranoia_level|CHECK constraint failed"):
+        db.commit()
+    db.rollback()
+
+
+def test_policy_negative_anomaly_threshold_raises_integrity_error(db: Session) -> None:
+    """DB must reject negative anomaly thresholds."""
+    db.add(
+        Policy(
+            name="invalid-anomaly-threshold",
+            paranoia_level=2,
+            anomaly_threshold=-1,
+            is_active=True,
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match="ck_policies_anomaly_threshold|CHECK constraint failed",
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_vhost_uppercase_domain_raises_integrity_error(db: Session) -> None:
+    """DB must enforce lowercase-only vhost domain values."""
+    db.add(
+        VHost(
+            domain="UpperCase.Example.com",
+            backend_url="http://localhost:8080",
+            is_active=True,
+            ssl_enabled=False,
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match="ck_vhosts_domain_lowercase|CHECK constraint failed",
+    ):
+        db.commit()
+    db.rollback()


### PR DESCRIPTION
## Summary
- add DB-level `CheckConstraint`s on `policies` for `paranoia_level` (`1..4`) and `anomaly_threshold` (`>= 0`) to enforce invariants below the API/schema layer
- add DB-level lowercase domain invariant on `vhosts.domain` via `CheckConstraint("domain = lower(domain)")` and document the strategy in the model docstring
- add Alembic migration and integration tests asserting invalid direct inserts fail with `IntegrityError`

Fixes #101

## Test plan
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`
- [x] `haproxy -c -f configs/haproxy/haproxy.cfg` (skipped: config path not present in repo)