### PR TITLE
Architecture Documentation Sweep For M1

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -60,10 +60,10 @@ with `503 Service Unavailable` and WAF degraded headers.
 
 ### Request Processing
 1. Client sends an HTTP request to HAProxy.
-2. HAProxy rejects unknown hosts before WAF inspection in the M1 reference config.
-3. HAProxy sends request-phase metadata to Coraza SPOA through SPOE.
-4. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
-5. HAProxy returns `403` for denied traffic, `503` for WAF inspection failures, or forwards allowed requests to the FastAPI backend.
+2. In the current M1 reference config, HAProxy sends request-phase metadata to Coraza SPOA through SPOE before enforcing the unknown-host deny ACL.
+3. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
+4. HAProxy enforces the WAF decision, rejects unknown hosts, or returns `503` if SPOE inspection fails.
+5. HAProxy forwards allowed requests to the FastAPI backend.
 
 ### Policy Management
 1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -60,10 +60,10 @@ with `503 Service Unavailable` and WAF degraded headers.
 
 ### Request Processing
 1. Client sends an HTTP request to HAProxy.
-2. In the current M1 reference config, HAProxy sends request-phase metadata to Coraza SPOA through SPOE before enforcing the unknown-host deny ACL.
-3. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
-4. HAProxy enforces the WAF decision, rejects unknown hosts, or returns `503` if SPOE inspection fails.
-5. HAProxy forwards allowed requests to the FastAPI backend.
+2. HAProxy rejects unknown hosts with `421` before WAF inspection.
+3. HAProxy sends request-phase metadata to Coraza SPOA through SPOE.
+4. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
+5. HAProxy returns `403` for denied traffic, `503` for WAF inspection failures (`txn.coraza.error`), or forwards allowed requests to the FastAPI backend.
 
 ### Policy Management
 1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -2,79 +2,103 @@
 
 ## High-Level Overview
 
+Guard Proxy is a self-hosted reverse proxy WAF. The M1 stack runs HAProxy,
+Coraza SPOA with OWASP CRS, the FastAPI backend, the React frontend, and
+PostgreSQL through Docker Compose.
+
 ```mermaid
 graph TB
-    C[Clients] -->|HTTP/HTTPS| H[HAProxy]
-    H -.->|SPOE| CS[Coraza WAF]
-    CS -.->|Allow/Deny| H
-    H --> APP[Backend Apps]
+    C[Clients] -->|HTTP on :8080| H[HAProxy]
+    H -.->|SPOE request inspection| CS[Coraza SPOA + OWASP CRS]
+    CS -.->|allow / deny / error metadata| H
+    H -->|allowed requests| BE[FastAPI Backend]
 
-    FE[React UI] -->|API| BE[FastAPI]
-    BE -->|Config| H
+    FE[React Admin UI] -->|REST API| BE
     BE --> DB[(PostgreSQL)]
+    BE -.->|future generated config| H
+    BE -.->|future generated config| CS
 ```
 
 ## Request Flow
 
 ```mermaid
 sequenceDiagram
-    Client->>HAProxy: HTTP Request
-    HAProxy->>Coraza: SPOE (request data)
-    Coraza->>Coraza: Evaluate rules
-    alt Score >= Threshold
-        Coraza->>HAProxy: DENY
+    Client->>HAProxy: HTTP request
+    HAProxy->>Coraza: SPOE request metadata
+    Coraza->>Coraza: Evaluate request-phase CRS rules
+    alt WAF inspection fails
+        HAProxy->>Client: 503 Service Unavailable
+    else CRS blocks request
+        Coraza->>HAProxy: deny decision + anomaly metadata
         HAProxy->>Client: 403 Forbidden
-    else Score < Threshold
-        Coraza->>HAProxy: ALLOW
-        HAProxy->>Backend: Forward
+    else Request allowed
+        Coraza->>HAProxy: allow decision + anomaly metadata
+        HAProxy->>Backend: Forward request
         Backend->>Client: Response
     end
 ```
+
+M1 focuses on request inspection. HAProxy sends method, path, query,
+headers, and body data to Coraza SPOA over SPOE. Coraza evaluates the request
+against the configured OWASP CRS bundle and returns transaction variables such
+as the action and anomaly score. HAProxy blocks `deny` decisions with `403`.
+If SPOE inspection is unavailable or returns an error, HAProxy fails closed
+with `503 Service Unavailable` and WAF degraded headers.
 
 ## Components
 
 | Component | Role | Location |
 |-----------|------|----------|
