### PR TITLE
feat(runtime): add runtime and deployed status endpoint

### DIFF
--- a/configs/haproxy/README.md
+++ b/configs/haproxy/README.md
@@ -28,8 +28,8 @@ Client ──► HAProxy :80 ──► (SPOE) ──► Coraza SPOA :9000
 
 1. The client sends an HTTP request to HAProxy on port 80.
 2. The `fe_http` frontend stamps it with `X-Request-ID` and matches
-   the `Host` header against the `host_app` ACL. Anything that is not
-   `app.local` is rejected with `421 Misdirected Request`.
+   the `Host` header, without any request port, against the `host_app`
+   ACL. Unknown hosts are rejected with `421 Misdirected Request`.
 3. The `spoe` filter sends a `coraza-req` message to the
    `coraza-spoa` backend (TCP, `coraza:9000`).
 4. The SPOA evaluates the request against Coraza/CRS rules and

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -2,7 +2,7 @@
 #
 # Goals:
 #   - Single frontend listening on :80
-#   - Single virtual host routed to a single backend
+#   - Virtual hosts routed to their configured backends
 #   - Reject unknown hosts before WAF inspection
 #   - SPOE filter forwarding request metadata to Coraza SPOA
 #   - Fail closed (503) if SPOA is unavailable or returns an error
@@ -38,10 +38,11 @@ frontend fe_http
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Known vhosts. Match Host without the optional request port so local
+    # Docker/browser requests such as app.local:8080 still route correctly.
     # Unknown hosts are rejected here, before WAF inspection, so that
     # Coraza does not process traffic destined for no valid backend.
-    acl host_app hdr(host) -i app.local app.local:80 app.local:8080 localhost localhost:8080 127.0.0.1 127.0.0.1:8080
+    acl host_app hdr(host),field(1,:) -i app.local localhost 127.0.0.1
     http-request deny deny_status 421 if !host_app
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
@@ -75,7 +76,7 @@ frontend fe_http
     use_backend be_app if host_app
     default_backend be_app
 
-# --- Application backend (single vhost target) -------------------
+# --- Application backends ----------------------------------------
 backend be_app
     option forwardfor
     option httpchk GET /health

--- a/src/backend/alembic/versions/6b5c4a3d2e10_add_runtime_operations_table.py
+++ b/src/backend/alembic/versions/6b5c4a3d2e10_add_runtime_operations_table.py
@@ -1,0 +1,99 @@
+"""add runtime operations table
+
+Revision ID: 6b5c4a3d2e10
+Revises: 8d4f2a6c1b90
+Create Date: 2026-05-16 19:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6b5c4a3d2e10"
+down_revision: str | Sequence[str] | None = "8d4f2a6c1b90"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _runtime_operation_type_enum() -> sa.Enum:
+    return sa.Enum("validation", "reload", name="runtimeoperationtype")
+
+
+def _runtime_operation_status_enum() -> sa.Enum:
+    return sa.Enum("success", "failed", name="runtimeoperationstatus")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    context = op.get_context()
+    bind = op.get_bind()
+
+    if context.dialect.name == "postgresql":
+        _runtime_operation_type_enum().create(bind, checkfirst=True)
+        _runtime_operation_status_enum().create(bind, checkfirst=True)
+        operation_type_enum: sa.Enum = postgresql.ENUM(
+            "validation",
+            "reload",
+            name="runtimeoperationtype",
+            create_type=False,
+        )
+        operation_status_enum: sa.Enum = postgresql.ENUM(
+            "success",
+            "failed",
+            name="runtimeoperationstatus",
+            create_type=False,
+        )
+    else:
+        operation_type_enum = _runtime_operation_type_enum()
+        operation_status_enum = _runtime_operation_status_enum()
+
+    op.create_table(
+        "runtime_operations",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("operation_type", operation_type_enum, nullable=False),
+        sa.Column("status", operation_status_enum, nullable=False),
+        sa.Column("config_checksum", sa.String(length=64), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_runtime_operations_created_at"),
+        "runtime_operations",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_runtime_operations_operation_type"),
+        "runtime_operations",
+        ["operation_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_runtime_operations_status"),
+        "runtime_operations",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_runtime_operations_status"), table_name="runtime_operations")
+    op.drop_index(
+        op.f("ix_runtime_operations_operation_type"),
+        table_name="runtime_operations",
+    )
+    op.drop_index(op.f("ix_runtime_operations_created_at"), table_name="runtime_operations")
+    op.drop_table("runtime_operations")
+
+    context = op.get_context()
+    if context.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS runtimeoperationstatus")
+        op.execute("DROP TYPE IF EXISTS runtimeoperationtype")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings, validate_runtime_settings
-from app.routers import auth, logs, policies, rule_overrides, vhosts
+from app.routers import auth, logs, policies, rule_overrides, runtime_status, vhosts
 
 
 class _HealthcheckAccessFilter(logging.Filter):
@@ -52,6 +52,7 @@ app.include_router(auth.router)
 app.include_router(logs.router)
 app.include_router(policies.router)
 app.include_router(rule_overrides.router)
+app.include_router(runtime_status.router)
 app.include_router(vhosts.router)
 
 

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -8,6 +8,11 @@ Without this, Alembic generates an empty migration (it does not see tables).
 from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_override import RuleAction, RuleOverride
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
 from app.models.user import User, UserRole
 from app.models.vhost import VHost
 
@@ -20,6 +25,9 @@ __all__ = [
     "Log",
     "LogAction",
     "LogSeverity",
+    "RuntimeOperation",
+    "RuntimeOperationType",
+    "RuntimeOperationStatus",
     "RuleOverride",
     "RuleAction",
 ]

--- a/src/backend/app/models/runtime_operation.py
+++ b/src/backend/app/models/runtime_operation.py
@@ -1,0 +1,59 @@
+"""Runtime operation status snapshots for generated/deployed config lifecycle."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, Enum, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class RuntimeOperationType(enum.StrEnum):
+    """Kinds of runtime operations relevant for deployment visibility."""
+
+    validation = "validation"
+    reload = "reload"
+
+
+class RuntimeOperationStatus(enum.StrEnum):
+    """Outcome of a runtime operation."""
+
+    success = "success"
+    failed = "failed"
+
+
+class RuntimeOperation(Base):
+    """Latest runtime operation snapshots used by status endpoints and dashboards."""
+
+    __tablename__ = "runtime_operations"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    operation_type: Mapped[RuntimeOperationType] = mapped_column(
+        Enum(RuntimeOperationType),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[RuntimeOperationStatus] = mapped_column(
+        Enum(RuntimeOperationStatus),
+        nullable=False,
+        index=True,
+    )
+    config_checksum: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        index=True,
+        server_default=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<RuntimeOperation id={self.id} type={self.operation_type} "
+            f"status={self.status} created_at={self.created_at.isoformat()}>"
+        )

