### PR TITLE
fix(smoke): repair generated_config volume wiring broken in ce8a9d3

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - .env
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
-      GUARD_PROXY_RUNTIME_DIR: /runtime
+      GUARD_PROXY_RUNTIME_DIR: /var/lib/guard-proxy/generated
     depends_on:
       postgres:
         condition: service_healthy
@@ -127,4 +127,4 @@ volumes:
   haproxy_runtime:
   coraza_logs:
   backend_logs:
-  guard_proxy_runtime:
+  generated_config:

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 RUN groupadd --system app && useradd --system --gid app --home-dir /app --no-create-home --shell /usr/sbin/nologin app
 
 WORKDIR /app
-RUN mkdir -p /runtime/crs && chown app:app /app /runtime /runtime/crs
+RUN mkdir -p /var/lib/guard-proxy/generated/crs && chown app:app /app /var/lib/guard-proxy/generated /var/lib/guard-proxy/generated/crs
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary

- **Bug 1 (critical):** top-level `volumes:` declared `guard_proxy_runtime:` while both `backend` and `haproxy` services referenced `generated_config:`. Docker Compose v2 refuses to start on an undeclared volume — no container could start at all, explaining the 8-day smoke-test outage.
- **Bug 2:** `GUARD_PROXY_RUNTIME_DIR: /runtime` in the backend environment pointed `docker-entrypoint.sh` at `/runtime`, but the `generated_config` volume is mounted at `/var/lib/guard-proxy/generated`. The entrypoint was chown-ing the wrong path, leaving the real volume root-owned and unwritable by the `app` user.
- **Bug 3:** The `Dockerfile` pre-created `/runtime/crs` (old path) instead of `/var/lib/guard-proxy/generated/crs`, which `config.py` and the compose mount both point to.

All three regressions were introduced when `ce8a9d3` (feat: config apply service with rollback) landed — the service-level volume references were updated to `generated_config` but the top-level declaration, entrypoint env var, and Dockerfile directory creation were not.

## Files changed

| File | Change |
|------|--------|
| `deploy/docker/docker-compose.yml` | Rename `guard_proxy_runtime:` to `generated_config:` in volumes section; align `GUARD_PROXY_RUNTIME_DIR` with actual mount path |
| `src/backend/Dockerfile` | Pre-create `/var/lib/guard-proxy/generated/crs` instead of `/runtime/crs` |

## Test plan

- [x] Run `bash benchmarks/smoke/e2e.sh` (after `cp deploy/docker/.env.example deploy/docker/.env`) — expect `E2E smoke test passed.`
- [x] Trigger the **E2E Smoke** workflow via `workflow_dispatch` and confirm the `e2e-smoke` job is green