### PR TITLE
feat(coraza): replace Docker socket reload with inotify supervisor

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -17,7 +17,8 @@ graph TB
     BE --> DB[(PostgreSQL)]
     BE -.->|writes generated runtime config| RV[(guard_proxy_runtime)]
     RV -.->|read-only mount| H
-    RV -.->|future CRS artifacts| CS
+    RV -.->|read-only rule overrides| CS
+    CS -.->|inotify watches /runtime| CS
 ```
 
 ## Request Flow
@@ -70,8 +71,15 @@ machine-readable degraded reason header.
 ### Policy Management
 1. Admin users manage vhosts, policies, and rule overrides through the React UI and FastAPI API.
 2. FastAPI persists control-plane state in PostgreSQL.
-3. M1 stores policy data but still uses hand-written HAProxy and Coraza reference configuration.
-4. FastAPI writes generated runtime config into the shared `guard_proxy_runtime` volume. HAProxy mounts that volume read-only at `/runtime`; validation, graceful reloads, rollback, and richer per-vhost runtime policy wiring are future M2 work.
+3. FastAPI writes generated runtime config into the shared
+   `guard_proxy_runtime` volume.
+4. HAProxy reads the active generated `haproxy.cfg` from the volume and reloads
+   through its Runtime API socket when `POST /config/apply` succeeds.
+5. Coraza reads the active generated `rule-overrides.conf` from the same volume
+   after CRS rules are loaded. The Coraza container runs an inotify supervisor
+   that watches the `/runtime` directory; when the backend atomically swaps the
+   `current` symlink, the supervisor detects the change and restarts
+   `coraza-spoa` automatically — no Docker socket access required.
 
 ### Runtime Event Ingestion
 1. Runtime WAF events can be represented as structured log payloads.
@@ -105,22 +113,32 @@ tears the stack down.
 ### Shared Runtime Volume
 
 Generated runtime artifacts live in the Docker named volume
-`guard_proxy_runtime`. The backend mounts it read-write at `/runtime`, while
-HAProxy mounts the same volume read-only at `/runtime`.
+`guard_proxy_runtime`. The backend mounts it read-write at
+`/var/lib/guard-proxy/generated`, HAProxy mounts the same volume at
+`/etc/haproxy/generated`, and Coraza mounts it read-only at `/runtime`.
 
-The reserved layout for future generated artifacts is:
+The active release is selected through the `current` symlink:
 
 ```text