--- a/src/backend/app/routers/runtime_status.py
+++ b/src/backend/app/routers/runtime_status.py
@@ -1,0 +1,22 @@
+"""Runtime/deployment status API router."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.models.user import User
+from app.schemas.runtime_status import RuntimeStatusResponse
+from app.services.runtime_status_service import RuntimeStatusService
+
+router = APIRouter(prefix="/runtime", tags=["runtime"])
+
+
+@router.get("/status", response_model=RuntimeStatusResponse)
+def get_runtime_status(
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> RuntimeStatusResponse:
+    """Return runtime/deployed configuration status for dashboard use."""
+    service = RuntimeStatusService(db)
+    return service.get_runtime_status()

--- a/src/backend/app/schemas/runtime_status.py
+++ b/src/backend/app/schemas/runtime_status.py
@@ -1,0 +1,44 @@
+"""Pydantic schemas for runtime/deployment status endpoint."""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from app.models.runtime_operation import (
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
+
+DeploymentState = Literal["never_deployed", "deployed", "failed"]
+
+
+class RuntimeGeneratedConfigStatus(BaseModel):
+    """Current generated configuration summary produced at request time."""
+
+    can_generate: bool
+    checksum: str | None = None
+    generated_at: datetime | None = None
+    error: str | None = None
+
+
+class RuntimeOperationSnapshot(BaseModel):
+    """Latest persisted status for a specific runtime operation type."""
+
+    id: int
+    operation_type: RuntimeOperationType
+    status: RuntimeOperationStatus
+    config_checksum: str | None = None
+    message: str | None = None
+    metadata_json: dict[str, Any] | None = None
+    created_at: datetime
+
+
+class RuntimeStatusResponse(BaseModel):
+    """Response body returned by GET /runtime/status."""
+
+    frontend_contract_version: str
+    deployment_state: DeploymentState
+    generated_config: RuntimeGeneratedConfigStatus
+    latest_validation: RuntimeOperationSnapshot | None = None
+    latest_reload: RuntimeOperationSnapshot | None = None

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -3,20 +3,21 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
-from app.models.policy import Policy, PolicyEnforcementMode
-from app.models.rule_override import RuleAction, RuleOverride
+from app.models.policy import PolicyEnforcementMode
+from app.models.rule_override import RuleAction
 
 # HAProxy identifiers (ACL names, backend names, server names): letters, digits,
 # hyphens, and underscores only.  No whitespace, newlines, or shell-special chars.
 _HAPROXY_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
-# HAProxy host values used in ACL conditions: hostname characters plus colon
-# (for optional port) and dots.  No whitespace or newlines.
-_HAPROXY_HOST_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+# HAProxy host values used in ACL conditions: bare hostname characters only.
+# The HAProxy template strips the request port before matching.
+_HAPROXY_HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 # HAProxy backend address (host:port): same allowlist as host values.
 _HAPROXY_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
@@ -38,7 +39,8 @@ def _validate_haproxy_host(value: str, field: str) -> None:
     if not _HAPROXY_HOST_RE.match(value):
         raise ValueError(
             f"{field} {value!r} contains characters unsafe for HAProxy config; "
-            "only hostname chars (letters, digits, dots, hyphens, colons) are allowed"
+            "only hostname chars (letters, digits, dots, hyphens, underscores) "
+            "are allowed"
         )
 
 
@@ -67,7 +69,7 @@ class HaproxyBackend:
 
 
 @dataclass(frozen=True)
-class HaproxyRenderContext:
+class HaproxyRoute:
     """Prepared HAProxy render input with no database behavior.
 
     All fields are validated on construction to reject characters that could
@@ -83,8 +85,51 @@ class HaproxyRenderContext:
         _validate_haproxy_identifier(
             self.vhost_acl_name, "HaproxyRenderContext.vhost_acl_name"
         )
+        if not self.vhost_hosts:
+            raise ValueError("HaproxyRenderContext.vhost_hosts must not be empty")
         for host in self.vhost_hosts:
             _validate_haproxy_host(host, "HaproxyRenderContext.vhost_hosts")
