### PR TITLE
feat(devops): add WAF smoke test and mounted Coraza config

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,22 @@
+name: E2E Smoke
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: e2e-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Prepare Docker Compose environment
+        run: cp deploy/docker/.env.example deploy/docker/.env
+
+      - name: Run E2E smoke test
+        run: bash benchmarks/smoke/e2e.sh

--- a/README.commands.md
+++ b/README.commands.md
@@ -54,10 +54,18 @@ cp deploy/docker/.env.example deploy/docker/.env                     # Create en
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config
 make dev                                                             # Start all services (runs backend migrations, attached, with build)
 make coraza-build                                                    # Build the pinned Coraza SPOA + CRS image
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza  # Reload mounted Coraza config/rules
+docker volume ls | grep guard-proxy                                  # Inspect pgdata, log, and generated_config volumes
 make ps                                                              # Show service status
 make logs                                                            # Follow all service logs
 make down                                                            # Stop stack and remove volumes
 make seed                                                            # Seed admin user in backend container
+```
+
+## Smoke Testing
+
+```bash
+bash benchmarks/smoke/e2e.sh  # Compose stack: benign request returns 200, SQLi returns 403
 ```
 
 ## Security Testing

--- a/README.testing.md
+++ b/README.testing.md
@@ -17,6 +17,27 @@
 - Path Traversal: >95% detection rate
 - False positive rate: <10%
 
+### End-to-End Smoke
+
+The M1 smoke test starts the Docker Compose stack, waits for healthy services,
+checks that a benign request is allowed, checks that a SQL injection request is
+blocked by Coraza, and then tears the stack down.
+
+Prerequisites:
+
+- Docker with Docker Compose
+- `deploy/docker/.env` created from `deploy/docker/.env.example`
+- The CRS submodule initialised with `git submodule update --init --recursive`
+
+Run locally:
+
+```sh
+bash benchmarks/smoke/e2e.sh
+```
+
+The smoke test sends `Host: app.local` because the reference HAProxy
+configuration rejects unknown hosts before WAF inspection. The same smoke test
+also runs nightly and on demand through `.github/workflows/smoke.yml`.
 
 ## Test Data
 

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -105,7 +105,7 @@ assert_status() {
 
 cd "${REPO_ROOT}"
 
-"${COMPOSE[@]}" up -d --build
+"${COMPOSE[@]}" up -d --build postgres backend coraza haproxy
 
 wait_for_healthy backend
 wait_for_healthy coraza

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${REPO_ROOT}/deploy/docker/docker-compose.yml"
 ENV_FILE="${REPO_ROOT}/deploy/docker/.env"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-120}"
+SMOKE_PROJECT="${SMOKE_PROJECT:-guard-proxy-smoke}"
 
 if [[ ! -f "${ENV_FILE}" ]]; then
   echo "Missing ${ENV_FILE}. Copy deploy/docker/.env.example to deploy/docker/.env first." >&2
@@ -13,9 +14,9 @@ if [[ ! -f "${ENV_FILE}" ]]; then
 fi
 
 if docker compose version >/dev/null 2>&1; then
-  COMPOSE=(docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+  COMPOSE=(docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --project-name "${SMOKE_PROJECT}")
 elif command -v docker-compose >/dev/null 2>&1; then
-  COMPOSE=(docker-compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+  COMPOSE=(docker-compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" --project-name "${SMOKE_PROJECT}")
 else
   echo "Docker Compose is required." >&2
   exit 1
@@ -30,7 +31,7 @@ cleanup() {
     "${COMPOSE[@]}" logs --tail=50 haproxy coraza || true
   fi
 
-  "${COMPOSE[@]}" down -v
+  "${COMPOSE[@]}" down -v || true
   exit "${status}"
 }
 trap cleanup EXIT

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/deploy/docker/docker-compose.yml"
+ENV_FILE="${REPO_ROOT}/deploy/docker/.env"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-120}"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}. Copy deploy/docker/.env.example to deploy/docker/.env first." >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+else
+  echo "Docker Compose is required." >&2
+  exit 1
+fi
+
+cleanup() {
+  local status=$?
+
+  if [[ "${status}" -ne 0 ]]; then
+    echo
+    echo "Smoke test failed. Recent HAProxy and Coraza logs:"
+    "${COMPOSE[@]}" logs --tail=50 haproxy coraza || true
+  fi
+
+  "${COMPOSE[@]}" down -v
+  exit "${status}"
+}
+trap cleanup EXIT
+
+container_id() {
+  local service="$1"
+  "${COMPOSE[@]}" ps -q "${service}"
+}
+
+health_status() {
+  local service="$1"
+  local id
+
+  id="$(container_id "${service}")"
+  if [[ -z "${id}" ]]; then
+    echo "missing"
+    return
+  fi
+
+  docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${id}"
+}
+
+wait_for_healthy() {
+  local service="$1"
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local status
+
+  echo "Waiting for ${service} to become healthy..."
+  while (( SECONDS < deadline )); do
+    status="$(health_status "${service}")"
+    case "${status}" in
+      healthy)
+        echo "${service} is healthy."
+        return 0
+        ;;
+      exited|dead)
+        echo "${service} is ${status}." >&2
+        return 1
+        ;;
+    esac
+
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${service}; last status: ${status:-unknown}." >&2
+  return 1
+}
+
+assert_status() {
+  local description="$1"
+  local expected="$2"
+  local url="$3"
+  local actual
+
+  actual="$(
+    curl \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --header 'Host: app.local' \
+      "${url}"
+  )"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "${description}: expected HTTP ${expected}, got ${actual}." >&2
+    return 1
+  fi
+
+  echo "${description}: got HTTP ${actual}."
+}
+
+cd "${REPO_ROOT}"
+
+"${COMPOSE[@]}" up -d --build
+
+wait_for_healthy backend
+wait_for_healthy coraza
+wait_for_healthy haproxy
+
+assert_status "Benign request" "200" "http://127.0.0.1:8080/health"
+assert_status "SQL injection request" "403" "http://127.0.0.1:8080/?id=1%27%20OR%20%271%27%3D%271"
+
+echo "E2E smoke test passed."

--- a/configs/coraza/README.md
+++ b/configs/coraza/README.md
@@ -36,6 +36,19 @@ git submodule update --init --recursive
 - Inbound and outbound anomaly thresholds are `5`.
 - Relevant audit events are written as JSON to `/var/log/coraza/audit.json`.
 
+## Docker Compose mounts
+
+When the stack runs through `deploy/docker/docker-compose.yml`, these files are
+mounted into the Coraza container read-only. After editing files in this
+directory, restart the service so `coraza-spoa` reloads them:
+
+```sh
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza
+```
+
+The Coraza image still ships the same defaults, so it can run outside the
+compose stack without host-mounted configuration.
+
 ## Updating CRS
 
 ```sh

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -68,6 +68,10 @@ services:
     restart: unless-stopped
     volumes:
       - coraza_logs:/var/log/coraza
+      - ../../configs/coraza/coraza-spoa.yaml:/etc/coraza-spoa/coraza-spoa.yaml:ro
+      - ../../configs/coraza/coraza.conf:/etc/coraza/coraza.conf:ro
+      - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
+      - ../../configs/coraza/crs:/etc/coraza/crs:ro
     healthcheck:
       test: ["CMD", "/bin/busybox", "nc", "-z", "127.0.0.1", "9000"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Mount Coraza SPOA config, Coraza directives, CRS setup, and CRS rules read-only into the compose service so local edits can be picked up with a service restart.
- Add a reproducible Docker Compose smoke test that asserts benign traffic returns 200 and SQL injection traffic returns 403 through HAProxy and Coraza.
- Add a separate nightly/manual GitHub Actions workflow for the smoke test and document local usage.

## Test plan
- `bash -n benchmarks/smoke/e2e.sh`
- `docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config >/dev/null`
- `bash benchmarks/smoke/e2e.sh`
- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run test`
- `docker run --rm -v "$PWD/configs/haproxy:/usr/local/etc/haproxy:ro" haproxy:3.0-alpine haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg`

Closes #7
Closes #108