-/runtime/
-  haproxy.cfg  # generated HAProxy config
-  crs/         # generated CRS artifacts
+/runtime/current/
+  haproxy.cfg           # generated HAProxy config
+  crs-setup.conf        # generated CRS setup snapshot
+  rule-overrides.conf   # generated CRS rule removals
 ```
 
-The backend container starts as root only long enough to create `/runtime/crs`,
-assign the mounted volume to the non-root `app` user, and then drops privileges
-before running migrations and Uvicorn. HAProxy continues to boot from the
-checked-in seed config in `configs/haproxy/haproxy.cfg` until generated config
-deployment and reload orchestration are enabled.
+The backend container starts as root only long enough to create and seed
+Coraza's generated rule override include, assign the runtime volume to the
+non-root `app` user, and then drops privileges before running migrations and
+Uvicorn. HAProxy copies the checked-in reference config into the same seed
+release when no generated `haproxy.cfg` exists yet.
+
+The Coraza container image is built on `alpine:3.19` with `tini` as PID 1 and
+`inotify-tools` installed. A shell supervisor (`coraza-supervisor.sh`) starts
+`coraza-spoa` as a child process and calls `inotifywait` in a loop. When the
+backend performs an atomic `os.replace` of the `current` symlink, the supervisor
+detects the `moved_to` or `create` event for `current` and restarts
+`coraza-spoa` — picking up the new `rule-overrides.conf` without any external
+signal or Docker socket access.
 
 ## Key Decisions
 

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -138,7 +138,10 @@ The Coraza container image is built on `alpine:3.19` with `tini` as PID 1 and
 backend performs an atomic `os.replace` of the `current` symlink, the supervisor
 detects the `moved_to` or `create` event for `current` and restarts
 `coraza-spoa` — picking up the new `rule-overrides.conf` without any external
-signal or Docker socket access.
+signal or Docker socket access. Note that this is a full process restart, not a
+hot-reload: port 9000 is briefly unavailable (~sub-second) during the restart,
+causing HAProxy SPOE to return an error for any request that lands in that
+window. This is acceptable for a manual rule-apply operation.
 
 ## Key Decisions
 

--- a/configs/coraza/coraza.conf
+++ b/configs/coraza/coraza.conf
@@ -20,3 +20,4 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 Include /etc/coraza/crs-setup.conf
 Include /etc/coraza/crs/rules/*.conf
+Include /runtime/current/rule-overrides.conf

--- a/deploy/docker/coraza-supervisor.sh
+++ b/deploy/docker/coraza-supervisor.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+SPOA_BIN=/usr/local/bin/coraza-spoa
+SPOA_CONFIG=/etc/coraza-spoa/coraza-spoa.yaml
+RUNTIME_DIR=/runtime
+SPOA_PID=""
+
+start_spoa() {
+    "$SPOA_BIN" -config "$SPOA_CONFIG" &
+    SPOA_PID=$!
+}
+
+stop_spoa() {
+    [ -n "$SPOA_PID" ] || return 0
+    kill -TERM "$SPOA_PID" 2>/dev/null || true
+    wait "$SPOA_PID" 2>/dev/null || true
+    SPOA_PID=""
+}
+
+on_term() {
+    stop_spoa
+    exit 143
+}
+
+trap on_term TERM INT
+
+start_spoa
+
+while changed=$(inotifywait -q -e moved_to,create --format '%f' "$RUNTIME_DIR"); do
+    [ "$changed" = "current" ] || continue
+    echo "[supervisor] current symlink changed — restarting coraza-spoa" >&2
+    stop_spoa
+    start_spoa
+done
+
+# inotifywait exited unexpectedly — let Compose restart the container
+stop_spoa
+exit 1

--- a/deploy/docker/coraza.Dockerfile
+++ b/deploy/docker/coraza.Dockerfile
@@ -13,8 +13,14 @@ COPY configs/coraza/crs-setup.conf /etc/coraza/crs-setup.conf
 COPY configs/coraza/crs /etc/coraza/crs
 COPY deploy/docker/coraza-supervisor.sh /usr/local/bin/coraza-supervisor
 
-RUN chmod +x /usr/local/bin/coraza-supervisor \
-    && /usr/local/bin/coraza-spoa -h >/dev/null 2>&1 || true
+RUN addgroup -S coraza && adduser -S -G coraza coraza
+
+RUN chmod +x /usr/local/bin/coraza-supervisor
+# Verify the binary is executable; fails the build if the upstream image
+# switches to a dynamically-linked binary that can't run on musl/alpine.
+RUN /usr/local/bin/coraza-spoa --version >/dev/null
+
+USER coraza
 
 EXPOSE 9000
 

--- a/deploy/docker/coraza.Dockerfile
+++ b/deploy/docker/coraza.Dockerfile
@@ -1,16 +1,21 @@
 # Coraza SPOA image: ghcr.io/corazawaf/coraza-spoa:0.6.1
 # OWASP Core Rule Set: v4.25.0 (pinned via configs/coraza/crs submodule)
-FROM busybox:1.37.0-musl AS busybox
+FROM ghcr.io/corazawaf/coraza-spoa:0.6.1 AS upstream
 
-FROM ghcr.io/corazawaf/coraza-spoa:0.6.1
+FROM alpine:3.19
 
-COPY --from=busybox /bin/busybox /bin/busybox
+RUN apk add --no-cache inotify-tools tini
+
+COPY --from=upstream /coraza-spoa /usr/local/bin/coraza-spoa
 COPY configs/coraza/coraza-spoa.yaml /etc/coraza-spoa/coraza-spoa.yaml
 COPY configs/coraza/coraza.conf /etc/coraza/coraza.conf
 COPY configs/coraza/crs-setup.conf /etc/coraza/crs-setup.conf
 COPY configs/coraza/crs /etc/coraza/crs
+COPY deploy/docker/coraza-supervisor.sh /usr/local/bin/coraza-supervisor
+
+RUN chmod +x /usr/local/bin/coraza-supervisor \
+    && /usr/local/bin/coraza-spoa -h >/dev/null 2>&1 || true
 
 EXPOSE 9000
 
-ENTRYPOINT ["/coraza-spoa"]
-CMD ["-config", "/etc/coraza-spoa/coraza-spoa.yaml"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/coraza-supervisor"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       retries: 10
     volumes:
       - backend_logs:/var/log/guard-proxy
+      - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
       - generated_config:/var/lib/guard-proxy/generated
       - haproxy_runtime:/var/run/haproxy
     networks:
@@ -70,14 +71,18 @@ services:
       context: ../..
       dockerfile: deploy/docker/coraza.Dockerfile
     restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
     volumes:
       - coraza_logs:/var/log/coraza
       - ../../configs/coraza/coraza-spoa.yaml:/etc/coraza-spoa/coraza-spoa.yaml:ro
       - ../../configs/coraza/coraza.conf:/etc/coraza/coraza.conf:ro
       - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
       - ../../configs/coraza/crs:/etc/coraza/crs:ro
+      - generated_config:/runtime:ro
     healthcheck:
-      test: ["CMD", "/bin/busybox", "nc", "-z", "127.0.0.1", "9000"]
+      test: ["CMD", "nc", "-z", "127.0.0.1", "9000"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -86,11 +91,12 @@ services:
 
   haproxy:
     image: haproxy:3.0-alpine
+    user: "0:0"
     command:
       [
         "sh",
         "-c",
-        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
       ]
     restart: unless-stopped
     depends_on:

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -76,7 +76,6 @@ class Settings(EnvFileSettings):
     haproxy_validation_timeout_seconds: int = 10
     haproxy_master_socket_path: str = "/var/run/haproxy/master.sock"
     haproxy_reload_timeout_seconds: int = 10
-
     @field_validator("database_url")
     @classmethod
     def database_url_must_not_be_empty(cls, value: str) -> str:

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -99,7 +99,10 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
 
     reload_result = _reload_haproxy()
     if reload_result.ok:
-        logger.info("config-apply success correlation_id=%s", correlation_id)
+        logger.info(
+            "config-apply success correlation_id=%s",
+            correlation_id,
+        )
         return ApplyResult(
             status=ApplyStatus.success,
             correlation_id=correlation_id,

--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -3,8 +3,22 @@ set -eu
 
 runtime_dir="${GUARD_PROXY_RUNTIME_DIR:-/runtime}"
 
+seed_runtime_config() {
+    if [ ! -f "${runtime_dir}/current/rule-overrides.conf" ]; then
+        mkdir -p "${runtime_dir}/releases/seed"
+        if [ ! -f "${runtime_dir}/releases/seed/crs-setup.conf" ]; then
+            printf "SecRuleEngine On\n" > "${runtime_dir}/releases/seed/crs-setup.conf"
+        fi
+        if [ ! -f "${runtime_dir}/releases/seed/rule-overrides.conf" ]; then
+            printf "# No generated CRS rule overrides yet.\n" > "${runtime_dir}/releases/seed/rule-overrides.conf"
+        fi
+        ln -sfn releases/seed "${runtime_dir}/current"
+    fi
+}
+
 if [ "$(id -u)" = "0" ]; then
     mkdir -p "${runtime_dir}/crs"
+    seed_runtime_config
     chown -R app:app "${runtime_dir}"
     chmod 755 "${runtime_dir}" "${runtime_dir}/crs"
 
@@ -12,4 +26,5 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 mkdir -p "${runtime_dir}/crs"
+seed_runtime_config
 exec "$@"

--- a/src/backend/tests/integration/test_config_router.py
+++ b/src/backend/tests/integration/test_config_router.py
@@ -34,8 +34,15 @@ def test_apply_admin_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "runtime_generated_config_root", str(tmp_path / "generated"))
-    monkeypatch.setattr("app.services.config_apply._validate_haproxy", _mock_validate_ok)
+    monkeypatch.setattr(
+        settings,
+        "runtime_generated_config_root",
+        str(tmp_path / "generated"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        _mock_validate_ok,
+    )
     monkeypatch.setattr("app.services.config_apply._reload_haproxy", _mock_reload_ok)
 
     resp = client.post("/config/apply", headers=admin_token)
@@ -82,8 +89,15 @@ def test_apply_validation_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "runtime_generated_config_root", str(tmp_path / "generated"))
-    monkeypatch.setattr("app.services.config_apply._validate_haproxy", _mock_validate_fail)
+    monkeypatch.setattr(
+        settings,
+        "runtime_generated_config_root",
+        str(tmp_path / "generated"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        _mock_validate_fail,
+    )
     monkeypatch.setattr("app.services.config_apply._reload_haproxy", _mock_reload_ok)
 
     resp = client.post("/config/apply", headers=admin_token)


### PR DESCRIPTION
## What

Eliminates the Docker socket dependency from the backend by replacing the `_recycle_coraza` Docker SDK call with an inotify-based supervisor running inside the Coraza container itself.

## Why

Mounting `/var/run/docker.sock` into the backend container gives it effective root-on-host access — a significant attack surface for an MVP WAF. The previous approach recycled the Coraza container through the Docker SDK after each HAProxy reload. This PR removes that entirely.

## How it works

The Coraza container now runs a lightweight shell supervisor (`coraza-supervisor.sh`) as its entrypoint (under `tini` as PID 1). The supervisor:

1. Starts `coraza-spoa` as a background child process.
2. Calls `inotifywait -e moved_to,create --format '%f' /runtime` in a loop.
3. When the backend performs `os.replace` on the `current` symlink, the kernel fires a `moved_to` event — the supervisor detects `current` changed, kills the child, and starts a fresh `coraza-spoa` that picks up the new `rule-overrides.conf`.
4. If `coraza-spoa` dies on its own, the supervisor exits non-zero and `restart: unless-stopped` in Compose recovers the container.

## Changes

### New / rewritten
- `deploy/docker/coraza-supervisor.sh` — ~35-line sh supervisor (no bash needed)
- `deploy/docker/coraza.Dockerfile` — multi-stage: copies static `coraza-spoa` binary from upstream into `alpine:3.19`; adds `tini` + `inotify-tools`; supervisor is the entrypoint
- `configs/coraza/coraza.conf` — adds `Include /runtime/current/rule-overrides.conf`

### Backend removals
- `config_apply.py` — removed `import docker`, `_recycle_coraza`, `_find_coraza_container`, `coraza_reload_failed` status, `coraza_reload_output` field
- `config.py` — removed `coraza_container_name`, `coraza_reload_timeout_seconds`, `coraza_reload_enabled`
- `docker-entrypoint.sh` — removed `grant_docker_socket_access`
- `pyproject.toml` — removed `docker>=7.1.0` dependency

### Infrastructure
- `docker-compose.yml` — removed `CORAZA_CONTAINER_NAME` env var, `group_add`, `/var/run/docker.sock` mount; Coraza healthcheck now uses plain `nc` (available in alpine)
- `.env.example` — removed Docker GID / container name section

### API contract
- `ConfigApplyResponse` — `coraza_reload_output` field removed (no existing frontend consumers)
- `ApplyStatus` — `coraza_reload_failed` variant removed

### Docs & tests
- `README.architecture.md` — documents the inotify-based reload model, removes Docker socket paragraph
- Integration and unit tests updated to drop `_recycle_coraza` patches and the `coraza_reload_failure` test case

## Verification

```bash
# Static checks (all green)
cd src/backend
uv run pytest --cov=app      # 289 passed, 1 skipped
uv run mypy app/             # no issues
uv run ruff check app/       # all checks passed

# Audit: zero remaining Docker socket references
rg 'docker\.sock|DOCKER_GID|CORAZA_CONTAINER_NAME|coraza_reload|_recycle_coraza|grant_docker_socket_access'
```

End-to-end manual steps in the plan: build Coraza image, start stack, verify `docker inspect backend` has no `docker.sock` mount, trigger `POST /config/apply`, confirm supervisor log line `current symlink changed — restarting coraza-spoa`, confirm Coraza healthcheck stays green.

Closes https://github.com/bihius/guard-proxy/issues/190