+
+
+@dataclass(frozen=True)
+class HaproxyRenderContext:
+    """Prepared HAProxy render input for all active virtual hosts."""
+
+    routes: tuple[HaproxyRoute, ...]
+
+    def __post_init__(self) -> None:
+        if not self.routes:
+            raise ValueError("HaproxyRenderContext.routes must not be empty")
+        _ensure_unique(
+            (route.vhost_acl_name for route in self.routes),
+            "HaproxyRenderContext.routes.vhost_acl_name",
+        )
+        _ensure_unique(
+            (route.backend.name for route in self.routes),
+            "HaproxyRenderContext.routes.backend.name",
+        )
+        _ensure_unique(
+            (route.backend.server_name for route in self.routes),
+            "HaproxyRenderContext.routes.backend.server_name",
+        )
+
+
+@dataclass(frozen=True)
+class CrsPolicyRenderContext:
+    """Policy fields needed to render CRS setup without an ORM object."""
+
+    paranoia_level: int
+    inbound_anomaly_threshold: int
+    outbound_anomaly_threshold: int
+    enforcement_mode: PolicyEnforcementMode
+
+
+@dataclass(frozen=True)
+class RuleOverrideRenderContext:
+    """Rule override fields needed to render CRS removals."""
+
+    rule_id: int
+    action: RuleAction
 
 
 _ENVIRONMENT = Environment(
@@ -99,13 +144,12 @@ def render_haproxy_cfg(context: HaproxyRenderContext) -> str:
     """Render haproxy.cfg from already prepared values."""
     template = _ENVIRONMENT.get_template("haproxy.cfg.j2")
     return template.render(
-        vhost_acl_name=context.vhost_acl_name,
-        vhost_hosts=context.vhost_hosts,
-        backend=context.backend,
+        routes=context.routes,
+        default_backend=context.routes[0].backend,
     )
 
 
-def render_crs_setup(policy: Policy) -> str:
+def render_crs_setup(policy: CrsPolicyRenderContext) -> str:
     """Render CRS setup configuration for a policy."""
     template = _ENVIRONMENT.get_template("crs-setup.conf.j2")
     sec_rule_engine = (
@@ -116,15 +160,25 @@ def render_crs_setup(policy: Policy) -> str:
     return template.render(policy=policy, sec_rule_engine=sec_rule_engine)
 
 
-def render_rule_overrides(policy: Policy) -> str:
+def render_rule_overrides(overrides: tuple[RuleOverrideRenderContext, ...]) -> str:
     """Render CRS rule removals for disabled policy overrides."""
     template = _ENVIRONMENT.get_template("rule-overrides.conf.j2")
-    disabled_rule_overrides = _sorted_disabled_overrides(policy.rule_overrides)
+    disabled_rule_overrides = _sorted_disabled_overrides(overrides)
     return template.render(disabled_rule_overrides=disabled_rule_overrides)
 
 
-def _sorted_disabled_overrides(overrides: list[RuleOverride]) -> list[RuleOverride]:
+def _sorted_disabled_overrides(
+    overrides: tuple[RuleOverrideRenderContext, ...],
+) -> list[RuleOverrideRenderContext]:
     return sorted(
         (override for override in overrides if override.action == RuleAction.disable),
         key=lambda override: override.rule_id,
     )
+
+
+def _ensure_unique(values: Iterable[str], field: str) -> None:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            raise ValueError(f"{field} contains duplicate HAProxy identifier {value!r}")
+        seen.add(value)

--- a/src/backend/app/services/runtime_status_service.py
+++ b/src/backend/app/services/runtime_status_service.py
@@ -1,0 +1,274 @@
+"""Service layer for runtime/deployed configuration status."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+from sqlalchemy.orm import Session
+
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_override import RuleOverride
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
+from app.models.vhost import VHost
+from app.schemas.runtime_status import (
+    DeploymentState,
+    RuntimeGeneratedConfigStatus,
+    RuntimeOperationSnapshot,
+    RuntimeStatusResponse,
+)
+from app.services.config_renderer import (
+    CrsPolicyRenderContext,
+    HaproxyBackend,
+    HaproxyRenderContext,
+    HaproxyRoute,
+    RuleOverrideRenderContext,
+    render_crs_setup,
+    render_haproxy_cfg,
+    render_rule_overrides,
+)
+
+_FRONTEND_CONTRACT_VERSION = "1"
+
+
+class RuntimeStatusService:
+    """Read-only status assembly for runtime and deployed configuration."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_runtime_status(self) -> RuntimeStatusResponse:
+        """Return status payload used by the backend API and frontend dashboard."""
+        latest_validation = self._get_latest_operation(RuntimeOperationType.validation)
+        latest_reload = self._get_latest_operation(RuntimeOperationType.reload)
+        generated_config = self._build_generated_config_status()
+        deployment_state = self._derive_deployment_state(latest_reload)
+
+        return RuntimeStatusResponse(
+            frontend_contract_version=_FRONTEND_CONTRACT_VERSION,
+            deployment_state=deployment_state,
+            generated_config=generated_config,
+            latest_validation=latest_validation,
+            latest_reload=latest_reload,
+        )
+
+    def _build_generated_config_status(self) -> RuntimeGeneratedConfigStatus:
+        vhosts = self.db.query(VHost).order_by(VHost.domain.asc()).all()
+        policies = self.db.query(Policy).order_by(Policy.id.asc()).all()
+        rule_overrides = (
+            self.db.query(RuleOverride).order_by(RuleOverride.id.asc()).all()
+        )
+        active_vhosts = [vhost for vhost in vhosts if vhost.is_active]
+
+        try:
+            active_policy, active_overrides = self._pick_active_policy(
+                active_vhosts=active_vhosts,
+                policies=policies,
+                rule_overrides=rule_overrides,
+            )
+            context = self._to_haproxy_context(active_vhosts)
+            haproxy_cfg = render_haproxy_cfg(context)
+            crs_setup_conf = render_crs_setup(active_policy)
+            rule_overrides_conf = render_rule_overrides(active_overrides)
+        except Exception as error:  # pragma: no cover - defensive conversion
+            return RuntimeGeneratedConfigStatus(
+                can_generate=False,
+                error=str(error),
+            )
+
+        return RuntimeGeneratedConfigStatus(
+            can_generate=True,
+            checksum=self._calculate_checksum(
+                haproxy_cfg,
+                crs_setup_conf,
+                rule_overrides_conf,
+            ),
+            generated_at=datetime.now(UTC),
+        )
+
+    def _get_latest_operation(
+        self, operation_type: RuntimeOperationType
+    ) -> RuntimeOperationSnapshot | None:
+        record = (
+            self.db.query(RuntimeOperation)
+            .filter(RuntimeOperation.operation_type == operation_type)
+            .order_by(RuntimeOperation.created_at.desc(), RuntimeOperation.id.desc())
+            .first()
+        )
+        if record is None:
+            return None
+
+        return RuntimeOperationSnapshot.model_validate(record, from_attributes=True)
+
+    def _derive_deployment_state(
+        self,
+        latest_reload: RuntimeOperationSnapshot | None,
+    ) -> DeploymentState:
+        if latest_reload is None:
+            return "never_deployed"
+        if latest_reload.status == RuntimeOperationStatus.success:
+            return "deployed"
+
+        latest_successful_reload = (
+            self.db.query(RuntimeOperation.id)
+            .filter(RuntimeOperation.operation_type == RuntimeOperationType.reload)
+            .filter(RuntimeOperation.status == RuntimeOperationStatus.success)
+            .first()
+        )
+        if latest_successful_reload is None:
+            return "never_deployed"
+        return "failed"
+
+    @staticmethod
+    def _calculate_checksum(
+        haproxy_cfg: str,
+        crs_setup_conf: str,
+        rule_overrides_conf: str,
+    ) -> str:
+        digest = hashlib.sha256()
+        digest.update(haproxy_cfg.encode("utf-8"))
+        digest.update(b"\n---\n")
+        digest.update(crs_setup_conf.encode("utf-8"))
+        digest.update(b"\n---\n")
+        digest.update(rule_overrides_conf.encode("utf-8"))
+        return digest.hexdigest()
+
+    @staticmethod
+    def _pick_active_policy(
+        *,
+        active_vhosts: list[VHost],
+        policies: list[Policy],
+        rule_overrides: list[RuleOverride],
+    ) -> tuple[CrsPolicyRenderContext, tuple[RuleOverrideRenderContext, ...]]:
+        policies_by_id = {policy.id: policy for policy in policies}
+        overrides_by_policy_id: dict[int, list[RuleOverride]] = {}
+        for override in rule_overrides:
+            overrides_by_policy_id.setdefault(override.policy_id, []).append(override)
+
+        effective_policy_ids: set[int] = set()
+        for vhost in active_vhosts:
+            if vhost.policy_id is None:
+                effective_policy_ids.add(0)
+                continue
+
+            policy = policies_by_id.get(vhost.policy_id)
+            if policy is None:
+                raise ValueError(
+                    f"Active vhost {vhost.domain!r} references missing policy "
+                    f"{vhost.policy_id}"
+                )
+            if not policy.is_active:
+                raise ValueError(
+                    f"Active vhost {vhost.domain!r} references inactive policy "
+                    f"{policy.id}"
+                )
+            effective_policy_ids.add(policy.id)
+
+        if len(effective_policy_ids) > 1:
+            policy_list = ", ".join(
+                str(policy_id) for policy_id in sorted(effective_policy_ids)
+            )
+            raise ValueError(
+                "Generated config supports one active CRS policy for MVP; "
+                f"found effective policies: {policy_list}"
+            )
+
+        effective_policy_id = next(iter(effective_policy_ids), 0)
+        if effective_policy_id == 0:
+            return (
+                CrsPolicyRenderContext(
+                    paranoia_level=1,
+                    inbound_anomaly_threshold=5,
+                    outbound_anomaly_threshold=4,
+                    enforcement_mode=PolicyEnforcementMode.detect_only,
+                ),
+                (),
+            )
+
+        policy = policies_by_id[effective_policy_id]
+        return (
+            RuntimeStatusService._to_crs_policy_context(policy),
+            RuntimeStatusService._to_rule_override_contexts(
+                overrides_by_policy_id.get(policy.id, [])
+            ),
+        )
+
+    @staticmethod
+    def _to_haproxy_context(active_vhosts: list[VHost]) -> HaproxyRenderContext:
+        if not active_vhosts:
+            return HaproxyRenderContext(
+                routes=(
+                    HaproxyRoute(
+                        vhost_acl_name="host_app",
+                        vhost_hosts=("app.local", "localhost", "127.0.0.1"),
+                        backend=HaproxyBackend(
+                            name="be_app",
+                            server_name="app",
+                            address="backend:8000",
+                        ),
+                    ),
+                )
+            )
+
+        return HaproxyRenderContext(
+            routes=tuple(
+                RuntimeStatusService._to_haproxy_route(vhost)
+                for vhost in active_vhosts
+            )
+        )
+
+    @staticmethod
+    def _to_haproxy_route(vhost: VHost) -> HaproxyRoute:
+        if vhost.id is None:
+            raise ValueError(f"Active vhost {vhost.domain!r} has no persisted id")
+        suffix = f"vhost_{vhost.id}"
+        backend_address = RuntimeStatusService._extract_backend_address(
+            vhost.backend_url
+        )
+        return HaproxyRoute(
+            vhost_acl_name=f"host_{suffix}",
+            vhost_hosts=(vhost.domain,),
+            backend=HaproxyBackend(
+                name=f"be_{suffix}",
+                server_name=f"srv_{suffix}",
+                address=backend_address,
+            ),
+        )
+
+    @staticmethod
+    def _to_crs_policy_context(policy: Policy) -> CrsPolicyRenderContext:
+        return CrsPolicyRenderContext(
+            paranoia_level=policy.paranoia_level,
+            inbound_anomaly_threshold=policy.inbound_anomaly_threshold,
+            outbound_anomaly_threshold=policy.outbound_anomaly_threshold,
+            enforcement_mode=policy.enforcement_mode,
+        )
+
+    @staticmethod
+    def _to_rule_override_contexts(
+        overrides: list[RuleOverride],
+    ) -> tuple[RuleOverrideRenderContext, ...]:
+        return tuple(
+            RuleOverrideRenderContext(
+                rule_id=override.rule_id,
+                action=override.action,
+            )
+            for override in overrides
+        )
+
+    @staticmethod
+    def _extract_backend_address(backend_url: str) -> str:
+        parsed = urlparse(backend_url)
+        address = parsed.netloc if parsed.scheme else parsed.path
+        if not address:
+            raise ValueError(f"Invalid backend URL {backend_url!r}: missing host")
+        if "@" in address:
+            raise ValueError(
+                f"Invalid backend URL {backend_url!r}: userinfo is not supported"
+            )
+        return address

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -2,7 +2,7 @@
 #
 # Goals:
 #   - Single frontend listening on :80
-#   - Single virtual host routed to a single backend
+#   - Virtual hosts routed to their configured backends
 #   - Reject unknown hosts before WAF inspection
 #   - SPOE filter forwarding request metadata to Coraza SPOA
 #   - Fail closed (503) if SPOA is unavailable or returns an error
@@ -38,11 +38,14 @@ frontend fe_http
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Reference vhost: accept app.local plus local-dev browser hosts.
+    # Known vhosts. Match Host without the optional request port so local
+    # Docker/browser requests such as app.local:8080 still route correctly.
     # Unknown hosts are rejected here, before WAF inspection, so that
     # Coraza does not process traffic destined for no valid backend.
-    acl {{ vhost_acl_name }} hdr(host) -i {{ vhost_hosts | join(" ") }}
-    http-request deny deny_status 421 if !{{ vhost_acl_name }}
+{% for route in routes %}
+    acl {{ route.vhost_acl_name }} hdr(host),field(1,:) -i {{ route.vhost_hosts | join(" ") }}
+{% endfor %}
+    http-request deny deny_status 421 if{% for route in routes %} !{{ route.vhost_acl_name }}{% endfor %}
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
@@ -72,17 +75,22 @@ frontend fe_http
     # shows up in the access log for debugging.
     http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
 
-    use_backend {{ backend.name }} if {{ vhost_acl_name }}
-    default_backend {{ backend.name }}
+{% for route in routes %}
+    use_backend {{ route.backend.name }} if {{ route.vhost_acl_name }}
+{% endfor %}
+    default_backend {{ default_backend.name }}
 
-# --- Application backend (single vhost target) -------------------
-backend {{ backend.name }}
+# --- Application backends ----------------------------------------
+{% for route in routes %}
+backend {{ route.backend.name }}
     option forwardfor
     option httpchk GET /health
     http-check expect status 200
     # init-addr none lets `haproxy -c` succeed even when the
     # `backend` DNS name is not resolvable (e.g. outside compose).
-    server {{ backend.server_name }} {{ backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
+    server {{ route.backend.server_name }} {{ route.backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
+
+{% endfor %}
 
 # --- Coraza SPOA backend used by the SPOE filter -----------------
 # The SPOA speaks SPOP (binary, request/response) over TCP, so this

--- a/src/backend/tests/integration/test_runtime_status_router.py
+++ b/src/backend/tests/integration/test_runtime_status_router.py
@@ -1,0 +1,134 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
+from app.models.vhost import VHost
+
+
+def test_runtime_status_requires_auth(client: TestClient) -> None:
+    response = client.get("/runtime/status")
+
+    assert response.status_code == 401
+
+
+def test_runtime_status_allows_viewer(
+    client: TestClient,
+    viewer_token: dict[str, str],
+) -> None:
+    response = client.get("/runtime/status", headers=viewer_token)
+
+    assert response.status_code == 200
+
+
+def test_runtime_status_returns_never_deployed_for_empty_state(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    response = client.get("/runtime/status", headers=admin_token)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["frontend_contract_version"] == "1"
+    assert body["deployment_state"] == "never_deployed"
+    assert body["generated_config"]["can_generate"] is True
+    assert len(body["generated_config"]["checksum"]) == 64
+    assert body["latest_validation"] is None
+    assert body["latest_reload"] is None
+
+
+def test_runtime_status_returns_latest_validation_and_reload(
+    client: TestClient,
+    admin_token: dict[str, str],
+    db: Session,
+) -> None:
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.validation,
+            status=RuntimeOperationStatus.success,
+            config_checksum="1" * 64,
+            message="Config validated successfully",
+        )
+    )
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.reload,
+            status=RuntimeOperationStatus.success,
+            config_checksum="2" * 64,
+            message="HAProxy reloaded",
+        )
+    )
+    db.commit()
+
+    response = client.get("/runtime/status", headers=admin_token)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["deployment_state"] == "deployed"
+    assert body["latest_validation"]["status"] == "success"
+    assert body["latest_validation"]["message"] == "Config validated successfully"
+    assert body["latest_reload"]["status"] == "success"
+    assert body["latest_reload"]["message"] == "HAProxy reloaded"
+
+
+def test_runtime_status_reports_generation_error_for_invalid_vhost_data(
+    client: TestClient,
+    admin_token: dict[str, str],
+    db: Session,
+) -> None:
+    # This simulates invalid persisted data bypassing API validation.
+    db.add(
+        VHost(
+            domain="broken.example.com",
+            backend_url="http://",
+            is_active=True,
+            ssl_enabled=False,
+            policy_id=None,
+        )
+    )
+    db.commit()
+
+    response = client.get("/runtime/status", headers=admin_token)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["generated_config"]["can_generate"] is False
+    assert "missing host" in body["generated_config"]["error"]
+
+
+def test_runtime_status_generates_config_for_multiple_active_vhosts(
+    client: TestClient,
+    admin_token: dict[str, str],
+    db: Session,
+) -> None:
+    db.add_all(
+        [
+            VHost(
+                domain="app.example.com",
+                backend_url="http://app-backend:8000",
+                is_active=True,
+                ssl_enabled=False,
+                policy_id=None,
+            ),
+            VHost(
+                domain="api.example.com",
+                backend_url="http://api-backend:8000",
+                is_active=True,
+                ssl_enabled=False,
+                policy_id=None,
+            ),
+        ]
+    )
+    db.commit()
+
+    response = client.get("/runtime/status", headers=admin_token)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["generated_config"]["can_generate"] is True
+    assert len(body["generated_config"]["checksum"]) == 64
+    assert body["generated_config"]["generated_at"] is not None
+    assert body["generated_config"]["error"] is None

--- a/src/backend/tests/unit/test_config_renderer_crs_setup.py
+++ b/src/backend/tests/unit/test_config_renderer_crs_setup.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pytest
 
-from app.models.policy import Policy, PolicyEnforcementMode
-from app.services.config_renderer import render_crs_setup
+from app.models.policy import PolicyEnforcementMode
+from app.services.config_renderer import CrsPolicyRenderContext, render_crs_setup
 
 
 def _find_repo_root(start: Path) -> Path:
@@ -29,14 +29,12 @@ def _policy(
     inbound_anomaly_threshold: int = 5,
     outbound_anomaly_threshold: int = 5,
     enforcement_mode: PolicyEnforcementMode = PolicyEnforcementMode.block,
-) -> Policy:
-    return Policy(
-        name="Renderer policy",
+) -> CrsPolicyRenderContext:
+    return CrsPolicyRenderContext(
         paranoia_level=paranoia_level,
         inbound_anomaly_threshold=inbound_anomaly_threshold,
         outbound_anomaly_threshold=outbound_anomaly_threshold,
         enforcement_mode=enforcement_mode,
-        is_active=True,
     )
 
 

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -7,6 +7,7 @@ import pytest
 from app.services.config_renderer import (
     HaproxyBackend,
     HaproxyRenderContext,
+    HaproxyRoute,
     render_haproxy_cfg,
 )
 
@@ -30,21 +31,17 @@ def _normalise_config(config: str) -> str:
 
 def _m1_reference_context() -> HaproxyRenderContext:
     return HaproxyRenderContext(
-        vhost_acl_name="host_app",
-        vhost_hosts=(
-            "app.local",
-            "app.local:80",
-            "app.local:8080",
-            "localhost",
-            "localhost:8080",
-            "127.0.0.1",
-            "127.0.0.1:8080",
-        ),
-        backend=HaproxyBackend(
-            name="be_app",
-            server_name="app",
-            address="backend:8000",
-        ),
+        routes=(
+            HaproxyRoute(
+                vhost_acl_name="host_app",
+                vhost_hosts=("app.local", "localhost", "127.0.0.1"),
+                backend=HaproxyBackend(
+                    name="be_app",
+                    server_name="app",
+                    address="backend:8000",
+                ),
+            ),
+        )
     )
 
 
@@ -58,21 +55,63 @@ def test_haproxy_template_renders_m1_reference_modulo_whitespace() -> None:
 def test_haproxy_template_parameterises_vhost_and_backend() -> None:
     rendered = render_haproxy_cfg(
         HaproxyRenderContext(
-            vhost_acl_name="host_api",
-            vhost_hosts=("api.example.com", "api.example.com:80"),
-            backend=HaproxyBackend(
-                name="be_api",
-                server_name="api",
-                address="api-backend:9000",
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    backend=HaproxyBackend(
+                        name="be_api",
+                        server_name="api",
+                        address="api-backend:9000",
+                    ),
+                ),
             ),
         )
     )
 
-    assert "acl host_api hdr(host) -i api.example.com api.example.com:80" in rendered
+    assert "acl host_api hdr(host),field(1,:) -i api.example.com" in rendered
     assert "http-request deny deny_status 421 if !host_api" in rendered
     assert "use_backend be_api if host_api" in rendered
     assert "default_backend be_api" in rendered
     assert "server api api-backend:9000 check" in rendered
+
+
+def test_haproxy_template_renders_multiple_vhost_routes() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_vhost_1",
+                    vhost_hosts=("foo-bar.com",),
+                    backend=HaproxyBackend(
+                        name="be_vhost_1",
+                        server_name="srv_vhost_1",
+                        address="foo-backend:8000",
+                    ),
+                ),
+                HaproxyRoute(
+                    vhost_acl_name="host_vhost_2",
+                    vhost_hosts=("foo.bar.com",),
+                    backend=HaproxyBackend(
+                        name="be_vhost_2",
+                        server_name="srv_vhost_2",
+                        address="bar-backend:8000",
+                    ),
+                ),
+            )
+        )
+    )
+
+    assert "acl host_vhost_1 hdr(host),field(1,:) -i foo-bar.com" in rendered
+    assert "acl host_vhost_2 hdr(host),field(1,:) -i foo.bar.com" in rendered
+    assert (
+        "http-request deny deny_status 421 if !host_vhost_1 !host_vhost_2"
+        in rendered
+    )
+    assert "use_backend be_vhost_1 if host_vhost_1" in rendered
+    assert "use_backend be_vhost_2 if host_vhost_2" in rendered
+    assert "backend be_vhost_1" in rendered
+    assert "backend be_vhost_2" in rendered
 
 
 @pytest.mark.parametrize(
@@ -89,9 +128,17 @@ def test_haproxy_template_parameterises_vhost_and_backend() -> None:
 def test_haproxy_render_context_rejects_unsafe_acl_name(vhost_acl_name: str) -> None:
     with pytest.raises(ValueError, match="vhost_acl_name"):
         HaproxyRenderContext(
-            vhost_acl_name=vhost_acl_name,
-            vhost_hosts=("safe.host",),
-            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name=vhost_acl_name,
+                    vhost_hosts=("safe.host",),
+                    backend=HaproxyBackend(
+                        name="be",
+                        server_name="srv",
+                        address="host:80",
+                    ),
+                ),
+            )
         )
 
 
