### PR TITLE
feat(runtime): add shared generated config volume

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -108,12 +108,12 @@ Generated runtime artifacts live in the Docker named volume
 `guard_proxy_runtime`. The backend mounts it read-write at `/runtime`, while
 HAProxy mounts the same volume read-only at `/runtime`.
 
-The reserved layout is:
+The reserved layout for future generated artifacts is:
 
 ```text
 /runtime/
-  haproxy.cfg  # generated HAProxy config, written by the backend
-  crs/         # generated CRS artifacts, written by the backend
+  haproxy.cfg  # generated HAProxy config
+  crs/         # generated CRS artifacts
 ```
 
 The backend container starts as root only long enough to create `/runtime/crs`,

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -15,8 +15,9 @@ graph TB
 
     FE[React Admin UI] -->|REST API| BE
     BE --> DB[(PostgreSQL)]
-    BE -.->|future generated config| H
-    BE -.->|future generated config| CS
+    BE -.->|writes generated runtime config| RV[(guard_proxy_runtime)]
+    RV -.->|read-only mount| H
+    RV -.->|future CRS artifacts| CS
 ```
 
 ## Request Flow
@@ -70,7 +71,7 @@ machine-readable degraded reason header.
 1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.
 2. FastAPI persists control-plane state in PostgreSQL.
 3. M1 stores policy data but still uses hand-written HAProxy and Coraza reference configuration.
-4. Generated HAProxy/Coraza config, validation, graceful reloads, rollback, and richer per-vhost runtime policy wiring are future M2 work.
+4. FastAPI writes generated runtime config into the shared `guard_proxy_runtime` volume. HAProxy mounts that volume read-only at `/runtime`; validation, graceful reloads, rollback, and richer per-vhost runtime policy wiring are future M2 work.
 
 ### Runtime Event Ingestion
 1. Runtime WAF events can be represented as structured log payloads.
@@ -100,6 +101,26 @@ Coraza debug logging. The end-to-end smoke test is
 `benchmarks/smoke/e2e.sh`; it starts the stack, waits for healthy services,
 checks a benign request, checks that a SQL injection request is blocked, and
 tears the stack down.
+
+### Shared Runtime Volume
+
+Generated runtime artifacts live in the Docker named volume
+`guard_proxy_runtime`. The backend mounts it read-write at `/runtime`, while
+HAProxy mounts the same volume read-only at `/runtime`.
+
+The reserved layout is:
+
+```text
+/runtime/
+  haproxy.cfg  # generated HAProxy config, written by the backend
+  crs/         # generated CRS artifacts, written by the backend
+```
+
+The backend container starts as root only long enough to create `/runtime/crs`,
+assign the mounted volume to the non-root `app` user, and then drops privileges
+before running migrations and Uvicorn. HAProxy continues to boot from the
+checked-in seed config in `configs/haproxy/haproxy.cfg` until generated config
+deployment and reload orchestration are enabled.
 
 ## Key Decisions
 

--- a/README.commands.md
+++ b/README.commands.md
@@ -56,7 +56,7 @@ make run                                                             # Start all
 make dev                                                             # Start all services with HAProxy -d flag and Coraza debug logging
 make coraza-build                                                    # Build the pinned Coraza SPOA + CRS image
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza  # Reload mounted Coraza config/rules
-docker volume ls | grep guard-proxy                                  # Inspect pgdata, log, and guard_proxy_runtime volumes
+docker volume ls | grep guard_proxy                                  # Inspect pgdata, log, and guard_proxy_runtime volumes
 make ps                                                              # Show service status
 make logs                                                            # Follow all service logs
 make down                                                            # Stop stack (keeps named volumes)

--- a/README.commands.md
+++ b/README.commands.md
@@ -56,7 +56,7 @@ make run                                                             # Start all
 make dev                                                             # Start all services with HAProxy -d flag and Coraza debug logging
 make coraza-build                                                    # Build the pinned Coraza SPOA + CRS image
 docker-compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env restart coraza  # Reload mounted Coraza config/rules
-docker volume ls | grep guard-proxy                                  # Inspect pgdata, log, and generated_config volumes
+docker volume ls | grep guard-proxy                                  # Inspect pgdata, log, and guard_proxy_runtime volumes
 make ps                                                              # Show service status
 make logs                                                            # Follow all service logs
 make down                                                            # Stop stack (keeps named volumes)

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - .env
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
+      GUARD_PROXY_RUNTIME_DIR: /runtime
     depends_on:
       postgres:
         condition: service_healthy
@@ -39,7 +40,7 @@ services:
       retries: 10
     volumes:
       - backend_logs:/var/log/guard-proxy
-      - generated_config:/var/lib/guard-proxy/generated
+      - guard_proxy_runtime:/runtime
     networks:
       - gp_internal
 
@@ -97,7 +98,7 @@ services:
       - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
       - haproxy_logs:/var/log/haproxy
-      - generated_config:/etc/haproxy/generated:ro
+      - guard_proxy_runtime:/runtime:ro
     healthcheck:
       test: ["CMD-SHELL", "haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg"]
       interval: 10s
@@ -118,4 +119,4 @@ volumes:
   haproxy_logs:
   coraza_logs:
   backend_logs:
-  generated_config:
+  guard_proxy_runtime:

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -18,10 +18,17 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:${PATH}"
 
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --system app && useradd --system --gid app --home-dir /app --no-create-home --shell /usr/sbin/nologin app
 
 WORKDIR /app
-RUN chown app:app /app
+RUN mkdir -p /runtime/crs && chown app:app /app /runtime /runtime/crs
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 COPY --chown=app:app alembic alembic
@@ -31,5 +38,5 @@ COPY --chown=app:app alembic.ini alembic.ini
 
 EXPOSE 8000
 
-USER app
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh", "-c", "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+runtime_dir="${GUARD_PROXY_RUNTIME_DIR:-/runtime}"
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "${runtime_dir}/crs"
+    chown -R app:app "${runtime_dir}"
+    chmod 755 "${runtime_dir}" "${runtime_dir}/crs"
+
+    exec gosu app "$@"
+fi
+
+mkdir -p "${runtime_dir}/crs"
+exec "$@"


### PR DESCRIPTION
## Summary

- Replaces #180 because the original PR head ref is detached on GitHub and no longer tracks the recreated branch ref.
- Add the shared guard_proxy_runtime Docker volume for generated runtime config.
- Mount the runtime volume read-write in the backend and read-only in HAProxy at /runtime.
- Initialize /runtime/crs with backend ownership before dropping to the non-root app user.
- Clarify the reserved future /runtime/haproxy.cfg and /runtime/crs/ layout.
- Fix the Docker volume inspection command to match guard_proxy volume names.

## Validation

- git diff --check
- sh -n src/backend/docker-entrypoint.sh