### PR TITLE
fix(smoke): repair generated_config volume wiring broken in ce8a9d3

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - .env
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
-      GUARD_PROXY_RUNTIME_DIR: /runtime
+      GUARD_PROXY_RUNTIME_DIR: /var/lib/guard-proxy/generated
     depends_on:
       postgres:
         condition: service_healthy
@@ -127,4 +127,4 @@ volumes:
   haproxy_runtime:
   coraza_logs:
   backend_logs:
-  guard_proxy_runtime:
+  generated_config:

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 RUN groupadd --system app && useradd --system --gid app --home-dir /app --no-create-home --shell /usr/sbin/nologin app
 
 WORKDIR /app
-RUN mkdir -p /runtime/crs && chown app:app /app /runtime /runtime/crs
+RUN mkdir -p /var/lib/guard-proxy/generated/crs && chown app:app /app /var/lib/guard-proxy/generated /var/lib/guard-proxy/generated/crs
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary

Three inconsistencies introduced when the config-apply feature was merged prevented the e2e smoke test from running for ~8 days:

1. docker-compose.yml declared `guard_proxy_runtime` in the top-level volumes section while both `backend` and `haproxy` services referenced `generated_config`.  Docker Compose v2 refuses to start on an undeclared volume, so no container could start at all.

2. The backend environment still set GUARD_PROXY_RUNTIME_DIR=/runtime, but the generated_config volume is mounted at /var/lib/guard-proxy/generated. The entrypoint was chowning the wrong path, leaving the real volume root-owned and unwritable by the app user.

3. The Dockerfile pre-created /runtime/crs (the old path) instead of the directory the app actually uses.