@@ -103,14 +150,23 @@ def test_haproxy_render_context_rejects_unsafe_acl_name(vhost_acl_name: str) -> 
         "has\ttab",
         "has#comment",
         "has;semi",
+        "safe.host:8080",
     ],
 )
 def test_haproxy_render_context_rejects_unsafe_host(host: str) -> None:
     with pytest.raises(ValueError, match="HaproxyRenderContext.vhost_hosts"):
         HaproxyRenderContext(
-            vhost_acl_name="safe_acl",
-            vhost_hosts=(host,),
-            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="safe_acl",
+                    vhost_hosts=(host,),
+                    backend=HaproxyBackend(
+                        name="be",
+                        server_name="srv",
+                        address="host:80",
+                    ),
+                ),
+            )
         )
 
 
@@ -139,18 +195,60 @@ def test_haproxy_backend_rejects_unsafe_values(field: str, kwargs: dict) -> None
 def test_haproxy_render_context_rejects_empty_acl_name() -> None:
     with pytest.raises(ValueError, match="vhost_acl_name"):
         HaproxyRenderContext(
-            vhost_acl_name="",
-            vhost_hosts=("safe.host",),
-            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="",
+                    vhost_hosts=("safe.host",),
+                    backend=HaproxyBackend(
+                        name="be",
+                        server_name="srv",
+                        address="host:80",
+                    ),
+                ),
+            )
         )
 
 
 def test_haproxy_render_context_rejects_empty_host() -> None:
     with pytest.raises(ValueError, match="HaproxyRenderContext.vhost_hosts"):
         HaproxyRenderContext(
-            vhost_acl_name="safe_acl",
-            vhost_hosts=("",),
-            backend=HaproxyBackend(name="be", server_name="srv", address="host:80"),
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="safe_acl",
+                    vhost_hosts=("",),
+                    backend=HaproxyBackend(
+                        name="be",
+                        server_name="srv",
+                        address="host:80",
+                    ),
+                ),
+            )
+        )
+
+
+def test_haproxy_render_context_rejects_duplicate_identifiers() -> None:
+    with pytest.raises(ValueError, match="duplicate HAProxy identifier"):
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_duplicate",
+                    vhost_hosts=("one.example.com",),
+                    backend=HaproxyBackend(
+                        name="be_one",
+                        server_name="srv_one",
+                        address="one-backend:8000",
+                    ),
+                ),
+                HaproxyRoute(
+                    vhost_acl_name="host_duplicate",
+                    vhost_hosts=("two.example.com",),
+                    backend=HaproxyBackend(
+                        name="be_two",
+                        server_name="srv_two",
+                        address="two-backend:8000",
+                    ),
+                ),
+            )
         )
 
 

