### PR TITLE
fix(smoke): stabilize degraded coraza transition

### DIFF
--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -131,6 +131,43 @@ assert_header() {
   echo "${description}: found '${expected}'."
 }
 
+wait_for_header() {
+  local description="$1"
+  local expected="$2"
+  local url="$3"
+  local timeout="${4:-20}"
+  local deadline=$((SECONDS + timeout))
+  local headers=""
+
+  echo "Waiting for ${description}..."
+  while (( SECONDS < deadline )); do
+    headers="$(
+      curl \
+        --silent \
+        --show-error \
+        --output /dev/null \
+        --dump-header - \
+        --header 'Host: app.local' \
+        --max-time 2 \
+        "${url}" \
+        2>/dev/null || true
+    )"
+
+    if grep -Fqi "${expected}" <<<"${headers}"; then
+      echo "${description}: found '${expected}'."
+      return 0
+    fi
+
+    sleep 1
+  done
+
+  echo "${description}: timed out waiting for response header containing '${expected}'." >&2
+  if [[ -n "${headers}" ]]; then
+    echo "${headers}" >&2
+  fi
+  return 1
+}
+
 cd "${REPO_ROOT}"
 
 "${COMPOSE[@]}" up -d --build postgres backend coraza haproxy
@@ -143,8 +180,8 @@ assert_status "Benign request" "200" "${HAPROXY_BASE_URL}/health"
 assert_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%20%271%27%3D%271"
 
 "${COMPOSE[@]}" stop coraza
-# Wait for HAProxy to mark the coraza server DOWN (inter 2s fall 1 = at most 2 s).
-sleep 5
+# Wait until HAProxy starts returning the explicit unavailable reason.
+wait_for_header "Coraza unavailable transition" "X-WAF-Degraded-Reason: coraza-unavailable" "${HAPROXY_BASE_URL}/" 20
 
 assert_status "Degraded request without Coraza" "503" "${HAPROXY_BASE_URL}/"
 assert_header "Degraded WAF status header" "X-WAF-Status: degraded" "${HAPROXY_BASE_URL}/"

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -93,7 +93,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -100,7 +100,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -156,6 +156,15 @@ def test_reference_haproxy_config_fails_closed_when_coraza_is_unavailable() -> N
     )
 
 
+def test_reference_haproxy_config_marks_coraza_down_quickly() -> None:
+    config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
+
+    assert (
+        "server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none"
+        in config
+    )
+
+
 def test_reference_haproxy_config_preserves_host_health_and_waf_rules() -> None:
     config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
 


### PR DESCRIPTION
## Summary

- Stabilize the smoke degraded-mode transition by reducing Coraza SPOA DOWN detection from `fall 3` to `fall 1` in both reference and template HAProxy configs.
- Replace the fixed sleep in `benchmarks/smoke/e2e.sh` with deterministic header polling for `X-WAF-Degraded-Reason: coraza-unavailable`.
- Add a regression assertion in backend unit tests to prevent health-check-threshold drift.

## Testing

- [x] `cd src/backend && uv sync --frozen --extra dev`
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm install --frozen-lockfile`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`