### PR TITLE
feat(policy): add paranoia and anomaly config rendering

### DIFF
--- a/notes/research/paranoia-levels.md
+++ b/notes/research/paranoia-levels.md
@@ -1,0 +1,70 @@
+# CRS paranoia levels and anomaly scoring
+
+## Scope
+
+Guard Proxy maps each WAF `Policy` to the OWASP Core Rule Set controls rendered
+in `crs-setup.conf`:
+
+- `paranoia_level` -> `tx.blocking_paranoia_level` and
+  `tx.detection_paranoia_level`
+- `inbound_anomaly_threshold` -> `tx.inbound_anomaly_score_threshold`
+- `outbound_anomaly_threshold` -> `tx.outbound_anomaly_score_threshold`
+- `enforcement_mode` -> `SecRuleEngine On` or `SecRuleEngine DetectionOnly`
+
+References:
+
+- CRS anomaly scoring: https://coreruleset.org/docs/concepts/anomaly_scoring/
+- CRS paranoia levels: https://coreruleset.org/docs/concepts/paranoia_levels/
+- CRS paranoia level FAQ:
+  https://coreruleset.org/faq/what-are-the-paranoia-levels
+
+## Paranoia levels
+
+PL1 is the baseline. It is designed for broad compatibility and should have the
+lowest false-positive rate. Guard Proxy should use PL1 as the default policy
+level for new vhosts.
+
+PL2 enables additional CRS rules and is a reasonable next step for applications
+handling customer data. It provides stronger coverage but needs application-
+specific tuning before broad blocking rollout.
+
+PL3 is aggressive. It detects more specialized attack patterns and is expected
+to generate more false positives, especially on applications with complex query
+syntax, rich text input, or API payloads.
+
+PL4 is maximum CRS coverage. It is useful for high-risk workloads only after
+careful tuning. Running PL4 in blocking mode without exclusions is likely to
+block legitimate traffic.
+
+## Anomaly thresholds
+
+CRS anomaly mode adds scores from matching rules instead of relying only on a
+single rule decision. Lower thresholds block faster; higher thresholds tolerate
+more suspicious matches before a transaction is denied.
+
+Recommended Guard Proxy starting points:
+
+- Inbound threshold: `5`
+- Outbound threshold: `4` or `5`
+
+The existing M1 baseline used `5` for both inbound and outbound. The M2 policy
+model stores the two values separately so outbound response inspection can be
+tuned independently when response-body inspection is enabled later.
+
+## Enforcement mode
+
+`block` maps to `SecRuleEngine On`. Matching CRS rules can block according to
+the anomaly score and disruptive action configuration.
+
+`detect_only` maps to `SecRuleEngine DetectionOnly`. CRS still evaluates and
+logs matches, but does not block. Use this during rollout, after increasing
+paranoia level, or while tuning false positives for a new application.
+
+## Rollout guidance
+
+Start new applications at PL1, inbound threshold `5`, outbound threshold `5`,
+and `detect_only` if traffic is unknown. Review WAF events, add targeted rule
+overrides or exclusions for confirmed false positives, then switch to `block`.
+
+Increase to PL2 only after PL1 is stable. Treat PL3 and PL4 as explicit
+hardening choices that require monitoring and application-specific tuning.

--- a/src/backend/alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py
+++ b/src/backend/alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py
@@ -57,10 +57,15 @@ def upgrade() -> None:
             )
         )
 
+    # Clamp any legacy 0 values to 1 so rows satisfy the new >= 1 CHECK
+    # constraints below.  The old constraint allowed anomaly_threshold >= 0,
+    # so existing production data may legitimately contain 0.
     op.execute(
         "UPDATE policies "
-        "SET inbound_anomaly_threshold = anomaly_threshold, "
-        "outbound_anomaly_threshold = anomaly_threshold"
+        "SET inbound_anomaly_threshold = CASE WHEN anomaly_threshold < 1 THEN 1 "
+        "ELSE anomaly_threshold END, "
+        "outbound_anomaly_threshold = CASE WHEN anomaly_threshold < 1 THEN 1 "
+        "ELSE anomaly_threshold END"
     )
 
     with op.batch_alter_table("policies") as batch_op:

--- a/src/backend/alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py
+++ b/src/backend/alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py
@@ -1,0 +1,108 @@
+"""split policy anomaly thresholds
+
+Revision ID: 8d4f2a6c1b90
+Revises: 2c9b5f4e8d31
+Create Date: 2026-05-04 18:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8d4f2a6c1b90"
+down_revision: str | Sequence[str] | None = "2c9b5f4e8d31"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _policy_enforcement_enum() -> sa.Enum:
+    return sa.Enum("block", "detect_only", name="policyenforcementmode")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    context = op.get_context()
+    bind = op.get_bind()
+
+    if context.dialect.name == "postgresql":
+        _policy_enforcement_enum().create(bind, checkfirst=True)
+        enforcement_enum = postgresql.ENUM(
+            "block",
+            "detect_only",
+            name="policyenforcementmode",
+            create_type=False,
+        )
+    else:
+        enforcement_enum = _policy_enforcement_enum()
+
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.drop_constraint("ck_policies_anomaly_threshold", type_="check")
+        batch_op.add_column(
+            sa.Column("inbound_anomaly_threshold", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("outbound_anomaly_threshold", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column(
+                "enforcement_mode",
+                enforcement_enum,
+                nullable=False,
+                server_default="block",
+            )
+        )
+
+    op.execute(
+        "UPDATE policies "
+        "SET inbound_anomaly_threshold = anomaly_threshold, "
+        "outbound_anomaly_threshold = anomaly_threshold"
+    )
+
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.alter_column("inbound_anomaly_threshold", nullable=False)
+        batch_op.alter_column("outbound_anomaly_threshold", nullable=False)
+        batch_op.alter_column("enforcement_mode", server_default=None)
+        batch_op.drop_column("anomaly_threshold")
+        batch_op.create_check_constraint(
+            "ck_policies_inbound_anomaly_threshold",
+            "inbound_anomaly_threshold >= 1",
+        )
+        batch_op.create_check_constraint(
+            "ck_policies_outbound_anomaly_threshold",
+            "outbound_anomaly_threshold >= 1",
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.drop_constraint(
+            "ck_policies_outbound_anomaly_threshold",
+            type_="check",
+        )
+        batch_op.drop_constraint(
+            "ck_policies_inbound_anomaly_threshold",
+            type_="check",
+        )
+        batch_op.add_column(sa.Column("anomaly_threshold", sa.Integer(), nullable=True))
+
+    op.execute("UPDATE policies SET anomaly_threshold = inbound_anomaly_threshold")
+
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.alter_column("anomaly_threshold", nullable=False)
+        batch_op.drop_column("enforcement_mode")
+        batch_op.drop_column("outbound_anomaly_threshold")
+        batch_op.drop_column("inbound_anomaly_threshold")
+        batch_op.create_check_constraint(
+            "ck_policies_anomaly_threshold",
+            "anomaly_threshold >= 0",
+        )
+
+    context = op.get_context()
+    if context.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS policyenforcementmode")

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -6,7 +6,7 @@ Without this, Alembic generates an empty migration (it does not see tables).
 """
 
 from app.models.log import Log, LogAction, LogSeverity