-| **HAProxy** | Reverse proxy, HTTPS termination, vhost routing, SPOE | `configs/haproxy/` *(planned)* |
-| **Coraza SPOA** | WAF engine, OWASP CRS, anomaly scoring, per-vhost rules | *(planned)* |
-| **FastAPI Backend** | Policy management API, config generation | `src/backend/` |
-| **React Frontend** | Admin panel UI, policy editor, Vite app managed with pnpm | `src/frontend/` *(planned)* |
+| **HAProxy** | Reference reverse proxy, host routing, SPOE filter, WAF enforcement, degraded-mode handling | `configs/haproxy/` |
+| **Coraza SPOA + OWASP CRS** | Request-phase WAF inspection, CRS anomaly scoring, audit logging seed configuration | `configs/coraza/`, `deploy/docker/coraza.Dockerfile` |
+| **FastAPI Backend** | Control-plane API for auth, vhosts, policies, rule overrides, logs, and health checks | `src/backend/` |
+| **React Frontend** | Admin panel SPA built with React, TypeScript, Vite, Tailwind CSS, and pnpm | `src/frontend/` |
+| **PostgreSQL** | Docker Compose database for backend state | `deploy/docker/docker-compose.yml` |
+| **Docker Compose Stack** | Local full-stack orchestration, health checks, networks, logs, and persistent volumes | `deploy/docker/` |
 
 ## Data Flow
 
 ### Request Processing
-1. Client -> HAProxy
-2. HAProxy -> Coraza (SPOE with method, path, query, headers, body)
-3. Coraza evaluates CRS rules, calculates anomaly score
-4. Coraza -> HAProxy (allow/deny + score)
-5. HAProxy -> Backend (if allowed) or 403 (if denied)
+1. Client sends an HTTP request to HAProxy.
+2. HAProxy rejects unknown hosts before WAF inspection in the M1 reference config.
+3. HAProxy sends request-phase metadata to Coraza SPOA through SPOE.
+4. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
+5. HAProxy returns `403` for denied traffic, `503` for WAF inspection failures, or forwards allowed requests to the FastAPI backend.
 
 ### Policy Management
-1. Admin edits policy in React UI
-2. API call to FastAPI backend
-3. Backend updates PostgreSQL
-4. Backend generates HAProxy/Coraza config
-5. Backend reloads HAProxy (graceful, no dropped connections)
+1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.
+2. FastAPI persists control-plane state in PostgreSQL.
+3. M1 stores policy data but still uses hand-written HAProxy and Coraza reference configuration.
+4. Generated HAProxy/Coraza config, validation, graceful reloads, rollback, and richer per-vhost runtime policy wiring are future M2 work.
 
 ### Runtime Event Ingestion
-1. Coraza or a proxy-side adapter produces a structured WAF event
-2. The producer sends the event to `POST /logs/ingest`
-3. FastAPI validates and normalizes the payload into the persisted log event model
-4. The backend stores the event as a historical snapshot in PostgreSQL
-5. `GET /logs` exposes the stored events to the future frontend log viewer
+1. Runtime WAF events can be represented as structured log payloads.
+2. Producers send events to `POST /logs/ingest`.
+3. FastAPI validates and normalizes payloads into the persisted log event model.
+4. `GET /logs` exposes stored events for the future frontend log viewer.
+5. Full automatic Coraza-to-backend event forwarding and production log presentation remain post-M1 work.
 
 ## Deployment
 
 ### Development (Docker Compose)
+
+The implemented M1 stack lives in `deploy/docker/docker-compose.yml`.
+
 ```yaml
 services:
-  haproxy:    # Port 80, 443
-  coraza:     # Port 9000 (SPOE)
-  backend:    # Port 8000 (API)
-  frontend:   # Port 3000 (pnpm + Vite dev server)
-  postgres:   # Port 5432
+  haproxy:   # host port 8080 -> container port 80
+  coraza:    # internal port 9000 (SPOE)
+  backend:   # internal port 8000 (FastAPI)
+  frontend:  # host port 3000 -> Vite port 5173
+  postgres:  # internal port 5432
 ```
 
