### PR TITLE
feat(degraded-mode): handle Coraza failures in degraded mode

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -43,7 +43,8 @@ headers, and body data to Coraza SPOA over SPOE. Coraza evaluates the request
 against the configured OWASP CRS bundle and returns transaction variables such
 as the action and anomaly score. HAProxy blocks `deny` decisions with `403`.
 If SPOE inspection is unavailable or returns an error, HAProxy fails closed
-with `503 Service Unavailable` and WAF degraded headers.
+with `503 Service Unavailable`, `X-WAF-Status: degraded`, and a
+machine-readable degraded reason header.
 
 ## Components
 
@@ -63,7 +64,7 @@ with `503 Service Unavailable` and WAF degraded headers.
 2. HAProxy rejects unknown hosts with `421` before WAF inspection.
 3. HAProxy sends request-phase metadata to Coraza SPOA through SPOE.
 4. Coraza evaluates OWASP CRS rules and returns allow/deny metadata.
-5. HAProxy returns `403` for denied traffic, `503` for WAF inspection failures (`txn.coraza.error`), or forwards allowed requests to the FastAPI backend.
+5. HAProxy returns `403` for denied traffic, `503` for WAF inspection failures (`coraza-unavailable` or `spoe-processing-error`), or forwards allowed requests to the FastAPI backend.
 
 ### Policy Management
 1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.

--- a/README.commands.md
+++ b/README.commands.md
@@ -53,6 +53,7 @@ docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env
 cp deploy/docker/.env.example deploy/docker/.env                     # Create env file for compose
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config
 make run                                                             # Start all services (normal mode)
+HAPROXY_HTTP_PORT=18080 make run                                     # Start HAProxy on an alternate host port
 make dev                                                             # Start all services with HAProxy -d flag and Coraza debug logging
 make coraza-build                                                    # Build the pinned Coraza SPOA + CRS image
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza  # Reload mounted Coraza config/rules

--- a/README.commands.md
+++ b/README.commands.md
@@ -53,7 +53,6 @@ docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env
 cp deploy/docker/.env.example deploy/docker/.env                     # Create env file for compose
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env config
 make run                                                             # Start all services (normal mode)
-HAPROXY_HTTP_PORT=18080 make run                                     # Start HAProxy on an alternate host port
 make dev                                                             # Start all services with HAProxy -d flag and Coraza debug logging
 make coraza-build                                                    # Build the pinned Coraza SPOA + CRS image
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza  # Reload mounted Coraza config/rules

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is being developed as a master's thesis at Wroclaw University DSW.
 
 - **HAProxy 3.0** reference reverse proxy with SPOE integration
 - **Coraza SPOA** with OWASP CRS 4.x for request inspection
-- **WAF degraded-mode error signalling** for Coraza inspection failures
+- **Fail-closed WAF degraded mode** for unavailable or failed Coraza inspection
 - **FastAPI backend** for auth, vhosts, policies, rule overrides, logs, and health
 - **React admin panel** served by the Docker Compose stack
 - **Docker Compose full-stack deployment** for local development and smoke testing

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -146,7 +146,7 @@ assert_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%2
 
 assert_status "Degraded request without Coraza" "503" "${HAPROXY_BASE_URL}/"
 assert_header "Degraded WAF status header" "X-WAF-Status: degraded" "${HAPROXY_BASE_URL}/"
-assert_header "Degraded WAF reason header" "X-WAF-Degraded-Reason:" "${HAPROXY_BASE_URL}/"
+assert_header "Degraded WAF reason header" "X-WAF-Degraded-Reason: coraza-unavailable" "${HAPROXY_BASE_URL}/"
 assert_status "Health bypass while Coraza is stopped" "200" "${HAPROXY_BASE_URL}/health"
 
 echo "E2E smoke test passed."

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -7,6 +7,8 @@ COMPOSE_FILE="${REPO_ROOT}/deploy/docker/docker-compose.yml"
 ENV_FILE="${REPO_ROOT}/deploy/docker/.env"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-120}"
 SMOKE_PROJECT="${SMOKE_PROJECT:-guard-proxy-smoke}"
+HAPROXY_HTTP_PORT="${HAPROXY_HTTP_PORT:-8080}"
+HAPROXY_BASE_URL="http://127.0.0.1:${HAPROXY_HTTP_PORT}"
 
 if [[ ! -f "${ENV_FILE}" ]]; then
   echo "Missing ${ENV_FILE}. Copy deploy/docker/.env.example to deploy/docker/.env first." >&2
@@ -104,6 +106,31 @@ assert_status() {
   echo "${description}: got HTTP ${actual}."
 }
 