-from app.models.policy import Policy
+from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.user import User, UserRole
 from app.models.vhost import VHost
@@ -15,6 +15,7 @@ __all__ = [
     "User",
     "UserRole",
     "Policy",
+    "PolicyEnforcementMode",
     "VHost",
     "Log",
     "LogAction",

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
+    Enum,
     ForeignKey,
     Integer,
     String,
@@ -24,13 +26,21 @@ if TYPE_CHECKING:
     from app.models.vhost import VHost
 
 
+class PolicyEnforcementMode(enum.StrEnum):
+    """WAF enforcement mode for a policy."""
+
+    block = "block"
+    detect_only = "detect_only"
+
+
 class Policy(Base):
     """policies table storing WAF configuration templates.
 
     A policy defines how aggressively WAF filters traffic:
     - paranoia_level 1 = fewer false positives, less blocking
     - paranoia_level 4 = very aggressive, may block legitimate requests
-    - anomaly_threshold = how many "suspicion" points before a request is blocked
+    - inbound/outbound anomaly thresholds decide when CRS flags traffic
+    - enforcement_mode controls whether CRS blocks or only logs matches
     """
 
     __tablename__ = "policies"
@@ -40,8 +50,12 @@ class Policy(Base):
             name="ck_policies_paranoia_level",
         ),
         CheckConstraint(
-            "anomaly_threshold >= 0",
-            name="ck_policies_anomaly_threshold",
+            "inbound_anomaly_threshold >= 1",
+            name="ck_policies_inbound_anomaly_threshold",
+        ),
+        CheckConstraint(
+            "outbound_anomaly_threshold >= 1",
+            name="ck_policies_outbound_anomaly_threshold",
         ),
     )
 
@@ -63,10 +77,20 @@ class Policy(Base):
         nullable=False,
         default=1,  # 1-4, least aggressive by default
     )
-    anomaly_threshold: Mapped[int] = mapped_column(
+    inbound_anomaly_threshold: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
         default=5,  # default OWASP CRS threshold
+    )
+    outbound_anomaly_threshold: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=4,  # CRS default outbound threshold
+    )
+    enforcement_mode: Mapped[PolicyEnforcementMode] = mapped_column(
+        Enum(PolicyEnforcementMode),
+        nullable=False,
+        default=PolicyEnforcementMode.block,
     )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 

--- a/src/backend/app/routers/policies.py
+++ b/src/backend/app/routers/policies.py
@@ -34,7 +34,9 @@ def create_policy(
             name=body.name,
             description=body.description,
             paranoia_level=body.paranoia_level,
-            anomaly_threshold=body.anomaly_threshold,
+            inbound_anomaly_threshold=body.inbound_anomaly_threshold,
+            outbound_anomaly_threshold=body.outbound_anomaly_threshold,
+            enforcement_mode=body.enforcement_mode,
             created_by=current_user.id,
         )
     except PolicyNameAlreadyExistsError as error:

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.models.policy import PolicyEnforcementMode
 from app.schemas.rule_override import RuleOverrideResponse
 
 
@@ -13,9 +14,11 @@ class PolicyCreate(BaseModel):
     name: str
     description: str | None = None
     paranoia_level: int = Field(default=1, ge=1, le=4)
-    anomaly_threshold: int = 5
+    inbound_anomaly_threshold: int = 5
+    outbound_anomaly_threshold: int = 4
+    enforcement_mode: PolicyEnforcementMode = PolicyEnforcementMode.block
 
-    @field_validator("anomaly_threshold")
+    @field_validator("inbound_anomaly_threshold", "outbound_anomaly_threshold")
     @classmethod
     def anomaly_threshold_positive(cls, v: int) -> int:
         """Anomaly score threshold must be positive."""
@@ -33,10 +36,12 @@ class PolicyUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     paranoia_level: int | None = Field(default=None, ge=1, le=4)
-    anomaly_threshold: int | None = None
+    inbound_anomaly_threshold: int | None = None
+    outbound_anomaly_threshold: int | None = None
+    enforcement_mode: PolicyEnforcementMode | None = None
     is_active: bool | None = None
 
-    @field_validator("anomaly_threshold")
+    @field_validator("inbound_anomaly_threshold", "outbound_anomaly_threshold")
     @classmethod
     def anomaly_threshold_positive(cls, v: int | None) -> int | None:
         if v is not None and v < 1:
@@ -53,7 +58,9 @@ class PolicyResponse(BaseModel):
     name: str
     description: str | None
     paranoia_level: int