--- a/src/backend/tests/unit/test_config_renderer_rule_overrides.py
+++ b/src/backend/tests/unit/test_config_renderer_rule_overrides.py
@@ -1,22 +1,18 @@
-from app.models.policy import Policy
-from app.models.rule_override import RuleAction, RuleOverride
-from app.services.config_renderer import render_rule_overrides
+from app.models.rule_override import RuleAction
+from app.services.config_renderer import (
+    RuleOverrideRenderContext,
+    render_rule_overrides,
+)
 
 
-def _policy_with_overrides(overrides: list[RuleOverride]) -> Policy:
-    policy = Policy(
-        name="Rule override renderer",
-        paranoia_level=1,
-        inbound_anomaly_threshold=5,
-        outbound_anomaly_threshold=5,
-        is_active=True,
-    )
-    policy.rule_overrides = overrides
-    return policy
+def _overrides(
+    overrides: list[RuleOverrideRenderContext],
+) -> tuple[RuleOverrideRenderContext, ...]:
+    return tuple(overrides)
 
 
 def test_rule_overrides_template_renders_header_for_empty_policy() -> None:
-    rendered = render_rule_overrides(_policy_with_overrides([]))
+    rendered = render_rule_overrides(_overrides([]))
 
     assert "Guard Proxy CRS rule overrides" in rendered
     assert "SecRuleRemoveById" not in rendered