+assert_header() {
+  local description="$1"
+  local expected="$2"
+  local url="$3"
+  local headers
+
+  headers="$(
+    curl \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --dump-header - \
+      --header 'Host: app.local' \
+      "${url}"
+  )"
+
+  if ! grep -Fqi "${expected}" <<<"${headers}"; then
+    echo "${description}: expected response header containing '${expected}'." >&2
+    echo "${headers}" >&2
+    return 1
+  fi
+
+  echo "${description}: found '${expected}'."
+}
+
 cd "${REPO_ROOT}"
 
 "${COMPOSE[@]}" up -d --build postgres backend coraza haproxy
@@ -112,7 +139,14 @@ wait_for_healthy backend
 wait_for_healthy coraza
 wait_for_healthy haproxy
 
-assert_status "Benign request" "200" "http://127.0.0.1:8080/health"
-assert_status "SQL injection request" "403" "http://127.0.0.1:8080/?id=1%27%20OR%20%271%27%3D%271"
+assert_status "Benign request" "200" "${HAPROXY_BASE_URL}/health"
+assert_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%20%271%27%3D%271"
+
+"${COMPOSE[@]}" stop coraza
+
+assert_status "Degraded request without Coraza" "503" "${HAPROXY_BASE_URL}/"
+assert_header "Degraded WAF status header" "X-WAF-Status: degraded" "${HAPROXY_BASE_URL}/"
+assert_header "Degraded WAF reason header" "X-WAF-Degraded-Reason:" "${HAPROXY_BASE_URL}/"
+assert_status "Health bypass while Coraza is stopped" "200" "${HAPROXY_BASE_URL}/health"
 
 echo "E2E smoke test passed."

--- a/configs/haproxy/README.md
+++ b/configs/haproxy/README.md
@@ -34,9 +34,15 @@ Client ──► HAProxy :80 ──► (SPOE) ──► Coraza SPOA :9000
    `coraza-spoa` backend (TCP, `coraza:9000`).
 4. The SPOA evaluates the request against Coraza/CRS rules and
    returns variables under `txn.coraza.*`.
-5. If `txn.coraza.action == "deny"`, HAProxy responds with
+5. If the `coraza-spoa` backend has no usable servers, HAProxy
+   returns `503 Service Unavailable` with degraded-mode headers before
+   attempting SPOE.
+6. If SPOE starts but fails, `txn.coraza.error` is set and HAProxy
+   returns `503 Service Unavailable` with degraded-mode headers before
+   contacting the backend.
+7. If `txn.coraza.action == "deny"`, HAProxy responds with
    `403 Forbidden` and never contacts the backend.
-6. Otherwise the request is routed to `be_app`, which forwards to
+8. Otherwise the request is routed to `be_app`, which forwards to
    `backend:8000` (the FastAPI service in Docker Compose).
 
 ## SPOE variables
@@ -48,6 +54,7 @@ All variables set by the SPOA are namespaced via
 |----------------------|--------------------------------------------------------|
 | `txn.coraza.action`  | Decision string (`deny` blocks; anything else allows)  |
 | `txn.coraza.anomaly_score` | Inbound anomaly score from the rule set, propagated as header |
+| `txn.coraza.error`   | SPOE/SPOP error code set by `option set-on-error error` |
 | `txn.coraza.id`      | Transaction id correlated with HAProxy's `unique-id`  |
 
 The exact set of variables produced depends on the Coraza SPOA
@@ -80,22 +87,25 @@ Response-phase inspection is deliberately out of scope for M1
 
 ## Degraded-mode behaviour
 
-`spoe-agent` is configured with `option set-on-error error`. If the
-SPOA is unreachable, times out, returns a malformed response, or
-returns an internal processing error, HAProxy sets
-`txn.coraza.error` to the SPOE/SPOP error code.
+`spoe-agent` is configured with `option set-on-error error`. If SPOE
+processing starts and then times out, receives a malformed response, or
+hits an internal processing error, HAProxy sets `txn.coraza.error` to
+the SPOE/SPOP error code. HAProxy also checks `nbsrv(coraza-spoa)` before
+sending SPOE, so startup and unhealthy-container windows fail closed even
+when no SPOE exchange can begin.
 
 The M1 reference configuration fails closed for protected traffic:
-when `txn.coraza.error` is present, HAProxy returns
-`503 Service Unavailable` before contacting `be_app`. The response
-includes `X-WAF-Degraded: true` and `X-WAF-Error: <code>` so operators
-can distinguish WAF degraded mode from an application outage. HAProxy
-also raises the request log level to `err` for these requests.
+degraded requests return `503 Service Unavailable` before contacting
+`be_app`. Responses include `X-WAF-Status: degraded` and
+`X-WAF-Degraded-Reason`, whose value is either `coraza-unavailable` or
+`spoe-processing-error`. SPOE processing failures also include
+`X-WAF-Error-Code: <code>`. HAProxy raises these requests to `err` log
+level and captures the degraded reason in the access log.
 
