### PR TITLE
Fix Vite permissions and healthcheck logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 COMPOSE_FILE := deploy/docker/docker-compose.yml
 ENV_FILE := deploy/docker/.env
 
-.PHONY: dev down logs ps seed coraza-build
+.PHONY: dev down clean logs ps seed coraza-build
 
 dev:
 	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) up --build
 
 down:
+	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) down
+
+clean:
 	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) down -v
 
 logs:

--- a/README.commands.md
+++ b/README.commands.md
@@ -58,7 +58,8 @@ docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env
 docker volume ls | grep guard-proxy                                  # Inspect pgdata, log, and generated_config volumes
 make ps                                                              # Show service status
 make logs                                                            # Follow all service logs
-make down                                                            # Stop stack and remove volumes
+make down                                                            # Stop stack (keeps named volumes)
+make clean                                                           # Stop stack and remove volumes
 make seed                                                            # Seed admin user in backend container
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ Or view [milestones](https://github.com/bihius/guard-proxy/milestones)
    - `make dev`
 3. Access services:
    - Frontend: `http://localhost:3000`
-   - API via HAProxy: `http://localhost:8080` with `Host: app.local`
-   - Backend health via HAProxy: `curl -H 'Host: app.local' http://localhost:8080/health`
+   - API via HAProxy: `http://localhost:8080`
+   - Backend health via HAProxy: `curl http://localhost:8080/health`
 4. Optional WAF smoke test:
    - `curl -i -H 'Host: app.local' "http://localhost:8080/?id=1%27%20OR%20%271%27=%271"` should return `403 Forbidden`
 
-Use `make down` to stop containers and remove volumes.
+Use `make down` to stop containers (keeps named volumes such as Postgres data).
+
+Use `make clean` to stop containers and remove volumes (full local reset).
 
 ## License
 

--- a/configs/haproxy/README.md
+++ b/configs/haproxy/README.md
@@ -114,9 +114,9 @@ The configuration is exercised in two ways:
    ```sh
    docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --build
    docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env ps
-   curl -i -H 'Host: app.local' http://localhost:8080/health
-   curl -i -H 'Host: app.local' "http://localhost:8080/?id=1%27%20OR%20%271%27=%271"
-   docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down -v
+   curl -i http://localhost:8080/health
+   curl -i "http://localhost:8080/?id=1%27%20OR%20%271%27=%271"
+   docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env down
    ```
 
    All five services should become healthy. The benign `/health` request

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -33,15 +33,17 @@ frontend fe_http
     # can be correlated.
     unique-id-format %[uuid()]
     unique-id-header X-Request-ID
+    acl is_health path /health
+    http-request set-log-level silent if is_health
 
     # Hand the request off to the Coraza SPOA. The engine name
     # ("coraza") must match the [coraza] section in coraza.cfg.
     filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
-    http-request send-spoe-group coraza coraza-req
+    http-request send-spoe-group coraza coraza-req unless is_health
 
-    # Reference vhost: only requests for app.local are accepted.
+    # Reference vhost: accept app.local plus local-dev browser hosts.
     # Anything else is rejected before it hits the backend.
-    acl host_app hdr(host) -i app.local app.local:80
+    acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
     http-request deny deny_status 421 if !host_app
 
     # Coraza populates txn.coraza.* via the SPOE response. If the

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -5,7 +5,8 @@
 POSTGRES_USER=guard_proxy
 POSTGRES_PASSWORD=guard_proxy_dev_password
 POSTGRES_DB=guard_proxy
-DATABASE_URL=postgresql://guard_proxy:guard_proxy_dev_password@postgres:5432/guard_proxy
+
+# The backend DATABASE_URL is built by docker-compose.yml from POSTGRES_*.
 
 JWT_SECRET_KEY=guard-proxy-dev-jwt-secret-key-please-change
 LOG_INGEST_SHARED_SECRET=guard-proxy-dev-log-ingest-shared-secret-please-change

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/notes/decisions/ADR-004-docker-compose-deployment.md
+++ b/notes/decisions/ADR-004-docker-compose-deployment.md
@@ -83,7 +83,7 @@ For production, deploy on **Proxmox VE** using LXC containers running Docker.
 - [ ] Create `deploy/docker/docker-compose.prod.yml` with production settings
 - [ ] Create `src/coraza/Dockerfile` for custom Coraza SPOA image
 - [ ] Create `.env.example` with all required environment variables
-- [ ] Add `Makefile` targets: `make dev`, `make prod`, `make down`
+- [ ] Add `Makefile` targets: `make dev`, `make prod`, `make down`, `make clean`
 
 ## Planned Service Configuration
 

--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -1,9 +1,11 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
 
 from alembic import context
+from app.config import get_database_settings
+from app.database import Base
+from app.models import *  # noqa: F403 — register all models for Alembic metadata
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -18,14 +20,10 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from app.config import get_database_settings
-from app.database import Base
-from app.models import *  # noqa: F403 — importuje wszystkie modele
 
 database_settings = get_database_settings()
 
-# Nadpisz URL z .env (settings.database_url) zamiast hardcoded z alembic.ini
-# Dzięki temu: dev=SQLite, prod=PostgreSQL — automatycznie z DATABASE_URL w .env
+# Override URL from settings (e.g. DATABASE_URL in .env) instead of alembic.ini alone.
 config.set_main_option("sqlalchemy.url", database_settings.database_url)
 
 target_metadata = Base.metadata

--- a/src/backend/alembic/versions/13e761207c57_create_initial_tables.py
+++ b/src/backend/alembic/versions/13e761207c57_create_initial_tables.py
@@ -6,17 +6,17 @@ Create Date: 2026-03-10 19:57:08.935206
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "13e761207c57"
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/backend/alembic/versions/1f4a7f0f9a11_add_rule_override_unique_constraint.py
+++ b/src/backend/alembic/versions/1f4a7f0f9a11_add_rule_override_unique_constraint.py
@@ -6,16 +6,15 @@ Create Date: 2026-04-10 10:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "1f4a7f0f9a11"
-down_revision: Union[str, Sequence[str], None] = "7e0f9c2c9e62"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "7e0f9c2c9e62"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/backend/alembic/versions/2c9b5f4e8d31_add_policy_and_vhost_check_constraints.py
+++ b/src/backend/alembic/versions/2c9b5f4e8d31_add_policy_and_vhost_check_constraints.py
@@ -6,16 +6,15 @@ Create Date: 2026-04-16 12:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = "2c9b5f4e8d31"
-down_revision: Union[str, Sequence[str], None] = ("1f4a7f0f9a11", "c7a2e5b8f1d0")
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = ("1f4a7f0f9a11", "c7a2e5b8f1d0")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/backend/alembic/versions/7e0f9c2c9e62_add_logs_table.py
+++ b/src/backend/alembic/versions/7e0f9c2c9e62_add_logs_table.py
@@ -6,17 +6,17 @@ Create Date: 2026-03-24 12:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "7e0f9c2c9e62"
-down_revision: Union[str, Sequence[str], None] = "13e761207c57"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "13e761207c57"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
+++ b/src/backend/alembic/versions/c7a2e5b8f1d0_redesign_logs_table_for_event_model.py
@@ -6,17 +6,18 @@ Create Date: 2026-04-11 11:00:00.000000
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = "c7a2e5b8f1d0"
-down_revision: Union[str, Sequence[str], None] = "7e0f9c2c9e62"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "7e0f9c2c9e62"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -31,7 +32,41 @@ def upgrade() -> None:
 
     context = op.get_context()
     if context.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS logaction")
         op.execute("DROP TYPE IF EXISTS logseverity")
+        bind = op.get_bind()
+        sa.Enum("allow", "deny", "monitor", name="logaction").create(
+            bind,
+            checkfirst=True,
+        )
+        sa.Enum("info", "warning", "error", "critical", name="logseverity").create(
+            bind,
+            checkfirst=True,
+        )
+        action_enum = postgresql.ENUM(
+            "allow",
+            "deny",
+            "monitor",
+            name="logaction",
+            create_type=False,
+        )
+        severity_enum = postgresql.ENUM(
+            "info",
+            "warning",
+            "error",
+            "critical",
+            name="logseverity",
+            create_type=False,
+        )
+    else:
+        action_enum = sa.Enum("allow", "deny", "monitor", name="logaction")
+        severity_enum = sa.Enum(
+            "info",
+            "warning",
+            "error",
+            "critical",
+            name="logseverity",
+        )
 
     op.create_table(
         "logs",
@@ -46,7 +81,7 @@ def upgrade() -> None:
         sa.Column("vhost", sa.String(length=255), nullable=False),
         sa.Column(
             "action",
-            sa.Enum("allow", "deny", "monitor", name="logaction"),
+            action_enum,
             nullable=False,
         ),
         sa.Column("source_ip", sa.String(length=45), nullable=False),
@@ -59,7 +94,7 @@ def upgrade() -> None:
         sa.Column("paranoia_level", sa.Integer(), nullable=True),
         sa.Column(
             "severity",
-            sa.Enum("info", "warning", "error", "critical", name="logseverity"),
+            severity_enum,
             nullable=False,
         ),
         sa.Column("message", sa.Text(), nullable=True),

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -6,6 +7,17 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings, validate_runtime_settings
 from app.routers import auth, logs, policies, rule_overrides, vhosts
+
+
+class _HealthcheckAccessFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if isinstance(args, tuple) and len(args) >= 3 and args[2] == "/health":
+            return False
+        return True
+
+
+logging.getLogger("uvicorn.access").addFilter(_HealthcheckAccessFilter())
 
 
 @asynccontextmanager

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -12,7 +12,12 @@ from app.routers import auth, logs, policies, rule_overrides, vhosts
 class _HealthcheckAccessFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         args = record.args
-        if isinstance(args, tuple) and len(args) >= 3 and args[1] == "GET" and args[2] == "/health":
+        if (
+            isinstance(args, tuple)
+            and len(args) >= 3
+            and args[1] == "GET"
+            and args[2] == "/health"
+        ):
             return False
         return True
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -12,7 +12,7 @@ from app.routers import auth, logs, policies, rule_overrides, vhosts
 class _HealthcheckAccessFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         args = record.args
-        if isinstance(args, tuple) and len(args) >= 3 and args[2] == "/health":
+        if isinstance(args, tuple) and len(args) >= 3 and args[1] == "GET" and args[2] == "/health":
             return False
         return True
 

--- a/src/backend/app/routers/logs.py
+++ b/src/backend/app/routers/logs.py
@@ -17,6 +17,7 @@ from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 
 router = APIRouter(prefix="/logs", tags=["logs"])
 
+
 def require_log_ingest_secret(
     x_guard_proxy_ingest_secret: str | None = Header(
         default=None,

--- a/src/backend/scripts/seed_admin.py
+++ b/src/backend/scripts/seed_admin.py
@@ -2,7 +2,8 @@
 
 Usage:
     uv run python scripts/seed_admin.py
-    uv run python scripts/seed_admin.py --email admin@example.com --password supersecretpw
+    uv run python scripts/seed_admin.py --email admin@example.com \\
+        --password supersecretpw
 
 If --email / --password are not provided, the script reads
 ADMIN_EMAIL and ADMIN_PASSWORD from the environment (or `.env` file).

--- a/src/backend/tests/integration/test_auth_router.py
+++ b/src/backend/tests/integration/test_auth_router.py
@@ -183,9 +183,7 @@ def test_refresh_nonexistent_user_returns_401(client: TestClient) -> None:
     assert resp.status_code == 401
 
 
-def test_logout_clears_refresh_cookie(
-    client: TestClient, admin_user: User
-) -> None:
+def test_logout_clears_refresh_cookie(client: TestClient, admin_user: User) -> None:
     client.post(
         "/auth/login",
         json={"email": admin_user.email, "password": ADMIN_PASSWORD},
@@ -195,9 +193,10 @@ def test_logout_clears_refresh_cookie(
 
     assert resp.status_code == 204
     assert settings.auth_refresh_cookie_name not in client.cookies
-    assert "Max-Age=0" in resp.headers["set-cookie"] or "expires=" in resp.headers[
-        "set-cookie"
-    ].lower()
+    assert (
+        "Max-Age=0" in resp.headers["set-cookie"]
+        or "expires=" in resp.headers["set-cookie"].lower()
+    )
 
 
 def test_me_returns_user_data(

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -19,7 +19,10 @@ def test_policy_paranoia_level_above_max_raises_integrity_error(db: Session) -> 
         )
     )
 
-    with pytest.raises(IntegrityError, match="ck_policies_paranoia_level|CHECK constraint failed"):
+    with pytest.raises(
+        IntegrityError,
+        match="ck_policies_paranoia_level|CHECK constraint failed",
+    ):
         db.commit()
     db.rollback()
 

--- a/src/backend/tests/integration/test_logs_router.py
+++ b/src/backend/tests/integration/test_logs_router.py
@@ -368,7 +368,11 @@ def test_ingest_log_event_persists_valid_payload(
     log_ingest_headers: dict[str, str],
 ) -> None:
     """A valid ingest request should store the event in the database."""
-    resp = client.post("/logs/ingest", json=_ingest_payload(), headers=log_ingest_headers)
+    resp = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(),
+        headers=log_ingest_headers,
+    )
     assert resp.status_code == 201
 
     body = resp.json()
@@ -445,7 +449,11 @@ def test_ingest_log_event_is_idempotent_when_producer_event_id_retries(
     log_ingest_headers: dict[str, str],
 ) -> None:
     """Retrying the same producer event id should return the existing record."""
-    first = client.post("/logs/ingest", json=_ingest_payload(), headers=log_ingest_headers)
+    first = client.post(
+        "/logs/ingest",
+        json=_ingest_payload(),
+        headers=log_ingest_headers,
+    )
     second = client.post(
         "/logs/ingest",
         json=_ingest_payload(message="Changed body should still dedupe"),
@@ -480,4 +488,3 @@ def test_ingest_then_list_logs_returns_persisted_event(
     body = resp.json()
     assert body["total"] == 1
     assert body["items"][0]["producer_event_id"] == "coraza-event-3"
-

--- a/src/backend/tests/unit/test_access_logging.py
+++ b/src/backend/tests/unit/test_access_logging.py
@@ -3,21 +3,25 @@ import logging
 from app.main import _HealthcheckAccessFilter
 
 
-def _access_record(path: str) -> logging.LogRecord:
+def _access_record(method: str, path: str, status: int = 200) -> logging.LogRecord:
     return logging.LogRecord(
         name="uvicorn.access",
         level=logging.INFO,
         pathname=__file__,
         lineno=1,
         msg='%s - "%s %s HTTP/%s" %d',
-        args=("127.0.0.1:12345", "GET", path, "1.1", 200),
+        args=("127.0.0.1:12345", method, path, "1.1", status),
         exc_info=None,
     )
 
 
-def test_healthcheck_access_filter_drops_health_requests() -> None:
-    assert not _HealthcheckAccessFilter().filter(_access_record("/health"))
+def test_healthcheck_access_filter_drops_get_health() -> None:
+    assert not _HealthcheckAccessFilter().filter(_access_record("GET", "/health"))
+
+
+def test_healthcheck_access_filter_keeps_non_get_health() -> None:
+    assert _HealthcheckAccessFilter().filter(_access_record("POST", "/health", 405))
 
 
 def test_healthcheck_access_filter_keeps_non_health_requests() -> None:
-    assert _HealthcheckAccessFilter().filter(_access_record("/api/v1/policies"))
+    assert _HealthcheckAccessFilter().filter(_access_record("GET", "/api/v1/policies"))

--- a/src/backend/tests/unit/test_access_logging.py
+++ b/src/backend/tests/unit/test_access_logging.py
@@ -1,0 +1,23 @@
+import logging
+
+from app.main import _HealthcheckAccessFilter
+
+
+def _access_record(path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:12345", "GET", path, "1.1", 200),
+        exc_info=None,
+    )
+
+
+def test_healthcheck_access_filter_drops_health_requests() -> None:
+    assert not _HealthcheckAccessFilter().filter(_access_record("/health"))
+
+
+def test_healthcheck_access_filter_keeps_non_health_requests() -> None:
+    assert _HealthcheckAccessFilter().filter(_access_record("/api/v1/policies"))

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -147,7 +147,10 @@ def test_log_ingest_shared_secret_placeholder_raises() -> None:
 
 
 def test_auth_refresh_cookie_samesite_none_requires_secure() -> None:
-    with pytest.raises(ValidationError, match="AUTH_REFRESH_COOKIE_SECURE must be true"):
+    with pytest.raises(
+        ValidationError,
+        match="AUTH_REFRESH_COOKIE_SECURE must be true",
+    ):
         _make_settings(
             JWT_SECRET_KEY="real-secret-value",
             LOG_INGEST_SHARED_SECRET="real-log-secret",
@@ -181,7 +184,9 @@ def test_settings_reject_empty_database_url() -> None:
         )
 
 
-def test_settings_ignore_dot_env_example(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_settings_ignore_dot_env_example(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from app.config import Settings
 
     monkeypatch.chdir(tmp_path)
@@ -209,4 +214,6 @@ def test_settings_ignore_dot_env_example(tmp_path: Path, monkeypatch: pytest.Mon
     settings = Settings()
 
     assert getattr(settings, "jwt_secret_key") == "real-secret-from-dot-env"
-    assert getattr(settings, "log_ingest_shared_secret") == "real-log-secret-from-dot-env"
+    assert (
+        getattr(settings, "log_ingest_shared_secret") == "real-log-secret-from-dot-env"
+    )

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -164,7 +164,9 @@ def test_policy_create_schema_exposes_paranoia_level_bounds() -> None:
 def test_policy_update_schema_exposes_paranoia_level_bounds() -> None:
     schema = PolicyUpdate.model_json_schema()
     paranoia_schema = schema["properties"]["paranoia_level"]
-    int_schema = next(item for item in paranoia_schema["anyOf"] if item.get("type") == "integer")
+    int_schema = next(
+        item for item in paranoia_schema["anyOf"] if item.get("type") == "integer"
+    )
 
     assert int_schema["minimum"] == 1
     assert int_schema["maximum"] == 4

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,9 +1,10 @@
 FROM node:24-alpine
 
+RUN corepack enable
+
 RUN mkdir -p /app && chown -R node:node /app
 WORKDIR /app
-
-RUN corepack enable
+USER node
 
 COPY --chown=node:node package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
@@ -12,5 +13,4 @@ COPY --chown=node:node . .
 
 EXPOSE 5173
 
-USER node
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
## Summary
- Run frontend dependency installation as the node user so Vite can write its optimizer cache at runtime.
- Filter backend uvicorn access logs for GET /health while preserving normal request logs.
- Add unit coverage for the backend healthcheck access-log filter.

## Test plan
- uv run pytest --cov=app
- uv run mypy app/
- uv run ruff check app/
- pnpm run type-check
- pnpm run lint
- pnpm run test
- docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env build --no-cache frontend
- docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env up -d --no-deps --force-recreate frontend
- python3 HTTP check for http://127.0.0.1:3000 returned 200
- docker-compose backend log check confirmed /health access logs are filtered while /docs still logs