+Prepare `deploy/docker/.env` from `deploy/docker/.env.example`, then use
+`make run` for the normal stack or `make dev` for HAProxy `-d` output and
+Coraza debug logging. The end-to-end smoke test is
+`benchmarks/smoke/e2e.sh`; it starts the stack, waits for healthy services,
+checks a benign request, checks that a SQL injection request is blocked, and
+tears the stack down.
 
 ## Key Decisions
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,22 @@ Guard Proxy is a Web Application Firewall (WAF) solution designed for self-hoste
 
 This project is being developed as a master's thesis at Wroclaw University DSW. 
 
-## Planned Features
+## Implemented M1 Capabilities
 
-- **HAProxy 2.8+** as reverse proxy with SPOE integration
-- **Coraza WAF 3.x** with OWASP CRS for threat detection
-- **Per-vhost policies** with configurable paranoia levels (PL1-PL4)
-- **Anomaly scoring** for intelligent threat detection
-- **Admin panel** (FastAPI + React) for managing policies and monitoring
-- **Docker-based deployment** for easy setup
+- **HAProxy 3.0** reference reverse proxy with SPOE integration
+- **Coraza SPOA** with OWASP CRS 4.x for request inspection
+- **Fail-closed WAF degraded mode** when Coraza inspection is unavailable
+- **FastAPI backend** for auth, vhosts, policies, rule overrides, logs, and health
+- **React admin panel** served by the Docker Compose stack
+- **Docker Compose full-stack deployment** for local development and smoke testing
+
+## Planned/Post-M1 Capabilities
+
+- Generated HAProxy and Coraza configuration from stored policies
+- Policy-driven graceful reload, validation, and rollback
+- Richer per-vhost runtime policy wiring
+- Complete frontend workflows for policy editing, monitoring, and WAF log review
+- Observability with Prometheus, Grafana, and Loki
 
 ## Architecture
 
@@ -33,8 +41,8 @@ graph TB
 
 ## Tech Stack
 
-- **Proxy**: HAProxy 2.8+ with SPOE
-- **WAF**: Coraza 3.x + OWASP CRS 4.x
+- **Proxy**: HAProxy 3.0 with SPOE
+- **WAF**: Coraza SPOA 0.6.1 + OWASP CRS 4.x
 - **Backend**: Python 3.13, FastAPI, SQLAlchemy, PostgreSQL
 - **Frontend**: React, TypeScript, Vite, Tailwind CSS, pnpm
 - **Infrastructure (MVP)**: Docker Compose
