### PR TITLE
fix(smoke): fix coraza-unavailable timing race in E2E smoke test

### DIFF
--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -143,6 +143,8 @@ assert_status "Benign request" "200" "${HAPROXY_BASE_URL}/health"
 assert_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%20%271%27%3D%271"
 
 "${COMPOSE[@]}" stop coraza
+# Wait for HAProxy to mark the coraza server DOWN (inter 2s fall 1 = at most 2 s).
+sleep 5
 
 assert_status "Degraded request without Coraza" "503" "${HAPROXY_BASE_URL}/"
 assert_header "Degraded WAF status header" "X-WAF-Status: degraded" "${HAPROXY_BASE_URL}/"

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -92,7 +92,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -92,7 +92,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 10s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats


### PR DESCRIPTION
Reduce coraza-spoa health-check from inter 10s fall 3 to inter 2s fall 1 so HAProxy marks the server DOWN within 2 seconds of container stop. Add sleep 5 in e2e.sh after `docker compose stop coraza` so the single failed check propagates before assertions run.

Without this fix HAProxy still sees nbsrv(coraza-spoa)==1 when the first curl fires, skips the coraza-unavailable guard, attempts SPOE (connection refused), and returns X-WAF-Degraded-Reason: spoe-processing-error instead of the expected coraza-unavailable.

Agent-Logs-Url: https://github.com/bihius/guard-proxy/sessions/6365b631-0439-44be-97fb-27d9d0d3f508

## Summary

- Describe the user-facing or developer-facing change.
- Link the related issue, for example: `Closes #96`.

## Testing

- [x] `cd src/backend && uv sync --frozen --extra dev`
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm install --frozen-lockfile`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`