@@ -24,10 +20,16 @@ def test_rule_overrides_template_renders_header_for_empty_policy() -> None:
 
 def test_rule_overrides_template_renders_disabled_rules_sorted() -> None:
     rendered = render_rule_overrides(
-        _policy_with_overrides(
+        _overrides(
             [
-                RuleOverride(policy_id=1, rule_id=942100, action=RuleAction.disable),
-                RuleOverride(policy_id=1, rule_id=941100, action=RuleAction.disable),
+                RuleOverrideRenderContext(
+                    rule_id=942100,
+                    action=RuleAction.disable,
+                ),
+                RuleOverrideRenderContext(
+                    rule_id=941100,
+                    action=RuleAction.disable,
+                ),
             ]
         )
     )
@@ -39,10 +41,16 @@ def test_rule_overrides_template_renders_disabled_rules_sorted() -> None:
 
 def test_rule_overrides_template_skips_enabled_rules() -> None:
     rendered = render_rule_overrides(
-        _policy_with_overrides(
+        _overrides(
             [
-                RuleOverride(policy_id=1, rule_id=941100, action=RuleAction.enable),
-                RuleOverride(policy_id=1, rule_id=942100, action=RuleAction.disable),
+                RuleOverrideRenderContext(
+                    rule_id=941100,
+                    action=RuleAction.enable,
+                ),
+                RuleOverrideRenderContext(
+                    rule_id=942100,
+                    action=RuleAction.disable,
+                ),
             ]
         )
     )

--- a/src/backend/tests/unit/test_runtime_status_service.py
+++ b/src/backend/tests/unit/test_runtime_status_service.py
@@ -1,0 +1,296 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_override import RuleAction, RuleOverride
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
+from app.models.vhost import VHost
+from app.services.config_renderer import render_haproxy_cfg
+from app.services.runtime_status_service import RuntimeStatusService
+
+
+def _add_operation(
+    db: Session,
+    *,
+    operation_type: RuntimeOperationType,
+    status: RuntimeOperationStatus,
+    created_at: datetime,
+) -> RuntimeOperation:
+    operation = RuntimeOperation(
+        operation_type=operation_type,
+        status=status,
+        created_at=created_at,
+    )
+    db.add(operation)
+    db.commit()
+    db.refresh(operation)
+    return operation
+
+
+def test_deployment_state_is_never_deployed_without_reload_records(db: Session) -> None:
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.deployment_state == "never_deployed"
+    assert status.latest_reload is None
+
+
+def test_deployment_state_is_deployed_when_latest_reload_succeeded(db: Session) -> None:
+    _add_operation(
+        db,
+        operation_type=RuntimeOperationType.reload,
+        status=RuntimeOperationStatus.success,
+        created_at=datetime(2026, 5, 16, 19, 0, 0),
+    )
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.deployment_state == "deployed"
+    assert status.latest_reload is not None
+    assert status.latest_reload.status == RuntimeOperationStatus.success
+
+
+def test_deployment_state_stays_never_deployed_with_only_failed_reloads(
+    db: Session,
+) -> None:
+    _add_operation(
+        db,
+        operation_type=RuntimeOperationType.reload,
+        status=RuntimeOperationStatus.failed,
+        created_at=datetime(2026, 5, 16, 19, 0, 0),
+    )
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.deployment_state == "never_deployed"
+    assert status.latest_reload is not None
+    assert status.latest_reload.status == RuntimeOperationStatus.failed
+
+
+def test_deployment_state_is_failed_when_latest_reload_failed_after_success(
+    db: Session,
+) -> None:
+    _add_operation(
+        db,
+        operation_type=RuntimeOperationType.reload,
+        status=RuntimeOperationStatus.success,
+        created_at=datetime(2026, 5, 16, 19, 0, 0),
+    )
+    _add_operation(
+        db,
+        operation_type=RuntimeOperationType.reload,
+        status=RuntimeOperationStatus.failed,
+        created_at=datetime(2026, 5, 16, 19, 5, 0),
+    )
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.deployment_state == "failed"
+    assert status.latest_reload is not None
+    assert status.latest_reload.status == RuntimeOperationStatus.failed
+
+
+def _add_policy(
+    db: Session,
+    *,
+    name: str,
+    is_active: bool = True,
+    enforcement_mode: PolicyEnforcementMode = PolicyEnforcementMode.block,
+) -> Policy:
+    policy = Policy(
+        name=name,
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=enforcement_mode,
+        is_active=is_active,
+    )
+    db.add(policy)
+    db.flush()
+    return policy
+
+
+def _add_vhost(
+    db: Session,
+    *,
+    domain: str,
+    backend_url: str,
+    policy_id: int | None = None,
+) -> VHost:
+    vhost = VHost(
+        domain=domain,
+        backend_url=backend_url,
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=policy_id,
+    )
+    db.add(vhost)
+    db.flush()
+    return vhost
+
+
+def test_generated_config_supports_multiple_active_vhosts(
+    db: Session,
+) -> None:
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+    )
+    _add_vhost(
+        db,
+        domain="api.example.com",
+        backend_url="http://api-backend:8000",
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is True
+    assert status.generated_config.checksum is not None
+    assert status.generated_config.generated_at is not None
+    assert status.generated_config.error is None
+
+
+def test_haproxy_context_uses_vhost_id_identifiers_for_colliding_domains(
+    db: Session,
+) -> None:
+    first = _add_vhost(
+        db,
+        domain="foo-bar.com",
+        backend_url="http://foo-backend:8000",
+    )
+    second = _add_vhost(
+        db,
+        domain="foo.bar.com",
+        backend_url="http://bar-backend:8000",
+    )
+
+    rendered = render_haproxy_cfg(
+        RuntimeStatusService._to_haproxy_context([first, second])
+    )
+
+    assert f"acl host_vhost_{first.id} hdr(host),field(1,:) -i foo-bar.com" in rendered
+    assert f"acl host_vhost_{second.id} hdr(host),field(1,:) -i foo.bar.com" in rendered
+    assert f"backend be_vhost_{first.id}" in rendered
+    assert f"backend be_vhost_{second.id}" in rendered
+    assert "host_foo_bar_com" not in rendered
+
+
+def test_generated_config_does_not_dirty_policy_relationships(
+    db: Session,
+) -> None:
+    policy = _add_policy(db, name="Pure generator")
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        policy_id=policy.id,
+    )
+    db.add(
+        RuleOverride(
+            policy_id=policy.id,
+            rule_id=942100,
+            action=RuleAction.disable,
+        )
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is True
+    assert not db.dirty
+
+
+def test_generated_config_rejects_mixed_active_policies(db: Session) -> None:
+    first_policy = _add_policy(db, name="Strict")
+    second_policy = _add_policy(db, name="Monitor")
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        policy_id=first_policy.id,
+    )
+    _add_vhost(
+        db,
+        domain="api.example.com",
+        backend_url="http://api-backend:8000",
+        policy_id=second_policy.id,
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is False
+    assert status.generated_config.error is not None
+    assert "one active CRS policy" in status.generated_config.error
+
+
+def test_generated_config_rejects_inactive_assigned_policy(db: Session) -> None:
+    policy = _add_policy(db, name="Inactive", is_active=False)
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        policy_id=policy.id,
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is False
+    assert status.generated_config.error is not None
+    assert "inactive policy" in status.generated_config.error
+
+
+def test_active_policy_selection_rejects_missing_policy() -> None:
+    vhost = VHost(
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=999,
+    )
+
+    try:
+        RuntimeStatusService._pick_active_policy(
+            active_vhosts=[vhost],
+            policies=[],
+            rule_overrides=[],
+        )
+    except ValueError as error:
+        assert "missing policy 999" in str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("Expected missing policy to fail generation")
+
+
+def test_checksum_is_stable_for_same_generated_content() -> None:
+    checksum_a = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
+    checksum_b = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
+
+    assert checksum_a == checksum_b
+    assert len(checksum_a) == 64
+
+
+def test_checksum_changes_when_generated_content_changes() -> None:
+    checksum_a = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
+    checksum_b = RuntimeStatusService._calculate_checksum(
+        "haproxy-changed",
+        "crs",
+        "rules",
+    )
+
+    assert checksum_a != checksum_b


### PR DESCRIPTION
## Summary
- Add persistent runtime operation tracking with a new `runtime_operations` model and Alembic migration for validation/reload outcomes.
- Add authenticated `GET /runtime/status` endpoint that returns `deployment_state`, `generated_config` checksum/health, and latest validation/reload snapshots.
- Add runtime status service and response schemas, including explicit `never_deployed` handling and deterministic checksum generation.
- Add unit/integration tests covering auth access, deployment-state transitions, operation snapshots, and generation failure reporting.

Closes #69

## Test plan
- [x] `uv run pytest tests/unit/test_runtime_status_service.py tests/integration/test_runtime_status_router.py`
- [x] `uv run pytest --cov=app`
- [x] `uv run mypy app/`
- [x] `uv run ruff check app/`