-    anomaly_threshold: int
+    inbound_anomaly_threshold: int
+    outbound_anomaly_threshold: int
+    enforcement_mode: PolicyEnforcementMode
     is_active: bool
     created_by: int | None
     created_at: datetime

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -23,6 +23,8 @@ _HAPROXY_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
 
 
 def _validate_haproxy_identifier(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must not be empty")
     if not _HAPROXY_IDENTIFIER_RE.match(value):
         raise ValueError(
             f"{field} {value!r} contains characters unsafe for HAProxy config; "
@@ -31,6 +33,8 @@ def _validate_haproxy_identifier(value: str, field: str) -> None:
 
 
 def _validate_haproxy_host(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must not be empty")
     if not _HAPROXY_HOST_RE.match(value):
         raise ValueError(
             f"{field} {value!r} contains characters unsafe for HAProxy config; "
@@ -53,6 +57,8 @@ class HaproxyBackend:
     def __post_init__(self) -> None:
         _validate_haproxy_identifier(self.name, "HaproxyBackend.name")
         _validate_haproxy_identifier(self.server_name, "HaproxyBackend.server_name")
+        if not self.address:
+            raise ValueError("HaproxyBackend.address must not be empty")
         if not _HAPROXY_ADDRESS_RE.match(self.address):
             raise ValueError(
                 f"HaproxyBackend.address {self.address!r} contains characters that are "

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -1,0 +1,71 @@
+"""Pure Jinja2 render helpers for HAProxy and CRS configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jinja2 import Environment, PackageLoader, StrictUndefined
+
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_override import RuleAction, RuleOverride
+
+
+@dataclass(frozen=True)
+class HaproxyBackend:
+    """Backend server data used by the HAProxy template."""
+
+    name: str
+    server_name: str
+    address: str
+
+
+@dataclass(frozen=True)
+class HaproxyRenderContext:
+    """Prepared HAProxy render input with no database behavior."""
+
+    vhost_acl_name: str
+    vhost_hosts: tuple[str, ...]
+    backend: HaproxyBackend
+
+
+_ENVIRONMENT = Environment(
+    loader=PackageLoader("app", "templates"),
+    autoescape=False,
+    keep_trailing_newline=True,
+    undefined=StrictUndefined,
+)
+
+
+def render_haproxy_cfg(context: HaproxyRenderContext) -> str:
+    """Render haproxy.cfg from already prepared values."""
+    template = _ENVIRONMENT.get_template("haproxy.cfg.j2")
+    return template.render(
+        vhost_acl_name=context.vhost_acl_name,
+        vhost_hosts=context.vhost_hosts,
+        backend=context.backend,
+    )
+
+
+def render_crs_setup(policy: Policy) -> str:
+    """Render CRS setup configuration for a policy."""
+    template = _ENVIRONMENT.get_template("crs-setup.conf.j2")
+    sec_rule_engine = (
+        "DetectionOnly"
+        if policy.enforcement_mode == PolicyEnforcementMode.detect_only
+        else "On"
+    )
+    return template.render(policy=policy, sec_rule_engine=sec_rule_engine)
+
+
+def render_rule_overrides(policy: Policy) -> str:
+    """Render CRS rule removals for disabled policy overrides."""
+    template = _ENVIRONMENT.get_template("rule-overrides.conf.j2")
+    disabled_rule_overrides = _sorted_disabled_overrides(policy.rule_overrides)
+    return template.render(disabled_rule_overrides=disabled_rule_overrides)
+
+
+def _sorted_disabled_overrides(overrides: list[RuleOverride]) -> list[RuleOverride]:
+    return sorted(
+        (override for override in overrides if override.action == RuleAction.disable),
+        key=lambda override: override.rule_id,
+    )

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from jinja2 import Environment, PackageLoader, StrictUndefined
@@ -9,23 +10,75 @@ from jinja2 import Environment, PackageLoader, StrictUndefined
 from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_override import RuleAction, RuleOverride
 
+# HAProxy identifiers (ACL names, backend names, server names): letters, digits,
+# hyphens, and underscores only.  No whitespace, newlines, or shell-special chars.
+_HAPROXY_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# HAProxy host values used in ACL conditions: hostname characters plus colon
+# (for optional port) and dots.  No whitespace or newlines.
+_HAPROXY_HOST_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+# HAProxy backend address (host:port): same allowlist as host values.
+_HAPROXY_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+def _validate_haproxy_identifier(value: str, field: str) -> None:
+    if not _HAPROXY_IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"{field} {value!r} contains characters unsafe for HAProxy config; "
+            "only letters, digits, hyphens, and underscores are allowed"
+        )
+
+
+def _validate_haproxy_host(value: str, field: str) -> None:
+    if not _HAPROXY_HOST_RE.match(value):
+        raise ValueError(
+            f"{field} {value!r} contains characters unsafe for HAProxy config; "
+            "only hostname chars (letters, digits, dots, hyphens, colons) are allowed"
+        )
+
 
 @dataclass(frozen=True)
 class HaproxyBackend:
-    """Backend server data used by the HAProxy template."""
+    """Backend server data used by the HAProxy template.
+
+    All fields are validated on construction to reject characters that could
+    allow HAProxy config injection (e.g. newlines, spaces, shell-special chars).
+    """
 
     name: str
     server_name: str
     address: str
 
+    def __post_init__(self) -> None:
+        _validate_haproxy_identifier(self.name, "HaproxyBackend.name")
+        _validate_haproxy_identifier(self.server_name, "HaproxyBackend.server_name")
+        if not _HAPROXY_ADDRESS_RE.match(self.address):
+            raise ValueError(
+                f"HaproxyBackend.address {self.address!r} contains characters that are "
+                "unsafe for HAProxy config; only host:port characters are allowed"
+            )
+
 
 @dataclass(frozen=True)
 class HaproxyRenderContext:
-    """Prepared HAProxy render input with no database behavior."""
+    """Prepared HAProxy render input with no database behavior.
+
+    All fields are validated on construction to reject characters that could
+    allow HAProxy config injection (e.g. newlines, spaces, shell-special chars).
+    The ``backend`` is validated independently inside :class:`HaproxyBackend`.
+    """
 
     vhost_acl_name: str
     vhost_hosts: tuple[str, ...]
     backend: HaproxyBackend
+
+    def __post_init__(self) -> None:
+        _validate_haproxy_identifier(
+            self.vhost_acl_name, "HaproxyRenderContext.vhost_acl_name"
+        )
+        for host in self.vhost_hosts:
+            _validate_haproxy_host(host, "vhost_hosts entry")
 
 
 _ENVIRONMENT = Environment(

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -84,7 +84,7 @@ class HaproxyRenderContext:
             self.vhost_acl_name, "HaproxyRenderContext.vhost_acl_name"
         )
         for host in self.vhost_hosts:
-            _validate_haproxy_host(host, "vhost_hosts entry")
+            _validate_haproxy_host(host, "HaproxyRenderContext.vhost_hosts")
 
 
 _ENVIRONMENT = Environment(

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -3,12 +3,14 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
-from app.models.policy import Policy
+from app.models.policy import Policy, PolicyEnforcementMode
 
 NON_NULLABLE_PATCH_FIELDS = {
     "name",
     "paranoia_level",
-    "anomaly_threshold",
+    "inbound_anomaly_threshold",
+    "outbound_anomaly_threshold",
+    "enforcement_mode",
     "is_active",
 }
 
@@ -17,7 +19,9 @@ PATCHABLE_FIELDS = {
     "name",
     "description",
     "paranoia_level",
-    "anomaly_threshold",
+    "inbound_anomaly_threshold",
+    "outbound_anomaly_threshold",
+    "enforcement_mode",
     "is_active",
 }
 
@@ -71,7 +75,9 @@ class PolicyService:
         name: str,
         description: str | None,
         paranoia_level: int,
-        anomaly_threshold: int,
+        inbound_anomaly_threshold: int,
+        outbound_anomaly_threshold: int,
+        enforcement_mode: PolicyEnforcementMode,
         created_by: int | None,
     ) -> Policy:
         """Create and persist a new policy."""
@@ -79,7 +85,9 @@ class PolicyService:
             name=name,
             description=description,
             paranoia_level=paranoia_level,
-            anomaly_threshold=anomaly_threshold,
+            inbound_anomaly_threshold=inbound_anomaly_threshold,
+            outbound_anomaly_threshold=outbound_anomaly_threshold,
+            enforcement_mode=enforcement_mode,
             is_active=True,
             created_by=created_by,
         )

--- a/src/backend/app/templates/crs-setup.conf.j2
+++ b/src/backend/app/templates/crs-setup.conf.j2
@@ -1,0 +1,43 @@
+# Guard Proxy CRS 4.x baseline.
+#
+# Keep this file small and explicit. The full upstream reference lives in
+# configs/coraza/crs/crs-setup.conf.example.
+
+SecRuleEngine {{ sec_rule_engine }}
+
+SecAction \
+    "id:900000,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:tx.blocking_paranoia_level={{ policy.paranoia_level }}"
+
+SecAction \
+    "id:900005,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:tx.detection_paranoia_level={{ policy.paranoia_level }}"
+
+SecAction \
+    "id:900110,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:tx.inbound_anomaly_score_threshold={{ policy.inbound_anomaly_threshold }},\
+    setvar:tx.outbound_anomaly_score_threshold={{ policy.outbound_anomaly_threshold }}"
+
+SecAction \
+    "id:900990,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:tx.crs_setup_version=4250"

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -8,8 +8,8 @@
 #   - Fail closed (503) if SPOA is unavailable or returns an error
 #   - Block requests when Coraza returns action=deny
 #
-# This file is the hand-written seed that the M2 Jinja2 template
-# generator will later reproduce from the policy database.
+# This file is the Jinja2 template used to render the HAProxy
+# configuration from the policy database.
 
 global
     log stdout format raw local0 info

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -1,0 +1,103 @@
+# Reference HAProxy configuration for Guard Proxy M1.
+#
+# Goals:
+#   - Single frontend listening on :80
+#   - Single virtual host routed to a single backend
+#   - Reject unknown hosts before WAF inspection
+#   - SPOE filter forwarding request metadata to Coraza SPOA
+#   - Fail closed (503) if SPOA is unavailable or returns an error
+#   - Block requests when Coraza returns action=deny
+#
+# This file is the hand-written seed that the M2 Jinja2 template
+# generator will later reproduce from the policy database.
+
+global
+    log stdout format raw local0 info
+    maxconn 2000
+    # The SPOE filter expects a writable runtime directory.
+    # Use operator level to avoid exposing administrative Runtime API
+    # commands via the local socket.
+    stats socket /tmp/haproxy.sock mode 660 level operator
+
+defaults
+    mode http
+    log global
+    option httplog
+    option dontlognull
+    timeout connect 5s
+    timeout client  30s
+    timeout server  30s
+
+# --- Public frontend ----------------------------------------------
+frontend fe_http
+    bind *:80
+    # Tag every request with a stable id so log lines and SPOE frames
+    # can be correlated.
+    unique-id-format %[uuid()]
+    unique-id-header X-Request-ID
+    acl is_health path /health
+    http-request set-log-level silent if is_health
+
+    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Unknown hosts are rejected here, before WAF inspection, so that
+    # Coraza does not process traffic destined for no valid backend.
+    acl {{ vhost_acl_name }} hdr(host) -i {{ vhost_hosts | join(" ") }}
+    http-request deny deny_status 421 if !{{ vhost_acl_name }}
+
+    # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
+    # server. This covers startup and unhealthy-container windows.
+    http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason coraza-unavailable if { var(txn.waf_degraded_reason) -m str coraza-unavailable }
+
+    # Hand the request off to the Coraza SPOA. The engine name
+    # ("coraza") must match the [coraza] section in coraza.cfg.
+    filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
+    http-request send-spoe-group coraza coraza-req unless is_health
+
+    # Fail closed when SPOE processing starts but fails. set-on-error
+    # in coraza.cfg stores the HAProxy/SPOP error code in
+    # txn.coraza.error; using -m found ensures every code is blocked.
+    http-request set-var(txn.waf_degraded_reason) str(spoe-processing-error) if { var(txn.coraza.error) -m found }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
+
+    # If the engine explicitly returns action=deny we stop the
+    # transaction with 403.
+    http-request deny deny_status 403 if { var(txn.coraza.action) -m str deny }
+
+    # Optional: log the WAF anomaly score on allowed requests so it
+    # shows up in the access log for debugging.
+    http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
+
+    use_backend {{ backend.name }} if {{ vhost_acl_name }}
+    default_backend {{ backend.name }}
+
+# --- Application backend (single vhost target) -------------------
+backend {{ backend.name }}
+    option forwardfor
+    option httpchk GET /health
+    http-check expect status 200
+    # init-addr none lets `haproxy -c` succeed even when the
+    # `backend` DNS name is not resolvable (e.g. outside compose).
+    server {{ backend.server_name }} {{ backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
+
+# --- Coraza SPOA backend used by the SPOE filter -----------------
+# The SPOA speaks SPOP (binary, request/response) over TCP, so this
+# backend runs in mode tcp and must NOT have an HTTP check.
+backend coraza-spoa
+    mode tcp
+    option spop-check
+    timeout connect 5s
+    timeout server  3m
+    server coraza coraza:9000 check inter 10s fall 3 rise 2 init-addr last,libc,none
+
+# --- Local stats endpoint (dev convenience, not exposed publicly) -
+listen stats
+    bind 127.0.0.1:8404
+    mode http
+    stats enable
+    stats uri /stats
+    stats refresh 10s

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -92,7 +92,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 10s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -8,8 +8,8 @@
 #   - Fail closed (503) if SPOA is unavailable or returns an error
 #   - Block requests when Coraza returns action=deny
 #
-# This file is the Jinja2 template used to render the HAProxy
-# configuration from the policy database.
+# This file is the hand-written seed that the M2 Jinja2 template
+# generator will later reproduce from the policy database.
 
 global
     log stdout format raw local0 info

--- a/src/backend/app/templates/rule-overrides.conf.j2
+++ b/src/backend/app/templates/rule-overrides.conf.j2
@@ -1,0 +1,7 @@
+# Guard Proxy CRS rule overrides.
+#
+# Rules are enabled by default through the CRS include. Disabled overrides remove
+# selected CRS rule IDs for the rendered policy.
+{% for override in disabled_rule_overrides %}
+SecRuleRemoveById {{ override.rule_id }}
+{% endfor %}

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "bcrypt>=3.2.0,<4.0.0",
     "python-multipart>=0.0.12",
     "pydantic[email]>=2.12.5",
+    "jinja2>=3.1.4",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -14,7 +14,8 @@ def test_policy_paranoia_level_above_max_raises_integrity_error(db: Session) -> 
         Policy(
             name="invalid-paranoia-level",
             paranoia_level=5,
-            anomaly_threshold=5,
+            inbound_anomaly_threshold=5,
+            outbound_anomaly_threshold=5,
             is_active=True,
         )
     )
@@ -27,20 +28,45 @@ def test_policy_paranoia_level_above_max_raises_integrity_error(db: Session) -> 
     db.rollback()
 
 
-def test_policy_negative_anomaly_threshold_raises_integrity_error(db: Session) -> None:
-    """DB must reject negative anomaly thresholds."""
+def test_policy_negative_inbound_anomaly_threshold_raises_integrity_error(
+    db: Session,
+) -> None:
+    """DB must reject negative inbound anomaly thresholds."""
     db.add(
         Policy(
             name="invalid-anomaly-threshold",
             paranoia_level=2,
-            anomaly_threshold=-1,
+            inbound_anomaly_threshold=-1,
+            outbound_anomaly_threshold=5,
             is_active=True,
         )
     )
 
     with pytest.raises(
         IntegrityError,
-        match="ck_policies_anomaly_threshold|CHECK constraint failed",
+        match="ck_policies_inbound_anomaly_threshold|CHECK constraint failed",
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_policy_negative_outbound_anomaly_threshold_raises_integrity_error(
+    db: Session,
+) -> None:
+    """DB must reject negative outbound anomaly thresholds."""
+    db.add(
+        Policy(
+            name="invalid-outbound-anomaly-threshold",
+            paranoia_level=2,
+            inbound_anomaly_threshold=5,
+            outbound_anomaly_threshold=-1,
+            is_active=True,
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match="ck_policies_outbound_anomaly_threshold|CHECK constraint failed",
     ):
         db.commit()
     db.rollback()

--- a/src/backend/tests/integration/test_policies_router.py
+++ b/src/backend/tests/integration/test_policies_router.py
@@ -14,7 +14,9 @@ def _create_policy(
     name: str = "Default Policy",
     description: str = "Domyslna polityka",
     paranoia_level: int = 2,
-    anomaly_threshold: int = 5,
+    inbound_anomaly_threshold: int = 5,
+    outbound_anomaly_threshold: int = 5,
+    enforcement_mode: str = "block",
 ) -> dict[str, Any]:
     """Pomocniczo tworzy politykę i zwraca body JSON."""
     resp = client.post(
@@ -24,7 +26,9 @@ def _create_policy(
             "name": name,
             "description": description,
             "paranoia_level": paranoia_level,
-            "anomaly_threshold": anomaly_threshold,
+            "inbound_anomaly_threshold": inbound_anomaly_threshold,
+            "outbound_anomaly_threshold": outbound_anomaly_threshold,
+            "enforcement_mode": enforcement_mode,
         },
     )
     assert resp.status_code == 201
@@ -47,7 +51,9 @@ def test_create_policy_admin_returns_201(
             "name": "Strict",
             "description": "Wysoka ochrona",
             "paranoia_level": 4,
-            "anomaly_threshold": 7,
+            "inbound_anomaly_threshold": 7,
+            "outbound_anomaly_threshold": 8,
+            "enforcement_mode": "detect_only",
         },
     )
 
@@ -57,7 +63,9 @@ def test_create_policy_admin_returns_201(
     assert body["name"] == "Strict"
     assert body["description"] == "Wysoka ochrona"
     assert body["paranoia_level"] == 4
-    assert body["anomaly_threshold"] == 7
+    assert body["inbound_anomaly_threshold"] == 7
+    assert body["outbound_anomaly_threshold"] == 8
+    assert body["enforcement_mode"] == "detect_only"
     assert body["is_active"] is True
     assert body["created_by"] == admin_user.id
 
@@ -72,7 +80,8 @@ def test_create_policy_viewer_forbidden(
         json={
             "name": "Viewer policy",
             "paranoia_level": 1,
-            "anomaly_threshold": 5,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
         },
     )
     assert resp.status_code == 403
@@ -91,7 +100,8 @@ def test_create_policy_duplicate_name_returns_409(
         json={
             "name": "Duplicate",
             "paranoia_level": 2,
-            "anomaly_threshold": 5,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
         },
     )
     assert resp.status_code == 409
@@ -108,7 +118,8 @@ def test_create_policy_invalid_paranoia_level_returns_422(
         json={
             "name": "Invalid paranoia",
             "paranoia_level": 5,
-            "anomaly_threshold": 5,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
         },
     )
     assert resp.status_code == 422
@@ -200,7 +211,8 @@ def test_patch_policy_admin_partial_update(
         name="Patch me",
         description="Opis",
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
     )
 
     resp = client.patch(
@@ -213,7 +225,8 @@ def test_patch_policy_admin_partial_update(
     assert body["name"] == "Patch me"
     assert body["description"] == "Opis"
     assert body["paranoia_level"] == 3
-    assert body["anomaly_threshold"] == 5
+    assert body["inbound_anomaly_threshold"] == 5
+    assert body["outbound_anomaly_threshold"] == 5
     assert body["is_active"] is False
 
 

--- a/src/backend/tests/integration/test_rule_overrides_router.py
+++ b/src/backend/tests/integration/test_rule_overrides_router.py
@@ -19,7 +19,8 @@ def _create_policy(
             "name": name,
             "description": "Policy used in rule override tests",
             "paranoia_level": 2,
-            "anomaly_threshold": 5,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
         },
     )
     assert resp.status_code == 201

--- a/src/backend/tests/integration/test_vhosts_router.py
+++ b/src/backend/tests/integration/test_vhosts_router.py
@@ -21,7 +21,8 @@ def _create_policy(
             "name": name,
             "description": "Policy for vhosts",
             "paranoia_level": 2,
-            "anomaly_threshold": 5,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
         },
     )
     assert resp.status_code == 201

--- a/src/backend/tests/unit/test_config_renderer_crs_setup.py
+++ b/src/backend/tests/unit/test_config_renderer_crs_setup.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.services.config_renderer import render_crs_setup
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+
+    raise FileNotFoundError(
+        f"Could not locate repository root from {start}; expected .git directory"
+    )
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+
+
+def _normalise_config(config: str) -> str:
+    return "\n".join(line.rstrip() for line in config.splitlines() if line.strip())
+
+
+def _policy(
+    *,
+    paranoia_level: int = 1,
+    inbound_anomaly_threshold: int = 5,
+    outbound_anomaly_threshold: int = 5,
+    enforcement_mode: PolicyEnforcementMode = PolicyEnforcementMode.block,
+) -> Policy:
+    return Policy(
+        name="Renderer policy",
+        paranoia_level=paranoia_level,
+        inbound_anomaly_threshold=inbound_anomaly_threshold,
+        outbound_anomaly_threshold=outbound_anomaly_threshold,
+        enforcement_mode=enforcement_mode,
+        is_active=True,
+    )
+
+
+@pytest.mark.parametrize("paranoia_level", [1, 2, 3, 4])
+def test_crs_setup_template_renders_paranoia_levels(paranoia_level: int) -> None:
+    rendered = render_crs_setup(_policy(paranoia_level=paranoia_level))
+
+    assert f"setvar:tx.blocking_paranoia_level={paranoia_level}" in rendered
+    assert f"setvar:tx.detection_paranoia_level={paranoia_level}" in rendered
+
+
+def test_crs_setup_template_renders_anomaly_thresholds() -> None:
+    rendered = render_crs_setup(
+        _policy(inbound_anomaly_threshold=7, outbound_anomaly_threshold=9)
+    )
+
+    assert "setvar:tx.inbound_anomaly_score_threshold=7" in rendered
+    assert "setvar:tx.outbound_anomaly_score_threshold=9" in rendered
+
+
+def test_crs_setup_template_renders_blocking_engine_mode() -> None:
+    rendered = render_crs_setup(_policy(enforcement_mode=PolicyEnforcementMode.block))
+
+    assert "SecRuleEngine On" in rendered
+
+
+def test_crs_setup_template_renders_detection_only_engine_mode() -> None:
+    rendered = render_crs_setup(
+        _policy(enforcement_mode=PolicyEnforcementMode.detect_only)
+    )
+
+    assert "SecRuleEngine DetectionOnly" in rendered
+
+
+def test_crs_setup_pl1_baseline_matches_reference_modulo_engine_line() -> None:
+    rendered = render_crs_setup(_policy())
+    reference = (REPO_ROOT / "configs/coraza/crs-setup.conf").read_text()
+
+    rendered_without_engine = rendered.replace("SecRuleEngine On\n\n", "")
+    assert _normalise_config(rendered_without_engine) == _normalise_config(reference)

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -106,7 +106,7 @@ def test_haproxy_render_context_rejects_unsafe_acl_name(vhost_acl_name: str) -> 
     ],
 )
 def test_haproxy_render_context_rejects_unsafe_host(host: str) -> None:
-    with pytest.raises(ValueError, match="vhost_hosts"):
+    with pytest.raises(ValueError, match="HaproxyRenderContext.vhost_hosts"):
         HaproxyRenderContext(
             vhost_acl_name="safe_acl",
             vhost_hosts=(host,),
@@ -146,7 +146,7 @@ def test_haproxy_render_context_rejects_empty_acl_name() -> None:
 
 
 def test_haproxy_render_context_rejects_empty_host() -> None:
-    with pytest.raises(ValueError, match="vhost_hosts"):
+    with pytest.raises(ValueError, match="HaproxyRenderContext.vhost_hosts"):
         HaproxyRenderContext(
             vhost_acl_name="safe_acl",
             vhost_hosts=("",),

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -136,6 +136,37 @@ def test_haproxy_backend_rejects_unsafe_values(field: str, kwargs: dict) -> None
         HaproxyBackend(**kwargs)
 
 
+def test_haproxy_render_context_rejects_empty_acl_name() -> None:
+    with pytest.raises(ValueError, match="vhost_acl_name"):
+        HaproxyRenderContext(
+            vhost_acl_name="",
+            vhost_hosts=("safe.host",),
+            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+        )
+
+
+def test_haproxy_render_context_rejects_empty_host() -> None:
+    with pytest.raises(ValueError, match="vhost_hosts"):
+        HaproxyRenderContext(
+            vhost_acl_name="safe_acl",
+            vhost_hosts=("",),
+            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"name": "", "server_name": "srv", "address": "host:80"},
+        {"name": "be", "server_name": "", "address": "host:80"},
+        {"name": "be", "server_name": "srv", "address": ""},
+    ],
+)
+def test_haproxy_backend_rejects_empty_values(kwargs: dict) -> None:
+    with pytest.raises(ValueError, match="HaproxyBackend"):
+        HaproxyBackend(**kwargs)
+
+
 @pytest.mark.skipif(shutil.which("haproxy") is None, reason="haproxy is not installed")
 def test_rendered_haproxy_template_validates_with_haproxy(tmp_path: Path) -> None:
     rendered_path = tmp_path / "haproxy.cfg"

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -1,0 +1,90 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app.services.config_renderer import (
+    HaproxyBackend,
+    HaproxyRenderContext,
+    render_haproxy_cfg,
+)
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+
+    raise FileNotFoundError(
+        f"Could not locate repository root from {start}; expected .git directory"
+    )
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+
+
+def _normalise_config(config: str) -> str:
+    return "\n".join(line.rstrip() for line in config.splitlines() if line.strip())
+
+
+def _m1_reference_context() -> HaproxyRenderContext:
+    return HaproxyRenderContext(
+        vhost_acl_name="host_app",
+        vhost_hosts=(
+            "app.local",
+            "app.local:80",
+            "app.local:8080",
+            "localhost",
+            "localhost:8080",
+            "127.0.0.1",
+            "127.0.0.1:8080",
+        ),
+        backend=HaproxyBackend(
+            name="be_app",
+            server_name="app",
+            address="backend:8000",
+        ),
+    )
+
+
+def test_haproxy_template_renders_m1_reference_modulo_whitespace() -> None:
+    rendered = render_haproxy_cfg(_m1_reference_context())
+    reference = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
+
+    assert _normalise_config(rendered) == _normalise_config(reference)
+
+
+def test_haproxy_template_parameterises_vhost_and_backend() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            vhost_acl_name="host_api",
+            vhost_hosts=("api.example.com", "api.example.com:80"),
+            backend=HaproxyBackend(
+                name="be_api",
+                server_name="api",
+                address="api-backend:9000",
+            ),
+        )
+    )
+
+    assert "acl host_api hdr(host) -i api.example.com api.example.com:80" in rendered
+    assert "http-request deny deny_status 421 if !host_api" in rendered
+    assert "use_backend be_api if host_api" in rendered
+    assert "default_backend be_api" in rendered
+    assert "server api api-backend:9000 check" in rendered
+
+
+@pytest.mark.skipif(shutil.which("haproxy") is None, reason="haproxy is not installed")
+def test_rendered_haproxy_template_validates_with_haproxy(tmp_path: Path) -> None:
+    rendered_path = tmp_path / "haproxy.cfg"
+    rendered_path.write_text(render_haproxy_cfg(_m1_reference_context()))
+
+    result = subprocess.run(
+        ["haproxy", "-c", "-f", str(rendered_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -75,6 +75,67 @@ def test_haproxy_template_parameterises_vhost_and_backend() -> None:
     assert "server api api-backend:9000 check" in rendered
 
 
+@pytest.mark.parametrize(
+    "vhost_acl_name",
+    [
+        "has space",
+        "has\nnewline",
+        "has\ttab",
+        "has#comment",
+        "has;semi",
+        "has{brace",
+    ],
+)
+def test_haproxy_render_context_rejects_unsafe_acl_name(vhost_acl_name: str) -> None:
+    with pytest.raises(ValueError, match="vhost_acl_name"):
+        HaproxyRenderContext(
+            vhost_acl_name=vhost_acl_name,
+            vhost_hosts=("safe.host",),
+            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+        )
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "has space",
+        "has\nnewline",
+        "has\ttab",
+        "has#comment",
+        "has;semi",
+    ],
+)
+def test_haproxy_render_context_rejects_unsafe_host(host: str) -> None:
+    with pytest.raises(ValueError, match="vhost_hosts"):
+        HaproxyRenderContext(
+            vhost_acl_name="safe_acl",
+            vhost_hosts=(host,),
+            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+        )
+
+
+@pytest.mark.parametrize(
+    "field,kwargs",
+    [
+        ("name", {"name": "has space", "server_name": "srv", "address": "host:80"}),
+        ("name", {"name": "has\nnewline", "server_name": "srv", "address": "host:80"}),
+        (
+            "server_name",
+            {"name": "be", "server_name": "has space", "address": "host:80"},
+        ),
+        (
+            "server_name",
+            {"name": "be", "server_name": "has\nnewline", "address": "host:80"},
+        ),
+        ("address", {"name": "be", "server_name": "srv", "address": "has space"}),
+        ("address", {"name": "be", "server_name": "srv", "address": "has\nnewline"}),
+    ],
+)
+def test_haproxy_backend_rejects_unsafe_values(field: str, kwargs: dict) -> None:
+    with pytest.raises(ValueError, match="HaproxyBackend"):
+        HaproxyBackend(**kwargs)
+
+
 @pytest.mark.skipif(shutil.which("haproxy") is None, reason="haproxy is not installed")
 def test_rendered_haproxy_template_validates_with_haproxy(tmp_path: Path) -> None:
     rendered_path = tmp_path / "haproxy.cfg"

--- a/src/backend/tests/unit/test_config_renderer_rule_overrides.py
+++ b/src/backend/tests/unit/test_config_renderer_rule_overrides.py
@@ -1,0 +1,51 @@
+from app.models.policy import Policy
+from app.models.rule_override import RuleAction, RuleOverride
+from app.services.config_renderer import render_rule_overrides
+
+
+def _policy_with_overrides(overrides: list[RuleOverride]) -> Policy:
+    policy = Policy(
+        name="Rule override renderer",
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    policy.rule_overrides = overrides
+    return policy
+
+
+def test_rule_overrides_template_renders_header_for_empty_policy() -> None:
+    rendered = render_rule_overrides(_policy_with_overrides([]))
+
+    assert "Guard Proxy CRS rule overrides" in rendered
+    assert "SecRuleRemoveById" not in rendered
+
+
+def test_rule_overrides_template_renders_disabled_rules_sorted() -> None:
+    rendered = render_rule_overrides(
+        _policy_with_overrides(
+            [
+                RuleOverride(policy_id=1, rule_id=942100, action=RuleAction.disable),
+                RuleOverride(policy_id=1, rule_id=941100, action=RuleAction.disable),
+            ]
+        )
+    )
+
+    assert rendered.index("SecRuleRemoveById 941100") < rendered.index(
+        "SecRuleRemoveById 942100"
+    )
+
+
+def test_rule_overrides_template_skips_enabled_rules() -> None:
+    rendered = render_rule_overrides(
+        _policy_with_overrides(
+            [
+                RuleOverride(policy_id=1, rule_id=941100, action=RuleAction.enable),
+                RuleOverride(policy_id=1, rule_id=942100, action=RuleAction.disable),
+            ]
+        )
+    )
+
+    assert "SecRuleRemoveById 941100" not in rendered
+    assert "SecRuleRemoveById 942100" in rendered

--- a/src/backend/tests/unit/test_policy_service.py
+++ b/src/backend/tests/unit/test_policy_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
-from app.models.policy import Policy  # noqa: E402
+from app.models.policy import Policy, PolicyEnforcementMode  # noqa: E402
 from app.models.user import User  # noqa: E402
 from app.services.policy_service import (  # noqa: E402
     PolicyDisallowedFieldError,
@@ -35,7 +35,9 @@ def test_create_policy_persists_values_and_created_by(
         name="Strict",
         description="High protection",
         paranoia_level=4,
-        anomaly_threshold=7,
+        inbound_anomaly_threshold=7,
+        outbound_anomaly_threshold=8,
+        enforcement_mode=PolicyEnforcementMode.detect_only,
         created_by=admin_user.id,
     )
 
@@ -43,7 +45,9 @@ def test_create_policy_persists_values_and_created_by(
     assert policy.name == "Strict"
     assert policy.description == "High protection"
     assert policy.paranoia_level == 4
-    assert policy.anomaly_threshold == 7
+    assert policy.inbound_anomaly_threshold == 7
+    assert policy.outbound_anomaly_threshold == 8
+    assert policy.enforcement_mode == PolicyEnforcementMode.detect_only
     assert policy.is_active is True
     assert policy.created_by == admin_user.id
 
@@ -57,7 +61,9 @@ def test_create_policy_duplicate_name_raises_error(
         name="Duplicate",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -66,7 +72,9 @@ def test_create_policy_duplicate_name_raises_error(
             name="Duplicate",
             description=None,
             paranoia_level=1,
-            anomaly_threshold=3,
+            inbound_anomaly_threshold=3,
+            outbound_anomaly_threshold=3,
+            enforcement_mode=PolicyEnforcementMode.block,
             created_by=admin_user.id,
         )
 
@@ -80,14 +88,18 @@ def test_list_policies_returns_items_sorted_by_id(
         name="Alpha",
         description=None,
         paranoia_level=1,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
     second = service.create_policy(
         name="Beta",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=6,
+        inbound_anomaly_threshold=6,
+        outbound_anomaly_threshold=6,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -103,7 +115,9 @@ def test_get_policy_returns_existing_policy(db: Session, admin_user: User) -> No
         name="Detail",
         description="Read me",
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -130,7 +144,9 @@ def test_update_policy_partial_update_changes_only_selected_fields(
         name="Patch me",
         description="Before",
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -142,7 +158,8 @@ def test_update_policy_partial_update_changes_only_selected_fields(
     assert updated.name == "Patch me"
     assert updated.description == "Before"
     assert updated.paranoia_level == 3
-    assert updated.anomaly_threshold == 5
+    assert updated.inbound_anomaly_threshold == 5
+    assert updated.outbound_anomaly_threshold == 5
     assert updated.is_active is False
 
 
@@ -155,7 +172,9 @@ def test_update_policy_null_for_non_nullable_field_raises_error(
         name="Null check",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -175,14 +194,18 @@ def test_update_policy_duplicate_name_raises_error(
         name="Alpha",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
     second = service.create_policy(
         name="Beta",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -196,7 +219,9 @@ def test_delete_policy_removes_existing_policy(db: Session, admin_user: User) ->
         name="Delete me",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 
@@ -221,7 +246,9 @@ def test_update_policy_disallowed_field_raises_error(
         name="Allowlist check",
         description=None,
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
         created_by=admin_user.id,
     )
 

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
+from app.models.policy import PolicyEnforcementMode  # noqa: E402
 from app.models.rule_override import RuleAction  # noqa: E402
 from app.schemas.log import LogIngestRequest  # noqa: E402
 from app.schemas.policy import PolicyCreate, PolicyUpdate  # noqa: E402
@@ -93,8 +94,17 @@ def test_user_update_password_valid() -> None:
 
 
 def test_policy_create_valid() -> None:
-    p = PolicyCreate(name="default", paranoia_level=2, anomaly_threshold=10)
+    p = PolicyCreate(
+        name="default",
+        paranoia_level=2,
+        inbound_anomaly_threshold=10,
+        outbound_anomaly_threshold=11,
+        enforcement_mode=PolicyEnforcementMode.detect_only,
+    )
     assert p.paranoia_level == 2
+    assert p.inbound_anomaly_threshold == 10
+    assert p.outbound_anomaly_threshold == 11
+    assert p.enforcement_mode == PolicyEnforcementMode.detect_only
 
 
 def test_policy_create_paranoia_level_zero() -> None:
@@ -117,20 +127,25 @@ def test_policy_create_paranoia_level_boundaries() -> None:
     assert p4.paranoia_level == 4
 
 
-def test_policy_create_anomaly_threshold_zero() -> None:
+def test_policy_create_inbound_anomaly_threshold_zero() -> None:
     """An anomaly threshold of 0 is invalid; it must be at least 1."""
     with pytest.raises(ValidationError, match="at least 1"):
-        PolicyCreate(name="x", anomaly_threshold=0)
+        PolicyCreate(name="x", inbound_anomaly_threshold=0)
 
 
-def test_policy_create_anomaly_threshold_negative() -> None:
+def test_policy_create_outbound_anomaly_threshold_negative() -> None:
     with pytest.raises(ValidationError, match="at least 1"):
-        PolicyCreate(name="x", anomaly_threshold=-5)
+        PolicyCreate(name="x", outbound_anomaly_threshold=-5)
 
 
 def test_policy_create_anomaly_threshold_one_valid() -> None:
-    p = PolicyCreate(name="x", anomaly_threshold=1)
-    assert p.anomaly_threshold == 1
+    p = PolicyCreate(
+        name="x",
+        inbound_anomaly_threshold=1,
+        outbound_anomaly_threshold=1,
+    )
+    assert p.inbound_anomaly_threshold == 1
+    assert p.outbound_anomaly_threshold == 1
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +165,7 @@ def test_policy_update_paranoia_invalid() -> None:
 
 def test_policy_update_anomaly_zero_invalid() -> None:
     with pytest.raises(ValidationError, match="at least 1"):
-        PolicyUpdate(anomaly_threshold=0)
+        PolicyUpdate(inbound_anomaly_threshold=0)
 
 
 def test_policy_create_schema_exposes_paranoia_level_bounds() -> None:

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -29,7 +29,8 @@ def _create_policy_for_test(
         name=name,
         description="Policy for vhost service tests",
         paranoia_level=2,
-        anomaly_threshold=5,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
         is_active=True,
         created_by=created_by,
     )

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -291,6 +291,7 @@ dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "jinja2" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "psycopg2-binary" },
     { name = "pydantic", extra = ["email"] },
@@ -317,6 +318,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=3.2.0,<4.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "jinja2", specifier = ">=3.1.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
@@ -408,6 +410,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Extend WAF policies with inbound/outbound anomaly thresholds and block vs detect-only enforcement mode.
- Add pure Jinja2 render helpers and templates for HAProxy, CRS setup, and CRS rule overrides.
- Add migration, backend API/test updates, and paranoia/anomaly research notes.

## Test plan
- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/ tests/ alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py`
- `uv run ruff format --check app/ tests/unit/test_config_renderer_haproxy.py tests/unit/test_config_renderer_crs_setup.py tests/unit/test_config_renderer_rule_overrides.py tests/unit/test_policy_service.py tests/unit/test_schemas.py tests/unit/test_vhost_service.py tests/integration/test_policies_router.py tests/integration/test_rule_overrides_router.py tests/integration/test_vhosts_router.py tests/integration/test_db_constraints.py alembic/versions/8d4f2a6c1b90_split_policy_anomaly_thresholds.py`
- `LOG_INGEST_SHARED_SECRET=test-log-ingest-secret uv run alembic -c alembic.ini upgrade heads`
- `LOG_INGEST_SHARED_SECRET=test-log-ingest-secret uv run alembic -c alembic.ini check`
- `pnpm run type-check`
- `pnpm run lint`

Note: `haproxy -c -f configs/haproxy/haproxy.cfg` could not run locally because `haproxy` is not installed in this shell.

Closes #14
Closes #15
Closes #110