@@ -60,7 +68,8 @@ Or view [milestones](https://github.com/bihius/guard-proxy/milestones)
    - `cp deploy/docker/.env.example deploy/docker/.env`
    - Update secrets in `deploy/docker/.env`
 2. Start the stack:
-   - `make dev`
+   - `make run` for normal mode
+   - `make dev` for HAProxy and Coraza debug logging
 3. Access services:
    - Frontend: `http://localhost:3000`
    - API via HAProxy: `http://localhost:8080`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is being developed as a master's thesis at Wroclaw University DSW.
 
 - **HAProxy 3.0** reference reverse proxy with SPOE integration
 - **Coraza SPOA** with OWASP CRS 4.x for request inspection
-- **Fail-closed WAF degraded mode** when Coraza inspection is unavailable
+- **WAF degraded-mode error signalling** for Coraza inspection failures
 - **FastAPI backend** for auth, vhosts, policies, rule overrides, logs, and health
 - **React admin panel** served by the Docker Compose stack
 - **Docker Compose full-stack deployment** for local development and smoke testing

--- a/configs/haproxy/coraza.cfg
+++ b/configs/haproxy/coraza.cfg
@@ -18,8 +18,8 @@ spoe-agent coraza-agent
     option              var-prefix  coraza
 
     # If the SPOA is unreachable or replies with an error, mark the
-    # transaction as errored. haproxy.cfg currently fail-opens in
-    # that case; failure handling is tracked separately in #80.
+    # transaction as errored by setting txn.coraza.error=1.
+    # haproxy.cfg checks this variable and returns 503 (fail-closed).
     option              set-on-error  error
 
     # SPOE handshake / idle / per-request timeouts. Keep processing

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -50,12 +50,12 @@ frontend fe_http
     http-request send-spoe-group coraza coraza-req unless is_health
 
     # Fail closed: if the SPOA is unreachable or returns an error,
-    # txn.coraza.error is set to 1 by the set-on-error option in
-    # coraza.cfg. Return 503 so no unscreened traffic reaches the backend.
-    http-request deny deny_status 503 if { var(txn.coraza.error) -m bool }
-
-    # Coraza populates txn.coraza.* via the SPOE response. If SPOE
-    # inspection fails, fail closed before the backend is contacted.
+    # txn.coraza.error is set by the set-on-error option in coraza.cfg.
+    # Raise the log level and return 503 with WAF-degraded headers so
+    # operators can distinguish a WAF outage from an application error.
+    # Using -m found (not -m bool) ensures fail-closed on any error code,
+    # including a hypothetical zero value. No unscreened traffic reaches
+    # the backend.
     http-request set-log-level err if { var(txn.coraza.error) -m found }
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Degraded true hdr X-WAF-Error %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
 

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -3,7 +3,9 @@
 # Goals:
 #   - Single frontend listening on :80
 #   - Single virtual host routed to a single backend
+#   - Reject unknown hosts before WAF inspection
 #   - SPOE filter forwarding request metadata to Coraza SPOA
+#   - Fail closed (503) if SPOA is unavailable or returns an error
 #   - Block requests when Coraza returns action=deny
 #
 # This file is the hand-written seed that the M2 Jinja2 template
@@ -36,15 +38,21 @@ frontend fe_http
     acl is_health path /health
     http-request set-log-level silent if is_health
 
+    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Unknown hosts are rejected here, before WAF inspection, so that
+    # Coraza does not process traffic destined for no valid backend.
+    acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
+    http-request deny deny_status 421 if !host_app
+
     # Hand the request off to the Coraza SPOA. The engine name
     # ("coraza") must match the [coraza] section in coraza.cfg.
     filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
     http-request send-spoe-group coraza coraza-req unless is_health
 
-    # Reference vhost: accept app.local plus local-dev browser hosts.
-    # Anything else is rejected before it hits the backend.
-    acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
-    http-request deny deny_status 421 if !host_app
+    # Fail closed: if the SPOA is unreachable or returns an error,
+    # txn.coraza.error is set to 1 by the set-on-error option in
+    # coraza.cfg. Return 503 so no unscreened traffic reaches the backend.
+    http-request deny deny_status 503 if { var(txn.coraza.error) -m bool }
 
     # Coraza populates txn.coraza.* via the SPOE response. If the
     # engine returns action=deny we stop the transaction with 403.

--- a/notes/decisions/ADR-001-fastapi-over-flask-django.md
+++ b/notes/decisions/ADR-001-fastapi-over-flask-django.md
@@ -17,6 +17,14 @@ The backend needs to be type-safe (complex policy schemas), provide auto-generat
 ## Decision
 Use **FastAPI** (Python 3.11+) as the backend web framework.
 
+## Current M1 Implementation
+
+The backend currently targets Python 3.13 in `src/backend/pyproject.toml`.
+Database access uses synchronous SQLAlchemy sessions for MVP scope, as recorded
+in [ADR-006](ADR-006-sync-sqlalchemy-for-mvp.md). FastAPI remains the API
+framework and still keeps an async migration path open for future runtime or
+I/O-heavy work.
+
 ## Rationale
 
 1. **Native async/await option** -- FastAPI is built on Starlette with first-class async support, which keeps an async path open for future HAProxy Runtime API and concurrent I/O workloads. The MVP currently uses synchronous SQLAlchemy (see ADR-006)

--- a/notes/decisions/ADR-001-fastapi-over-flask-django.md
+++ b/notes/decisions/ADR-001-fastapi-over-flask-django.md
@@ -15,7 +15,7 @@ The Guard Proxy system requires a backend API for the policy management panel. T
 The backend needs to be type-safe (complex policy schemas), provide auto-generated API documentation (thesis deliverable), and keep async-capable options available for future runtime and I/O-heavy paths.
 
 ## Decision
-Use **FastAPI** (Python 3.11+) as the backend web framework.
+Use **FastAPI** (Python 3.13+) as the backend web framework.
 
 ## Current M1 Implementation
 

--- a/notes/decisions/ADR-002-postgresql-with-sqlite-dev.md
+++ b/notes/decisions/ADR-002-postgresql-with-sqlite-dev.md
@@ -21,6 +21,12 @@ The database must support:
 ## Decision
 Use **PostgreSQL 15+** for production/Docker environments and **SQLite 3** for local development and testing. Use **SQLAlchemy 2.0** as the ORM to abstract database differences.
 
+## Current M1 Implementation
+
+The Docker Compose stack currently uses `postgres:16-alpine`, which satisfies
+the PostgreSQL 15+ decision. Local backend development and tests continue to
+use SQLite through the configured `DATABASE_URL` default and test fixtures.
+
 ## Rationale
 
 1. **PostgreSQL for production** -- JSONB support for flexible policy schemas, proper concurrency (MVCC), full-text search for log filtering, and battle-tested reliability

--- a/notes/decisions/ADR-003-react-typescript-frontend.md
+++ b/notes/decisions/ADR-003-react-typescript-frontend.md
@@ -15,16 +15,22 @@ The Guard Proxy system needs an admin panel for managing WAF policies. The panel
 The frontend is an internal admin tool, not a public-facing website. It needs to be functional, maintainable, and reasonably polished -- but not a design showcase.
 
 ## Decision
-Use **React 18** with **TypeScript 5** (strict mode), **Vite 5** as build tool, **TanStack Query** for server state, **React Hook Form** for forms, **shadcn/ui** (Radix UI + Tailwind CSS 3) for components, and **pnpm** as the only frontend package manager.
+Use **React 18** with **TypeScript 5** in strict mode, **Vite**, **Tailwind
+CSS**, and **pnpm** as the only frontend package manager.
+
+## Current M1 Implementation
+
+The implemented frontend is a React 18 and TypeScript SPA built with Vite 6,
+Tailwind CSS v4, React Router v6, pnpm, and a custom CSS-token design system.
+Additional server-state, form, or component libraries remain optional future
+choices if the policy editor and data-fetching flows need them.
 
 ## Rationale
 
 1. **React** -- Largest ecosystem, most libraries, best TypeScript support among UI frameworks. Finding solutions to problems is easier due to community size
 2. **TypeScript strict mode** -- The API returns complex nested objects (policies with rules, vhosts with configs). Type safety prevents runtime errors when the API schema changes
 3. **Vite** -- Instant HMR, fast builds. Development experience is significantly better than webpack-based setups
-4. **TanStack Query** -- Eliminates manual loading/error/cache state management for API calls. Built-in refetching, optimistic updates, and pagination support match our use cases exactly
-5. **shadcn/ui** -- Copy-paste components (not an npm dependency), so we own the code. Built on Radix UI (accessible) + Tailwind (utility-first). Good-looking defaults with zero design effort
-6. **React Hook Form** -- The policy editor has complex forms (dynamic IP lists, rule selection, nested config). RHF handles this with minimal re-renders
+4. **Library flexibility** -- The current frontend keeps data fetching, form handling, and shared components lightweight. More specialized libraries can be added when the policy editor or log viewer needs them.
 
 ## Alternatives Considered
 
@@ -53,13 +59,10 @@ Use **React 18** with **TypeScript 5** (strict mode), **Vite 5** as build tool, 
 ### Positive
 - Type-safe frontend that catches errors at compile time
 - Rich ecosystem of React libraries for any need
-- shadcn/ui provides professional-looking UI with minimal effort
-- TanStack Query eliminates most hand-written data fetching logic
 - Fast development with Vite HMR
 
 ### Negative
 - React's mental model (hooks, effects, closures) has a learning curve
-- shadcn/ui components need manual installation (copy-paste per component)
 - Tailwind's utility classes make HTML verbose
 
 ### Neutral
@@ -74,5 +77,5 @@ This decision is correct if:
 
 ## References
 - [React Documentation](https://react.dev/)
-- [shadcn/ui](https://ui.shadcn.com/)
-- [TanStack Query](https://tanstack.com/query/)
+- [Vite Documentation](https://vite.dev/)
+- [Tailwind CSS Documentation](https://tailwindcss.com/)

--- a/notes/decisions/ADR-004-docker-compose-deployment.md
+++ b/notes/decisions/ADR-004-docker-compose-deployment.md
@@ -20,18 +20,30 @@ These services need to:
 - Support independent scaling and updates in production
 
 ## Decision
-Use **Docker Compose** as the primary orchestration tool with three compose files:
-- `docker-compose.yml` -- Base service definitions
-- `docker-compose.dev.yml` -- Development overrides (hot reload, debug ports, volume mounts)
-- `docker-compose.prod.yml` -- Production overrides (optimized builds, restart policies, resource limits)
+Use **Docker Compose** as the primary orchestration tool for the local and
+MVP deployment stack.
 
 For production, deploy on **Proxmox VE** using LXC containers running Docker.
+
+## Current M1 Implementation
+
+M1 implements the full local stack with:
+- `deploy/docker/docker-compose.yml` as the base five-service stack.
+- `deploy/docker/docker-compose.debug.yml` as the debug overlay used by `make dev`.
+- `deploy/docker/coraza.Dockerfile` building from `ghcr.io/corazawaf/coraza-spoa:0.6.1`.
+- `haproxy:3.0-alpine` exposed as host port `8080` and configured from `configs/haproxy/`.
+- `postgres:16-alpine`, backend, frontend, Coraza, and HAProxy health checks.
+- Named volumes for PostgreSQL data, HAProxy logs, Coraza logs, backend logs, and generated config.
+- Make targets for `run`, `dev`, `down`, `clean`, `logs`, `ps`, `seed`, and `coraza-build`.
+
+Production-specific compose overlays remain future work; the implemented M1
+deployment target is reproducible local Docker Compose.
 
 ## Rationale
 
 1. **Single command startup** -- `docker-compose up` starts all 5 services with correct networking, volumes, and environment. Critical for reproducibility in a thesis project
 2. **Network isolation** -- Docker networks handle service discovery (HAProxy reaches Coraza at `coraza:9000`). No port conflicts with host services
-3. **Multi-file composition** -- Base + override pattern keeps configs DRY. Development gets hot-reload and debug ports; production gets resource limits and restart policies
+3. **Multi-file composition** -- Base + override patterns can keep configs DRY. The current M1 stack uses a base file plus a debug overlay; production overlays remain future work.
 4. **Proxmox compatibility** -- Docker Compose runs inside LXC containers on Proxmox. This matches the planned production deployment (3 LXC containers: proxy, panel, monitoring)
 5. **Thesis reproducibility** -- Anyone reviewing the thesis can clone the repo and run `docker-compose up` to see the system working. This is a strong demonstration for the defense
 
@@ -77,23 +89,24 @@ For production, deploy on **Proxmox VE** using LXC containers running Docker.
 - PostgreSQL official Docker image handles initialization scripts
 - Volume mounts for development enable hot-reload but can have file-watching issues on macOS
 
-## Implementation
-- [ ] Create `deploy/docker/docker-compose.yml` with all 5 services
-- [ ] Create `deploy/docker/docker-compose.dev.yml` with dev overrides
-- [ ] Create `deploy/docker/docker-compose.prod.yml` with production settings
-- [ ] Create `src/coraza/Dockerfile` for custom Coraza SPOA image
-- [ ] Create `.env.example` with all required environment variables
-- [ ] Add `Makefile` targets: `make dev`, `make prod`, `make down`, `make clean`
+## Implementation Status
 
-## Planned Service Configuration
+- [x] Create `deploy/docker/docker-compose.yml` with all 5 services
+- [x] Create `deploy/docker/docker-compose.debug.yml` with debug overrides
+- [x] Create `deploy/docker/coraza.Dockerfile` for the pinned Coraza SPOA image
+- [x] Create `deploy/docker/.env.example` with required environment variables
+- [x] Add Makefile targets for local stack operation and troubleshooting
+- [ ] Add production-specific compose overlays when production deployment is in scope
+
+## M1 Service Configuration
 
 | Service | Image | Ports | Notes |
 |---------|-------|-------|-------|
-| haproxy | haproxy:2.8 | 80, 443 | SPOE filter, custom config mount |
-| coraza | custom build | 9000 (SPOE) | Go binary with CRS rules |
-| backend | custom build | 8000 | FastAPI + uvicorn |
-| frontend | node:20 (dev) / nginx (prod) | 3000 (dev) | Vite dev server or static build |
-| postgres | postgres:15 | 5432 | Init script for schema |
+| haproxy | `haproxy:3.0-alpine` | `8080:80` | SPOE filter, WAF enforcement, config mounts |
+| coraza | `ghcr.io/corazawaf/coraza-spoa:0.6.1` via `deploy/docker/coraza.Dockerfile` | `9000` internal | Coraza SPOA with mounted CRS rules |
+| backend | custom build from `src/backend/Dockerfile` | `8000` internal | FastAPI + uvicorn |
+| frontend | custom build from `src/frontend/Dockerfile` | `3000:5173` | Vite dev server |
+| postgres | `postgres:16-alpine` | `5432` internal | Policy and log storage |
 
 ## Validation
 This decision is correct if:


### PR DESCRIPTION
feat(docs) Architecture Documentation Sweep For M1:

- remove stale *(planned)* markers
- document component paths: configs/, deploy/
- reflect current WAF behavior
- update tech stack in docs