### PR TITLE
fix(config-apply): fix spurious rollbacks, disk leak, and misleading status

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -31,7 +31,14 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+    && curl -fsSL https://haproxy.debian.net/bernat.debian.org.gpg \
+       | gpg --dearmor > /etc/apt/trusted.gpg.d/haproxy.gpg \
+    && printf "deb [signed-by=/etc/apt/trusted.gpg.d/haproxy.gpg] http://haproxy.debian.net bookworm-backports-3.0 main\n" \
+       > /etc/apt/sources.list.d/haproxy.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends haproxy \
+    && apt-get purge -y ca-certificates curl gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder --chown=app:app /app/.venv /app/.venv

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -23,6 +23,7 @@ class ApplyStatus(StrEnum):
     """Outcome classes for config apply attempts."""
 
     success = "success"
+    write_failed = "write_failed"
     validation_failed = "validation_failed"
     reload_failed_rolled_back = "reload_failed_rolled_back"
     rollback_failed = "rollback_failed"
@@ -68,7 +69,7 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
             error,
         )
         return ApplyResult(
-            status=ApplyStatus.rollback_failed,
+            status=ApplyStatus.write_failed,
             correlation_id=correlation_id,
             checksum=checksum,
             message=f"Failed to prepare candidate files: {error}",
@@ -78,6 +79,7 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
 
     validation = _validate_haproxy(candidate_dir / "haproxy.cfg")
     if not validation.ok:
+        shutil.rmtree(candidate_dir, ignore_errors=True)
         logger.warning(
             "config-apply validation failed correlation_id=%s output=%s",
             correlation_id,
@@ -166,7 +168,7 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
 
 
 @dataclass(frozen=True)
-class _CommandResult:
+class CommandResult:
     ok: bool
     output: str
 
@@ -184,7 +186,7 @@ def _write_candidate(candidate_dir: Path, generated: GeneratedConfig) -> None:
     )
 
 
-def _validate_haproxy(config_path: Path) -> _CommandResult:
+def _validate_haproxy(config_path: Path) -> CommandResult:
     try:
         result = subprocess.run(
             [
@@ -199,13 +201,13 @@ def _validate_haproxy(config_path: Path) -> _CommandResult:
             timeout=settings.haproxy_validation_timeout_seconds,
         )
     except (OSError, subprocess.TimeoutExpired) as error:
-        return _CommandResult(ok=False, output=str(error))
+        return CommandResult(ok=False, output=str(error))
 
     output = _join_output(result.stdout, result.stderr)
-    return _CommandResult(ok=result.returncode == 0, output=output)
+    return CommandResult(ok=result.returncode == 0, output=output)
 
 
-def _reload_haproxy() -> _CommandResult:
+def _reload_haproxy() -> CommandResult:
     socket_path = settings.haproxy_master_socket_path
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
@@ -220,12 +222,13 @@ def _reload_haproxy() -> _CommandResult:
                     break
                 output_chunks.append(chunk)
     except OSError as error:
-        return _CommandResult(ok=False, output=str(error))
+        return CommandResult(ok=False, output=str(error))
 
     output = b"".join(output_chunks).decode("utf-8", errors="replace").strip()
     output_lower = output.lower()
-    is_success = "success" in output_lower and "fail" not in output_lower
-    return _CommandResult(ok=is_success, output=output)
+    _error_keywords = ("error", "fail", "denied", "permission")
+    is_error = any(kw in output_lower for kw in _error_keywords)
+    return CommandResult(ok=not is_error, output=output)
 
 
 def _swap_current_link(current_link: Path, target: Path, runtime_root: Path) -> None:

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from app.config import settings
 from app.services.config_apply import (
     ApplyStatus,
-    _CommandResult,
+    CommandResult,
     apply,
 )
 from app.services.config_generator import GeneratedConfig
@@ -41,11 +41,11 @@ def test_apply_success_writes_files_and_switches_current(
     monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
     monkeypatch.setattr(
         "app.services.config_apply._validate_haproxy",
-        lambda _: _CommandResult(ok=True, output="Configuration file is valid"),
+        lambda _: CommandResult(ok=True, output="Configuration file is valid"),
     )
     monkeypatch.setattr(
         "app.services.config_apply._reload_haproxy",
-        lambda: _CommandResult(ok=True, output="Reload succeeded"),
+        lambda: CommandResult(ok=True, output="Reload succeeded"),
     )
 
     result = apply(_sample_generated())
@@ -73,11 +73,11 @@ def test_apply_validation_failure_keeps_current_unchanged(
     monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
     monkeypatch.setattr(
         "app.services.config_apply._validate_haproxy",
-        lambda _: _CommandResult(ok=False, output="line 42 parse error"),
+        lambda _: CommandResult(ok=False, output="line 42 parse error"),
     )
     monkeypatch.setattr(
         "app.services.config_apply._reload_haproxy",
-        lambda: _CommandResult(ok=True, output="should not run"),
+        lambda: CommandResult(ok=True, output="should not run"),
     )
 
     result = apply(_sample_generated())
@@ -96,13 +96,13 @@ def test_apply_reload_failure_rolls_back_to_previous_release(
     monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
     monkeypatch.setattr(
         "app.services.config_apply._validate_haproxy",
-        lambda _: _CommandResult(ok=True, output="valid"),
+        lambda _: CommandResult(ok=True, output="valid"),
     )
 
     reload_results = iter(
         [
-            _CommandResult(ok=False, output="reload failed"),
-            _CommandResult(ok=True, output="rollback reload ok"),
+            CommandResult(ok=False, output="reload failed"),
+            CommandResult(ok=True, output="rollback reload ok"),
         ]
     )
     monkeypatch.setattr(
@@ -127,13 +127,13 @@ def test_apply_reports_rollback_failed_when_second_reload_fails(
     monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
     monkeypatch.setattr(
         "app.services.config_apply._validate_haproxy",
-        lambda _: _CommandResult(ok=True, output="valid"),
+        lambda _: CommandResult(ok=True, output="valid"),
     )
 
     reload_results = iter(
         [
-            _CommandResult(ok=False, output="reload failed"),
-            _CommandResult(ok=False, output="rollback reload failed"),
+            CommandResult(ok=False, output="reload failed"),
+            CommandResult(ok=False, output="rollback reload failed"),
         ]
     )
     monkeypatch.setattr(
@@ -148,6 +148,25 @@ def test_apply_reports_rollback_failed_when_second_reload_fails(
     assert "rollback reload failed" in (result.rollback_output or "")
 
 
+def test_apply_write_failure_returns_write_failed_and_leaves_current_unchanged(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    previous = _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._write_candidate",
+        lambda *_: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.write_failed
+    assert "disk full" in result.message
+    assert (runtime_root / "current").resolve() == previous.resolve()
+
+
 def test_apply_logs_attempt_with_correlation_id(
     tmp_path: Path,
     monkeypatch,
@@ -157,11 +176,11 @@ def test_apply_logs_attempt_with_correlation_id(
     monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
     monkeypatch.setattr(
         "app.services.config_apply._validate_haproxy",
-        lambda _: _CommandResult(ok=True, output="valid"),
+        lambda _: CommandResult(ok=True, output="valid"),
     )
     monkeypatch.setattr(
         "app.services.config_apply._reload_haproxy",
-        lambda: _CommandResult(ok=True, output="reload ok"),
+        lambda: CommandResult(ok=True, output="reload ok"),
     )
     caplog.set_level(logging.INFO, logger="app.services.config_apply")
 


### PR DESCRIPTION
## Summary

Post-merge fixes for issues found during code review of #185.

- **Spurious rollbacks on every apply**: `_reload_haproxy` matched on the string `"success"` which HAProxy's master socket never returns (it sends process info like `[1] (SIGTERM->MASTER)`). Every valid reload was treated as a failure and rolled back. Fixed by flipping to a negative match on known error keywords (`error`, `fail`, `denied`, `permission`).
- **Disk leak on validation failure**: candidate directories under `releases/<correlation_id>/` were left on disk after `validation_failed`. Added `shutil.rmtree(candidate_dir, ignore_errors=True)` before returning that status.
- **Misleading `rollback_failed` status for write errors**: when `_write_candidate` raises `OSError`, the old code returned `rollback_failed`, which implies HAProxy is in an unknown state — it isn't, since `current` was never modified. Added a new `ApplyStatus.write_failed` status for this path.
- **HAProxy version mismatch in backend Dockerfile**: `apt-get install haproxy` on Debian bookworm installs ~2.6, while `docker-compose.yml` uses `haproxy:3.0-alpine`. Config syntax differences between versions could cause the validation step to give wrong results. Fixed by pulling from the official HAProxy 3.0 Debian backport repo (`haproxy.debian.net/bookworm-backports-3.0`).
- **`_CommandResult` leaked into tests as private symbol**: renamed to `CommandResult`.

## Test plan

- [x] All 285 existing tests pass (`uv run pytest`)
- [x] New test `test_apply_write_failure_returns_write_failed_and_leaves_current_unchanged` added and passing
- [x] `uv run mypy app/services/config_apply.py` — no issues
- [x] `uv run ruff check app/services/config_apply.py` — no issues