### PR TITLE
Feat/config apply service and ha proxy reload wiring

### DIFF
--- a/deploy/docker/docker-compose.debug.yml
+++ b/deploy/docker/docker-compose.debug.yml
@@ -5,7 +5,12 @@
 
 services:
   haproxy:
-    command: ["haproxy", "-d", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -d -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+      ]
 
   coraza:
     volumes:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     volumes:
       - backend_logs:/var/log/guard-proxy
       - generated_config:/var/lib/guard-proxy/generated
+      - haproxy_runtime:/var/run/haproxy
     networks:
       - gp_internal
 
@@ -84,7 +85,12 @@ services:
 
   haproxy:
     image: haproxy:3.0-alpine
-    command: ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]
+    command:
+      [
+        "sh",
+        "-c",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+      ]
     restart: unless-stopped
     depends_on:
       backend:
@@ -97,9 +103,10 @@ services:
       - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
       - haproxy_logs:/var/log/haproxy
-      - generated_config:/etc/haproxy/generated:ro
+      - generated_config:/etc/haproxy/generated
+      - haproxy_runtime:/var/run/haproxy
     healthcheck:
-      test: ["CMD-SHELL", "haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg"]
+      test: ["CMD-SHELL", "haproxy -c -f /etc/haproxy/generated/current/haproxy.cfg"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -116,6 +123,7 @@ networks:
 volumes:
   pgdata:
   haproxy_logs:
+  haproxy_runtime:
   coraza_logs:
   backend_logs:
   generated_config:

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -35,6 +35,13 @@ DEBUG=false
 # Optional frontend origins for local development
 # CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
+# Optional runtime config apply settings (issue #112)
+# RUNTIME_GENERATED_CONFIG_ROOT=/var/lib/guard-proxy/generated
+# HAPROXY_VALIDATION_BINARY=haproxy
+# HAPROXY_VALIDATION_TIMEOUT_SECONDS=10
+# HAPROXY_MASTER_SOCKET_PATH=/var/run/haproxy/master.sock
+# HAPROXY_RELOAD_TIMEOUT_SECONDS=10
+
 # Optional: used by scripts/seed_admin.py
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASSWORD=change-me-please

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -23,6 +23,10 @@ RUN groupadd --system app && useradd --system --gid app --home-dir /app --no-cre
 WORKDIR /app
 RUN chown app:app /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends haproxy \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 COPY --chown=app:app alembic alembic
 COPY --chown=app:app app app

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -71,11 +71,37 @@ class Settings(EnvFileSettings):
     # Database
     database_url: str = "sqlite:///./guard_proxy.db"
     debug: bool = False
+    runtime_generated_config_root: str = "/var/lib/guard-proxy/generated"
+    haproxy_validation_binary: str = "haproxy"
+    haproxy_validation_timeout_seconds: int = 10
+    haproxy_master_socket_path: str = "/var/run/haproxy/master.sock"
+    haproxy_reload_timeout_seconds: int = 10
 
     @field_validator("database_url")
     @classmethod
     def database_url_must_not_be_empty(cls, value: str) -> str:
         return _validate_database_url(value)
+
+    @field_validator(
+        "runtime_generated_config_root",
+        "haproxy_validation_binary",
+        "haproxy_master_socket_path",
+    )
+    @classmethod
+    def runtime_paths_must_not_be_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Runtime path settings must not be empty.")
+        return value
+
+    @field_validator(
+        "haproxy_validation_timeout_seconds",
+        "haproxy_reload_timeout_seconds",
+    )
+    @classmethod
+    def timeout_settings_must_be_positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("Runtime timeout settings must be greater than zero.")
+        return value
 
     # JWT
     jwt_secret_key: str

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -1,0 +1,272 @@
+"""Apply generated runtime config with validation, reload, and rollback."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import uuid
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from app.config import settings
+from app.services.config_generator import GeneratedConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ApplyStatus(StrEnum):
+    """Outcome classes for config apply attempts."""
+
+    success = "success"
+    validation_failed = "validation_failed"
+    reload_failed_rolled_back = "reload_failed_rolled_back"
+    rollback_failed = "rollback_failed"
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Structured result for one config apply attempt."""
+
+    status: ApplyStatus
+    correlation_id: str
+    checksum: str
+    message: str
+    candidate_path: str
+    active_path: str | None
+    validation_output: str | None = None
+    reload_output: str | None = None
+    rollback_output: str | None = None
+
+
+def apply(generated: GeneratedConfig) -> ApplyResult:
+    """Validate and atomically activate generated runtime config."""
+    correlation_id = uuid.uuid4().hex
+    checksum = _calculate_checksum(generated)
+    runtime_root = Path(settings.runtime_generated_config_root).resolve()
+    releases_root = runtime_root / "releases"
+    candidate_dir = releases_root / correlation_id
+    current_link = runtime_root / "current"
+    previous_target = _read_current_symlink(current_link)
+
+    logger.info(
+        "config-apply start correlation_id=%s checksum=%s",
+        correlation_id,
+        checksum,
+    )
+
+    try:
+        _write_candidate(candidate_dir, generated)
+    except OSError as error:
+        logger.exception(
+            "config-apply write failed correlation_id=%s error=%s",
+            correlation_id,
+            error,
+        )
+        return ApplyResult(
+            status=ApplyStatus.rollback_failed,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message=f"Failed to prepare candidate files: {error}",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+        )
+
+    validation = _validate_haproxy(candidate_dir / "haproxy.cfg")
+    if not validation.ok:
+        logger.warning(
+            "config-apply validation failed correlation_id=%s output=%s",
+            correlation_id,
+            validation.output,
+        )
+        return ApplyResult(
+            status=ApplyStatus.validation_failed,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message="HAProxy config validation failed.",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+            validation_output=validation.output,
+        )
+
+    _swap_current_link(current_link, candidate_dir, runtime_root)
+
+    reload_result = _reload_haproxy()
+    if reload_result.ok:
+        logger.info("config-apply success correlation_id=%s", correlation_id)
+        return ApplyResult(
+            status=ApplyStatus.success,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message="Configuration applied and HAProxy reloaded successfully.",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+            validation_output=validation.output,
+            reload_output=reload_result.output,
+        )
+
+    logger.error(
+        "config-apply reload failed correlation_id=%s output=%s",
+        correlation_id,
+        reload_result.output,
+    )
+
+    if previous_target is None:
+        return ApplyResult(
+            status=ApplyStatus.rollback_failed,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message="Reload failed and no previous release exists for rollback.",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+            validation_output=validation.output,
+            reload_output=reload_result.output,
+        )
+
+    _swap_current_link(current_link, previous_target, runtime_root)
+    rollback_reload = _reload_haproxy()
+    if rollback_reload.ok:
+        logger.warning(
+            "config-apply rolled back correlation_id=%s rollback_output=%s",
+            correlation_id,
+            rollback_reload.output,
+        )
+        return ApplyResult(
+            status=ApplyStatus.reload_failed_rolled_back,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message="Reload failed; previous release restored and reloaded.",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+            validation_output=validation.output,
+            reload_output=reload_result.output,
+            rollback_output=rollback_reload.output,
+        )
+
+    logger.critical(
+        "config-apply rollback reload failed correlation_id=%s output=%s",
+        correlation_id,
+        rollback_reload.output,
+    )
+    return ApplyResult(
+        status=ApplyStatus.rollback_failed,
+        correlation_id=correlation_id,
+        checksum=checksum,
+        message="Reload failed and rollback reload also failed.",
+        candidate_path=str(candidate_dir),
+        active_path=str(_resolve_current(current_link)),
+        validation_output=validation.output,
+        reload_output=reload_result.output,
+        rollback_output=rollback_reload.output,
+    )
+
+
+@dataclass(frozen=True)
+class _CommandResult:
+    ok: bool
+    output: str
+
+
+def _write_candidate(candidate_dir: Path, generated: GeneratedConfig) -> None:
+    candidate_dir.mkdir(parents=True, exist_ok=False)
+    (candidate_dir / "haproxy.cfg").write_text(generated.haproxy_cfg, encoding="utf-8")
+    (candidate_dir / "crs-setup.conf").write_text(
+        generated.crs_setup_conf,
+        encoding="utf-8",
+    )
+    (candidate_dir / "rule-overrides.conf").write_text(
+        generated.rule_overrides_conf,
+        encoding="utf-8",
+    )
+
+
+def _validate_haproxy(config_path: Path) -> _CommandResult:
+    try:
+        result = subprocess.run(
+            [
+                settings.haproxy_validation_binary,
+                "-c",
+                "-f",
+                str(config_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=settings.haproxy_validation_timeout_seconds,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return _CommandResult(ok=False, output=str(error))
+
+    output = _join_output(result.stdout, result.stderr)
+    return _CommandResult(ok=result.returncode == 0, output=output)
+
+
+def _reload_haproxy() -> _CommandResult:
+    socket_path = settings.haproxy_master_socket_path
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(settings.haproxy_reload_timeout_seconds)
+            client.connect(socket_path)
+            client.sendall(b"reload\n")
+            client.shutdown(socket.SHUT_WR)
+            output_chunks: list[bytes] = []
+            while True:
+                chunk = client.recv(4096)
+                if not chunk:
+                    break
+                output_chunks.append(chunk)
+    except OSError as error:
+        return _CommandResult(ok=False, output=str(error))
+
+    output = b"".join(output_chunks).decode("utf-8", errors="replace").strip()
+    output_lower = output.lower()
+    is_success = "success" in output_lower and "fail" not in output_lower
+    return _CommandResult(ok=is_success, output=output)
+
+
+def _swap_current_link(current_link: Path, target: Path, runtime_root: Path) -> None:
+    relative_target = os.path.relpath(target, start=runtime_root)
+    temp_link = runtime_root / f".current-{uuid.uuid4().hex}.tmp"
+    temp_link.symlink_to(relative_target)
+    os.replace(temp_link, current_link)
+
+
+def _read_current_symlink(current_link: Path) -> Path | None:
+    if not current_link.exists() and not current_link.is_symlink():
+        return None
+
+    if current_link.is_symlink():
+        return _resolve_current(current_link)
+
+    backup_dir = current_link.with_name(f"current-backup-{uuid.uuid4().hex}")
+    shutil.move(str(current_link), str(backup_dir))
+    current_link.symlink_to(os.path.relpath(backup_dir, start=current_link.parent))
+    return backup_dir.resolve()
+
+
+def _resolve_current(current_link: Path) -> Path | None:
+    if not current_link.exists() and not current_link.is_symlink():
+        return None
+    try:
+        return current_link.resolve(strict=True)
+    except OSError:
+        return None
+
+
+def _calculate_checksum(generated: GeneratedConfig) -> str:
+    digest = hashlib.sha256()
+    digest.update(generated.haproxy_cfg.encode("utf-8"))
+    digest.update(b"\n---\n")
+    digest.update(generated.crs_setup_conf.encode("utf-8"))
+    digest.update(b"\n---\n")
+    digest.update(generated.rule_overrides_conf.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _join_output(stdout: str, stderr: str) -> str:
+    combined = "\n".join(part.strip() for part in (stdout, stderr) if part.strip())
+    return combined or "<no output>"

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -217,3 +217,24 @@ def test_settings_ignore_dot_env_example(
     assert (
         getattr(settings, "log_ingest_shared_secret") == "real-log-secret-from-dot-env"
     )
+
+
+def test_settings_reject_empty_haproxy_master_socket_path() -> None:
+    with pytest.raises(ValidationError, match="Runtime path settings must not be empty"):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            HAPROXY_MASTER_SOCKET_PATH="   ",
+        )
+
+
+def test_settings_reject_non_positive_reload_timeout() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="Runtime timeout settings must be greater than zero",
+    ):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            HAPROXY_RELOAD_TIMEOUT_SECONDS="0",
+        )

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from app.config import settings
+from app.services.config_apply import (
+    ApplyStatus,
+    _CommandResult,
+    apply,
+)
+from app.services.config_generator import GeneratedConfig
+
+
+def _sample_generated() -> GeneratedConfig:
+    return GeneratedConfig(
+        haproxy_cfg="global\n",
+        crs_setup_conf="SecRuleEngine On\n",
+        rule_overrides_conf="# no overrides\n",
+    )
+
+
+def _seed_current_release(runtime_root: Path, *, name: str = "previous") -> Path:
+    releases = runtime_root / "releases"
+    release_dir = releases / name
+    release_dir.mkdir(parents=True, exist_ok=True)
+    (release_dir / "haproxy.cfg").write_text("global\n", encoding="utf-8")
+    (release_dir / "crs-setup.conf").write_text("SecRuleEngine On\n", encoding="utf-8")
+    (release_dir / "rule-overrides.conf").write_text("# seed\n", encoding="utf-8")
+    current = runtime_root / "current"
+    current.parent.mkdir(parents=True, exist_ok=True)
+    current.symlink_to("releases/" + name)
+    return release_dir
+
+
+def test_apply_success_writes_files_and_switches_current(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: _CommandResult(ok=True, output="Configuration file is valid"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: _CommandResult(ok=True, output="Reload succeeded"),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.success
+    assert len(result.correlation_id) == 32
+
+    current = runtime_root / "current"
+    assert current.is_symlink()
+    active_dir = current.resolve()
+    assert active_dir == Path(result.active_path)
+    assert (active_dir / "haproxy.cfg").read_text(encoding="utf-8") == "global\n"
+    assert (
+        (active_dir / "crs-setup.conf").read_text(encoding="utf-8")
+        == "SecRuleEngine On\n"
+    )
+
+
+def test_apply_validation_failure_keeps_current_unchanged(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    previous = _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: _CommandResult(ok=False, output="line 42 parse error"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: _CommandResult(ok=True, output="should not run"),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.validation_failed
+    assert "parse error" in (result.validation_output or "")
+    assert (runtime_root / "current").resolve() == previous.resolve()
+
+
+def test_apply_reload_failure_rolls_back_to_previous_release(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    previous = _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: _CommandResult(ok=True, output="valid"),
+    )
+
+    reload_results = iter(
+        [
+            _CommandResult(ok=False, output="reload failed"),
+            _CommandResult(ok=True, output="rollback reload ok"),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: next(reload_results),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.reload_failed_rolled_back
+    assert (runtime_root / "current").resolve() == previous.resolve()
+    assert "reload failed" in (result.reload_output or "")
+    assert "rollback reload ok" in (result.rollback_output or "")
+
+
+def test_apply_reports_rollback_failed_when_second_reload_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    previous = _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: _CommandResult(ok=True, output="valid"),
+    )
+
+    reload_results = iter(
+        [
+            _CommandResult(ok=False, output="reload failed"),
+            _CommandResult(ok=False, output="rollback reload failed"),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: next(reload_results),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.rollback_failed
+    assert (runtime_root / "current").resolve() == previous.resolve()
+    assert "rollback reload failed" in (result.rollback_output or "")
+
+
+def test_apply_logs_attempt_with_correlation_id(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: _CommandResult(ok=True, output="valid"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: _CommandResult(ok=True, output="reload ok"),
+    )
+    caplog.set_level(logging.INFO, logger="app.services.config_apply")
+
+    result = apply(_sample_generated())
+
+    start_record = next(
+        (record for record in caplog.records if "config-apply start" in record.message),
+        None,
+    )
+    assert start_record is not None
+    assert result.correlation_id in start_record.message

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -52,10 +52,8 @@ def test_debug_coraza_spoa_config_enables_debug_logging() -> None:
 def test_debug_compose_override_enables_haproxy_debug_flag() -> None:
     compose = (REPO_ROOT / "deploy/docker/docker-compose.debug.yml").read_text()
 
-    assert (
-        'command: ["haproxy", "-d", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]'
-        in compose
-    )
+    assert "exec haproxy -d -W -S /var/run/haproxy/master.sock" in compose
+    assert "-f /etc/haproxy/generated/current/haproxy.cfg" in compose
 
 
 def test_debug_compose_override_mounts_debug_coraza_config() -> None:


### PR DESCRIPTION
## Summary

- Add `src/backend/app/services/config_apply.py` with generated-config apply, `haproxy -c` validation, atomic `current` swap, native master-socket reload, and rollback flow.
- Wire runtime settings and Docker compose paths so HAProxy runs from generated config and exposes a shared master socket for backend-driven reload.
- Add unit tests for config apply outcomes and update related config/debug compose tests.
- Closes #112.

## Testing

- [x] `cd src/backend && uv sync --frozen --extra dev`
- [x] `cd src/backend && uv run pytest --cov=app`
- [x] `cd src/backend && uv run mypy app/`
- [x] `cd src/backend && uv run ruff check app/`
- [x] `cd src/frontend && pnpm install --frozen-lockfile`
- [x] `cd src/frontend && pnpm run type-check`
- [x] `cd src/frontend && pnpm run lint`