### PR TITLE
feat(config): add multi-vhost config generator (M2-02)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 CLAUDE.md
 AGENTS.md
 CODEX.md
+.claude/
 .opencode/
 .opencodeignore
 opencode.json

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -92,7 +92,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -38,11 +38,12 @@ frontend fe_http
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Reference vhost: accept known hosts from generated config.
     # Unknown hosts are rejected here, before WAF inspection, so that
     # Coraza does not process traffic destined for no valid backend.
     acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
     http-request deny deny_status 421 if !host_app
+
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
@@ -75,7 +76,7 @@ frontend fe_http
     use_backend be_app if host_app
     default_backend be_app
 
-# --- Application backend (single vhost target) -------------------
+# --- Application backends ----------------------------------------
 backend be_app
     option forwardfor
     option httpchk GET /health

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -1,0 +1,117 @@
+"""Pure configuration generator from pre-fetched ORM objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_override import RuleOverride
+from app.models.vhost import VHost
+from app.services.config_renderer import (
+    HaproxyBackend,
+    HaproxyRenderContext,
+    render_crs_setup,
+    render_haproxy_cfg_multi,
+    render_rule_overrides,
+)
+
+
+@dataclass(frozen=True)
+class GeneratedConfig:
+    """All generated text files needed by the runtime stack."""
+
+    haproxy_cfg: str
+    crs_setup_conf: str
+    rule_overrides_conf: str
+
+
+def generate(
+    vhosts: list[VHost],
+    policies: list[Policy],
+    rule_overrides: list[RuleOverride],
+) -> GeneratedConfig:
+    """Generate all runtime config files from already loaded objects."""
+    active_vhosts = sorted(
+        (vhost for vhost in vhosts if vhost.is_active),
+        key=lambda vhost: vhost.domain,
+    )
+    vhost_contexts = [_to_haproxy_context(vhost) for vhost in active_vhosts]
+
+    active_policy = _pick_active_policy(active_vhosts, policies, rule_overrides)
+    haproxy_cfg = render_haproxy_cfg_multi(vhost_contexts)
+    crs_setup_conf = render_crs_setup(active_policy)
+    rule_overrides_conf = render_rule_overrides(active_policy)
+
+    return GeneratedConfig(
+        haproxy_cfg=haproxy_cfg,
+        crs_setup_conf=crs_setup_conf,
+        rule_overrides_conf=rule_overrides_conf,
+    )
+
+
+def _pick_active_policy(
+    active_vhosts: list[VHost],
+    policies: list[Policy],
+    rule_overrides: list[RuleOverride],
+) -> Policy:
+    policies_by_id = {policy.id: policy for policy in policies}
+    overrides_by_policy_id: dict[int, list[RuleOverride]] = {}
+    for override in rule_overrides:
+        overrides_by_policy_id.setdefault(override.policy_id, []).append(override)
+
+    for vhost in active_vhosts:
+        if vhost.policy_id is None:
+            continue
+        policy = policies_by_id.get(vhost.policy_id)
+        if policy is None or not policy.is_active:
+            continue
+        policy.rule_overrides = overrides_by_policy_id.get(policy.id, [])
+        return policy
+
+    default_policy = Policy(
+        id=0,
+        name="default-detect-only",
+        description="Auto-generated default policy",
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.detect_only,
+        is_active=True,
+    )
+    default_policy.rule_overrides = []
+    return default_policy
+
+
+def _to_haproxy_context(vhost: VHost) -> HaproxyRenderContext:
+    domain_slug = _slug(vhost.domain)
+    backend_address = _extract_backend_address(vhost.backend_url)
+    return HaproxyRenderContext(
+        vhost_acl_name=f"host_{domain_slug}",
+        vhost_hosts=(vhost.domain,),
+        backend=HaproxyBackend(
+            name=f"be_{domain_slug}",
+            server_name=f"srv_{domain_slug}",
+            address=backend_address,
+        ),
+    )
+
+
+def _slug(value: str) -> str:
+    return value.replace(".", "_").replace("-", "_")
+
+
+def _extract_backend_address(backend_url: str) -> str:
+    parsed = urlparse(backend_url)
+    if parsed.scheme:
+        address = parsed.netloc
+    else:
+        address = parsed.path
+
+    if not address:
+        raise ValueError(f"Invalid backend URL {backend_url!r}: missing host")
+    if "@" in address:
+        raise ValueError(
+            f"Invalid backend URL {backend_url!r}: userinfo is not supported"
+        )
+    return address

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -9,8 +9,11 @@ from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_override import RuleOverride
 from app.models.vhost import VHost
 from app.services.config_renderer import (
+    CrsPolicyRenderContext,
     HaproxyBackend,
     HaproxyRenderContext,
+    HaproxyRoute,
+    RuleOverrideRenderContext,
     render_crs_setup,
     render_haproxy_cfg_multi,
     render_rule_overrides,
@@ -38,10 +41,12 @@ def generate(
     )
     vhost_contexts = [_to_haproxy_context(vhost) for vhost in active_vhosts]
 
-    active_policy = _pick_active_policy(active_vhosts, policies, rule_overrides)
+    active_policy, active_overrides = _pick_active_policy(
+        active_vhosts, policies, rule_overrides
+    )
     haproxy_cfg = render_haproxy_cfg_multi(vhost_contexts)
     crs_setup_conf = render_crs_setup(active_policy)
-    rule_overrides_conf = render_rule_overrides(active_policy)
+    rule_overrides_conf = render_rule_overrides(active_overrides)
 
     return GeneratedConfig(
         haproxy_cfg=haproxy_cfg,
@@ -54,7 +59,7 @@ def _pick_active_policy(
     active_vhosts: list[VHost],
     policies: list[Policy],
     rule_overrides: list[RuleOverride],
-) -> Policy:
+) -> tuple[CrsPolicyRenderContext, tuple[RuleOverrideRenderContext, ...]]:
     policies_by_id = {policy.id: policy for policy in policies}
     overrides_by_policy_id: dict[int, list[RuleOverride]] = {}
     for override in rule_overrides:
@@ -66,39 +71,63 @@ def _pick_active_policy(
         policy = policies_by_id.get(vhost.policy_id)
         if policy is None or not policy.is_active:
             continue
-        policy.rule_overrides = overrides_by_policy_id.get(policy.id, [])
-        return policy
+        return (
+            _to_crs_policy_context(policy),
+            _to_rule_override_contexts(overrides_by_policy_id.get(policy.id, [])),
+        )
 
-    default_policy = Policy(
-        id=0,
-        name="default-detect-only",
-        description="Auto-generated default policy",
-        paranoia_level=1,
-        inbound_anomaly_threshold=5,
-        outbound_anomaly_threshold=4,
-        enforcement_mode=PolicyEnforcementMode.detect_only,
-        is_active=True,
+    return (
+        CrsPolicyRenderContext(
+            paranoia_level=1,
+            inbound_anomaly_threshold=5,
+            outbound_anomaly_threshold=4,
+            enforcement_mode=PolicyEnforcementMode.detect_only,
+        ),
+        (),
     )
-    default_policy.rule_overrides = []
-    return default_policy
 
 
 def _to_haproxy_context(vhost: VHost) -> HaproxyRenderContext:
     domain_slug = _slug(vhost.domain)
     backend_address = _extract_backend_address(vhost.backend_url)
     return HaproxyRenderContext(
-        vhost_acl_name=f"host_{domain_slug}",
-        vhost_hosts=(vhost.domain,),
-        backend=HaproxyBackend(
-            name=f"be_{domain_slug}",
-            server_name=f"srv_{domain_slug}",
-            address=backend_address,
-        ),
+        routes=(
+            HaproxyRoute(
+                vhost_acl_name=f"host_{domain_slug}",
+                vhost_hosts=(vhost.domain,),
+                backend=HaproxyBackend(
+                    name=f"be_{domain_slug}",
+                    server_name=f"srv_{domain_slug}",
+                    address=backend_address,
+                ),
+            ),
+        )
     )
 
 
 def _slug(value: str) -> str:
     return value.replace(".", "_").replace("-", "_")
+
+
+def _to_crs_policy_context(policy: Policy) -> CrsPolicyRenderContext:
+    return CrsPolicyRenderContext(
+        paranoia_level=policy.paranoia_level,
+        inbound_anomaly_threshold=policy.inbound_anomaly_threshold,
+        outbound_anomaly_threshold=policy.outbound_anomaly_threshold,
+        enforcement_mode=policy.enforcement_mode,
+    )
+
+
+def _to_rule_override_contexts(
+    overrides: list[RuleOverride],
+) -> tuple[RuleOverrideRenderContext, ...]:
+    return tuple(
+        RuleOverrideRenderContext(
+            rule_id=override.rule_id,
+            action=override.action,
+        )
+        for override in overrides
+    )
 
 
 def _extract_backend_address(backend_url: str) -> str:

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -96,13 +96,24 @@ _ENVIRONMENT = Environment(
 
 
 def render_haproxy_cfg(context: HaproxyRenderContext) -> str:
-    """Render haproxy.cfg from already prepared values."""
+    """Render haproxy.cfg for a single vhost context."""
+    return render_haproxy_cfg_multi([context])
+
+
+def render_haproxy_cfg_multi(vhost_contexts: list[HaproxyRenderContext]) -> str:
+    """Render haproxy.cfg from one or many prepared vhost contexts."""
     template = _ENVIRONMENT.get_template("haproxy.cfg.j2")
-    return template.render(
-        vhost_acl_name=context.vhost_acl_name,
-        vhost_hosts=context.vhost_hosts,
-        backend=context.backend,
-    )
+    vhosts = [
+        {
+            "acl_name": context.vhost_acl_name,
+            "hosts": context.vhost_hosts,
+            "backend_name": context.backend.name,
+            "backend_server_name": context.backend.server_name,
+            "backend_address": context.backend.address,
+        }
+        for context in vhost_contexts
+    ]
+    return template.render(vhosts=vhosts)
 
 
 def render_crs_setup(policy: Policy) -> str:

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -142,15 +142,20 @@ _ENVIRONMENT = Environment(
 
 def render_haproxy_cfg(context: HaproxyRenderContext) -> str:
     """Render haproxy.cfg for a single vhost context."""
-    return render_haproxy_cfg_multi([context])
+    return _render_haproxy_routes(context.routes)
 
 
 def render_haproxy_cfg_multi(vhost_contexts: list[HaproxyRenderContext]) -> str:
     """Render haproxy.cfg from one or many prepared vhost contexts."""
+    routes = tuple(route for context in vhost_contexts for route in context.routes)
+    return _render_haproxy_routes(routes)
+
+
+def _render_haproxy_routes(routes: tuple[HaproxyRoute, ...]) -> str:
     template = _ENVIRONMENT.get_template("haproxy.cfg.j2")
     return template.render(
-        routes=context.routes,
-        default_backend=context.routes[0].backend,
+        routes=routes,
+        default_backend=routes[0].backend if routes else None,
     )
 
 

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -38,11 +38,17 @@ frontend fe_http
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Reference vhost: accept known hosts from generated config.
     # Unknown hosts are rejected here, before WAF inspection, so that
     # Coraza does not process traffic destined for no valid backend.
-    acl {{ vhost_acl_name }} hdr(host) -i {{ vhost_hosts | join(" ") }}
-    http-request deny deny_status 421 if !{{ vhost_acl_name }}
+{% for vhost in vhosts %}
+    acl {{ vhost.acl_name }} hdr(host) -i {{ vhost.hosts | join(" ") }}
+{% endfor %}
+{% if vhosts %}
+    http-request deny deny_status 421 if {% for vhost in vhosts %}!{{ vhost.acl_name }}{% if not loop.last %} {% endif %}{% endfor %}
+{% else %}
+    http-request deny deny_status 421
+{% endif %}
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
@@ -72,17 +78,23 @@ frontend fe_http
     # shows up in the access log for debugging.
     http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
 
-    use_backend {{ backend.name }} if {{ vhost_acl_name }}
-    default_backend {{ backend.name }}
+{% for vhost in vhosts %}
+    use_backend {{ vhost.backend_name }} if {{ vhost.acl_name }}
+{% endfor %}
+{% if vhosts %}
+    default_backend {{ vhosts[0].backend_name }}
+{% endif %}
 
-# --- Application backend (single vhost target) -------------------
-backend {{ backend.name }}
+# --- Application backends ----------------------------------------
+{% for vhost in vhosts %}
+backend {{ vhost.backend_name }}
     option forwardfor
     option httpchk GET /health
     http-check expect status 200
     # init-addr none lets `haproxy -c` succeed even when the
     # `backend` DNS name is not resolvable (e.g. outside compose).
-    server {{ backend.server_name }} {{ backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
+    server {{ vhost.backend_server_name }} {{ vhost.backend_address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
+{% endfor %}
 
 # --- Coraza SPOA backend used by the SPOE filter -----------------
 # The SPOA speaks SPOP (binary, request/response) over TCP, so this

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -92,7 +92,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -45,7 +45,11 @@ frontend fe_http
 {% for route in routes %}
     acl {{ route.vhost_acl_name }} hdr(host),field(1,:) -i {{ route.vhost_hosts | join(" ") }}
 {% endfor %}
+{% if routes %}
     http-request deny deny_status 421 if{% for route in routes %} !{{ route.vhost_acl_name }}{% endfor %}
+{% else %}
+    http-request deny deny_status 421
+{% endif %}
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
@@ -78,7 +82,9 @@ frontend fe_http
 {% for route in routes %}
     use_backend {{ route.backend.name }} if {{ route.vhost_acl_name }}
 {% endfor %}
+{% if default_backend is not none %}
     default_backend {{ default_backend.name }}
+{% endif %}
 
 # --- Application backends ----------------------------------------
 {% for route in routes %}

--- a/src/backend/tests/unit/test_config_generator.py
+++ b/src/backend/tests/unit/test_config_generator.py
@@ -1,0 +1,90 @@
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_override import RuleAction, RuleOverride
+from app.models.vhost import VHost
+from app.services.config_generator import generate
+
+
+def test_generate_empty_db() -> None:
+    generated = generate(vhosts=[], policies=[], rule_overrides=[])
+
+    assert "global" in generated.haproxy_cfg
+    assert "defaults" in generated.haproxy_cfg
+    assert "backend coraza-spoa" in generated.haproxy_cfg
+    assert "backend be_" not in generated.haproxy_cfg
+    assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
+    assert generated.rule_overrides_conf.strip() == "# Guard Proxy CRS rule overrides.\n#\n# Rules are enabled by default through the CRS include. Disabled overrides remove\n# selected CRS rule IDs for the rendered policy."
+
+
+def test_generate_one_vhost_no_policy() -> None:
+    vhost = VHost(
+        id=1,
+        domain="app.local",
+        backend_url="http://backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+
+    generated = generate(vhosts=[vhost], policies=[], rule_overrides=[])
+
+    assert "acl host_app_local hdr(host) -i app.local" in generated.haproxy_cfg
+    assert "use_backend be_app_local if host_app_local" in generated.haproxy_cfg
+    assert "server srv_app_local backend:8000 check" in generated.haproxy_cfg
+    assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
+
+
+def test_generate_one_vhost_with_policy() -> None:
+    vhost = VHost(
+        id=1,
+        domain="api.example.com",
+        backend_url="http://api-backend:9000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=10,
+    )
+    policy = Policy(
+        id=10,
+        name="Strict",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+    )
+
+    generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[])
+
+    assert "acl host_api_example_com hdr(host) -i api.example.com" in generated.haproxy_cfg
+    assert "use_backend be_api_example_com if host_api_example_com" in generated.haproxy_cfg
+    assert "SecRuleEngine On" in generated.crs_setup_conf
+    assert "setvar:tx.blocking_paranoia_level=2" in generated.crs_setup_conf
+
+
+def test_generate_one_vhost_with_policy_and_overrides() -> None:
+    vhost = VHost(
+        id=1,
+        domain="api.example.com",
+        backend_url="http://api-backend:9000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=10,
+    )
+    policy = Policy(
+        id=10,
+        name="Strict",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+    )
+    override = RuleOverride(
+        id=100,
+        policy_id=10,
+        rule_id=942100,
+        action=RuleAction.disable,
+    )
+
+    generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[override])
+
+    assert "SecRuleRemoveById 942100" in generated.rule_overrides_conf

--- a/src/backend/tests/unit/test_config_generator.py
+++ b/src/backend/tests/unit/test_config_generator.py
@@ -27,7 +27,7 @@ def test_generate_one_vhost_no_policy() -> None:
 
     generated = generate(vhosts=[vhost], policies=[], rule_overrides=[])
 
-    assert "acl host_app_local hdr(host) -i app.local" in generated.haproxy_cfg
+    assert "acl host_app_local hdr(host),field(1,:) -i app.local" in generated.haproxy_cfg
     assert "use_backend be_app_local if host_app_local" in generated.haproxy_cfg
     assert "server srv_app_local backend:8000 check" in generated.haproxy_cfg
     assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
@@ -54,7 +54,7 @@ def test_generate_one_vhost_with_policy() -> None:
 
     generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[])
 
-    assert "acl host_api_example_com hdr(host) -i api.example.com" in generated.haproxy_cfg
+    assert "acl host_api_example_com hdr(host),field(1,:) -i api.example.com" in generated.haproxy_cfg
     assert "use_backend be_api_example_com if host_api_example_com" in generated.haproxy_cfg
     assert "SecRuleEngine On" in generated.crs_setup_conf
     assert "setvar:tx.blocking_paranoia_level=2" in generated.crs_setup_conf


### PR DESCRIPTION
## Summary

- Add `render_haproxy_cfg_multi` to `config_renderer.py` so the HAProxy template can render one config file for any number of virtual hosts; `render_haproxy_cfg` delegates to it unchanged.
- Rewrite `haproxy.cfg.j2` to loop over a `vhosts` list; remove the dead single-vhost backwards-compat branch.
- Add `config_generator.py` with a pure `generate()` function that accepts pre-loaded ORM objects (vhosts, policies, rule overrides) and returns all three runtime config files (`haproxy.cfg`, `crs-setup.conf`, `rule-overrides.conf`) in one call.
- Add unit tests covering: empty DB defaults, single vhost with no policy, single vhost with a blocking policy, and rule override rendering.
- Tidy `configs/haproxy/haproxy.cfg` reference file (comment wording and whitespace aligned with the updated template).

Closes #111