-This covers startup or unhealthy Coraza containers, connection
-failures, SPOE processing timeouts, malformed WAF responses, and
-transient runtime failures. Backend/dashboard status reporting is
-tracked separately in #69.
+This intentionally trades availability for safety: if inspection is not
+available, protected application traffic is not forwarded. `/health`
+continues to bypass WAF inspection, and backend/dashboard status
+reporting is tracked separately in #69.
 
 ## Troubleshooting SPOE frames
 
@@ -139,10 +149,11 @@ mode uses `info` logging.
 5. If HAProxy returns `421`, the request failed the reference host ACL
    before routing. Retry with `Host: app.local`.
 
-6. If HAProxy returns `503` with `X-WAF-Degraded: true`, Coraza/SPOA
+6. If HAProxy returns `503` with `X-WAF-Status: degraded`, Coraza/SPOA
    inspection failed and the proxy failed closed before contacting the
-   backend. Use the `X-WAF-Error` value and HAProxy `err` log line to
-   identify the SPOE/SPOP failure class.
+   backend. Use `X-WAF-Degraded-Reason`, `X-WAF-Error-Code` when
+   present, and the HAProxy `err` log line to identify the failure
+   class.
 
 For raw frame inspection in the Docker Compose setup, capture the SPOA
 traffic from inside the `haproxy` container while reproducing the

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -44,20 +44,25 @@ frontend fe_http
     acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
     http-request deny deny_status 421 if !host_app
 
+    # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
+    # server. This covers startup and unhealthy-container windows.
+    http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason coraza-unavailable if { var(txn.waf_degraded_reason) -m str coraza-unavailable }
+
     # Hand the request off to the Coraza SPOA. The engine name
     # ("coraza") must match the [coraza] section in coraza.cfg.
     filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
     http-request send-spoe-group coraza coraza-req unless is_health
 
-    # Fail closed: if the SPOA is unreachable or returns an error,
-    # txn.coraza.error is set by the set-on-error option in coraza.cfg.
-    # Raise the log level and return 503 with WAF-degraded headers so
-    # operators can distinguish a WAF outage from an application error.
-    # Using -m found (not -m bool) ensures fail-closed on any error code,
-    # including a hypothetical zero value. No unscreened traffic reaches
-    # the backend.
-    http-request set-log-level err if { var(txn.coraza.error) -m found }
-    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Degraded true hdr X-WAF-Error %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
+    # Fail closed when SPOE processing starts but fails. set-on-error
+    # in coraza.cfg stores the HAProxy/SPOP error code in
+    # txn.coraza.error; using -m found ensures every code is blocked.
+    http-request set-var(txn.waf_degraded_reason) str(spoe-processing-error) if { var(txn.coraza.error) -m found }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
 
     # If the engine explicitly returns action=deny we stop the
     # transaction with 403.

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -90,9 +90,9 @@ services:
       backend:
         condition: service_healthy
       coraza:
-        condition: service_healthy
+        condition: service_started
     ports:
-      - "8080:80"
+      - "${HAPROXY_HTTP_PORT:-8080}:80"
     volumes:
       - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -34,6 +34,14 @@ def test_default_docker_compose_does_not_use_debug_flag() -> None:
     assert '"-d"' not in compose
 
 
+def test_default_docker_compose_starts_haproxy_before_coraza_is_healthy() -> None:
+    compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
+
+    assert "coraza:\n        condition: service_started" in compose
+    assert "coraza:\n        condition: service_healthy" not in compose
+    assert '"${HAPROXY_HTTP_PORT:-8080}:80"' in compose
+
+
 def test_debug_coraza_spoa_config_enables_debug_logging() -> None:
     config = (REPO_ROOT / "configs/coraza/coraza-spoa.debug.yaml").read_text()
 
@@ -77,7 +85,18 @@ def test_reference_haproxy_config_fails_closed_on_spoe_errors() -> None:
     config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
 
     assert (
-        "http-request set-log-level err if { var(txn.coraza.error) -m found }"
+        "http-request set-var(txn.waf_degraded_reason) "
+        "str(spoe-processing-error) if { var(txn.coraza.error) -m found }"
+        in config
+    )
+    assert (
+        "http-request set-log-level err if "
+        "{ var(txn.waf_degraded_reason) -m found }"
+        in config
+    )
+    assert (
+        "http-request capture var(txn.waf_degraded_reason) len 32 "
+        "if { var(txn.waf_degraded_reason) -m found }"
         in config
     )
 
@@ -89,22 +108,71 @@ def test_reference_haproxy_config_fails_closed_on_spoe_errors() -> None:
         (
             line.strip()
             for line in config.splitlines()
-            if line.strip().startswith("http-request return status 503")
+            if "X-WAF-Degraded-Reason spoe-processing-error" in line
         ),
         None,
     )
-    assert return_line is not None, "No 'http-request return status 503' rule found"
+    assert return_line is not None, "No SPOE error return rule found"
+    assert return_line.startswith("http-request return status 503")
     assert (
-        "hdr X-WAF-Degraded true" in return_line
-        or 'hdr "X-WAF-Degraded" "true"' in return_line
-    ), f"X-WAF-Degraded header missing from return rule: {return_line}"
+        "hdr X-WAF-Status degraded" in return_line
+        or 'hdr "X-WAF-Status" "degraded"' in return_line
+    ), f"X-WAF-Status header missing from return rule: {return_line}"
+    assert "hdr X-WAF-Degraded-Reason spoe-processing-error" in return_line, (
+        f"X-WAF-Degraded-Reason header missing from return rule: {return_line}"
+    )
     assert (
-        "hdr X-WAF-Error %[var(txn.coraza.error)]" in return_line
-        or 'hdr "X-WAF-Error" "%[var(txn.coraza.error)]"' in return_line
-    ), f"X-WAF-Error header missing from return rule: {return_line}"
+        "hdr X-WAF-Error-Code %[var(txn.coraza.error)]" in return_line
+        or 'hdr "X-WAF-Error-Code" "%[var(txn.coraza.error)]"' in return_line
+    ), f"X-WAF-Error-Code header missing from return rule: {return_line}"
     assert "if { var(txn.coraza.error) -m found }" in return_line, (
         f"Condition missing from return rule: {return_line}"
     )
+
+
+def test_reference_haproxy_config_fails_closed_when_coraza_is_unavailable() -> None:
+    config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
+
+    assert (
+        "http-request set-var(txn.waf_degraded_reason) "
+        "str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }"
+        in config
+    )
+
+    unavailable_line = next(
+        (
+            line.strip()
+            for line in config.splitlines()
+            if "X-WAF-Degraded-Reason coraza-unavailable" in line
+        ),
+        None,
+    )
+    assert unavailable_line is not None, "No coraza-unavailable return rule found"
+    assert unavailable_line.startswith("http-request return status 503")
+    assert "hdr X-WAF-Status degraded" in unavailable_line
+    assert "hdr X-WAF-Degraded-Reason coraza-unavailable" in unavailable_line
+    assert "if { var(txn.waf_degraded_reason) -m str coraza-unavailable }" in (
+        unavailable_line
+    )
+
+
+def test_reference_haproxy_config_preserves_host_health_and_waf_rules() -> None:
+    config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
+
+    assert "acl is_health path /health" in config
+    assert "http-request send-spoe-group coraza coraza-req unless is_health" in config
+    assert "http-request deny deny_status 421 if !host_app" in config
+    assert (
+        "http-request deny deny_status 403 if "
+        "{ var(txn.coraza.action) -m str deny }"
+        in config
+    )
+
+
+def test_reference_coraza_spoe_config_sets_error_variable() -> None:
+    config = (REPO_ROOT / "configs/haproxy/coraza.cfg").read_text()
+
+    assert "option              set-on-error  error" in config
 
 
 def test_haproxy_readme_documents_fail_closed_degraded_mode() -> None:
@@ -113,5 +181,8 @@ def test_haproxy_readme_documents_fail_closed_degraded_mode() -> None:
     assert "## Degraded-mode behaviour" in readme
     assert "fails closed" in readme
     assert "503 Service Unavailable" in readme
-    assert "X-WAF-Degraded: true" in readme
+    assert "X-WAF-Status: degraded" in readme
+    assert "X-WAF-Degraded-Reason" in readme
+    assert "coraza-unavailable" in readme
+    assert "spoe-processing-error" in readme
     assert "tracked separately in #69" in readme


### PR DESCRIPTION
## Summary
- fail closed with `503 Service Unavailable` when Coraza/SPOA is unavailable or SPOE processing fails
- expose degraded-mode response headers and log/capture the degraded reason in HAProxy
- let HAProxy start before Coraza is healthy so startup degraded mode is observable
- extend smoke and config-level tests for degraded mode
- document operator-facing degraded behavior and alternate HAProxy host port usage

Closes #80

## Validation
- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- `docker run --rm -v "$PWD/configs/haproxy:/usr/local/etc/haproxy:ro" haproxy:3.0-alpine haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg`
- `HAPROXY_HTTP_PORT=18080 SMOKE_PROJECT=guard-proxy-smoke-issue80 bash benchmarks/smoke/e2e.sh`