### PR TITLE
Add policy apply e2e test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,8 +15,26 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.11.6"
+
+      - name: Install backend dependencies
+        working-directory: src/backend
+        run: uv sync --frozen --extra dev
+
       - name: Prepare Docker Compose environment
         run: cp deploy/docker/.env.example deploy/docker/.env
+
+      - name: Run policy apply e2e test
+        working-directory: src/backend
+        run: uv run pytest -m e2e tests/e2e/test_policy_apply.py
 
       - name: Run E2E smoke test
         run: bash benchmarks/smoke/e2e.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,6 +24,8 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.11.6"
+          enable-cache: true
+          cache-dependency-glob: src/backend/uv.lock
 
       - name: Install backend dependencies
         working-directory: src/backend

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -18,7 +18,7 @@ graph TB
     BE -.->|writes generated runtime config| RV[(guard_proxy_runtime)]
     RV -.->|read-only mount| H
     RV -.->|read-only rule overrides| CS
-    CS -.->|inotify watches /runtime| CS
+    CS -.->|polls /runtime/current| CS
 ```
 
 ## Request Flow
@@ -76,10 +76,10 @@ machine-readable degraded reason header.
 4. HAProxy reads the active generated `haproxy.cfg` from the volume and reloads
    through its Runtime API socket when `POST /config/apply` succeeds.
 5. Coraza reads the active generated `rule-overrides.conf` from the same volume
-   after CRS rules are loaded. The Coraza container runs an inotify supervisor
-   that watches the `/runtime` directory; when the backend atomically swaps the
-   `current` symlink, the supervisor detects the change and restarts
-   `coraza-spoa` automatically — no Docker socket access required.
+   after CRS rules are loaded. The Coraza container runs a supervisor that polls
+   the `/runtime/current` symlink; when the backend atomically swaps it, the
+   supervisor restarts `coraza-spoa` automatically — no Docker socket access
+   required.
 
 ### Runtime Event Ingestion
 1. Runtime WAF events can be represented as structured log payloads.
@@ -132,16 +132,17 @@ non-root `app` user, and then drops privileges before running migrations and
 Uvicorn. HAProxy copies the checked-in reference config into the same seed
 release when no generated `haproxy.cfg` exists yet.
 
-The Coraza container image is built on `alpine:3.19` with `tini` as PID 1 and
-`inotify-tools` installed. A shell supervisor (`coraza-supervisor.sh`) starts
-`coraza-spoa` as a child process and calls `inotifywait` in a loop. When the
-backend performs an atomic `os.replace` of the `current` symlink, the supervisor
-detects the `moved_to` or `create` event for `current` and restarts
-`coraza-spoa` — picking up the new `rule-overrides.conf` without any external
-signal or Docker socket access. Note that this is a full process restart, not a
-hot-reload: port 9000 is briefly unavailable (~sub-second) during the restart,
-causing HAProxy SPOE to return an error for any request that lands in that
-window. This is acceptable for a manual rule-apply operation.
+The Coraza container image is built on `alpine:3.19` with `tini` as PID 1. A
+shell supervisor (`coraza-supervisor.sh`) starts as root long enough to make the
+audit log volume writable, drops to the non-root `coraza` user, starts
+`coraza-spoa` as a child process, and polls `/runtime/current` once per second.
+When the backend performs an atomic `os.replace` of the `current` symlink, the
+supervisor restarts `coraza-spoa` — picking up the new `rule-overrides.conf`
+without any external signal or Docker socket access. Note that this is a full
+process restart, not a hot-reload: port 9000 is briefly unavailable
+(~sub-second) during the restart, causing HAProxy SPOE to return an error for
+any request that lands in that window. This is acceptable for a manual
+rule-apply operation.
 
 ## Key Decisions
 

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -134,12 +134,17 @@ release when no generated `haproxy.cfg` exists yet.
 
 The Coraza container image is built on `alpine:3.19` with `tini` as PID 1. A
 shell supervisor (`coraza-supervisor.sh`) starts as root long enough to make the
-audit log volume writable, drops to the non-root `coraza` user, starts
+fresh audit log volume writable, drops to the non-root `coraza` user, starts
 `coraza-spoa` as a child process, and polls `/runtime/current` once per second.
-When the backend performs an atomic `os.replace` of the `current` symlink, the
-supervisor restarts `coraza-spoa` — picking up the new `rule-overrides.conf`
-without any external signal or Docker socket access. Note that this is a full
-process restart, not a hot-reload: port 9000 is briefly unavailable
+The earlier inotify-based supervisor looked simpler, but it did not reliably
+observe the backend's atomic `current` symlink replacement through the
+read-only runtime volume mount while Coraza kept using the previous loaded
+rules. Polling the symlink target is intentionally less clever but directly
+tests the state Coraza includes. When the target changes, the supervisor
+restarts `coraza-spoa` — picking up the new `rule-overrides.conf` without any
+external signal or Docker socket access. If the child process exits, the
+supervisor exits non-zero so Compose can restart the container. Note that this
+is a full process restart, not a hot-reload: port 9000 is briefly unavailable
 (~sub-second) during the restart, causing HAProxy SPOE to return an error for
 any request that lands in that window. This is acceptable for a manual
 rule-apply operation.

--- a/README.commands.md
+++ b/README.commands.md
@@ -68,6 +68,7 @@ make seed                                                            # Seed admi
 
 ```bash
 bash benchmarks/smoke/e2e.sh  # Compose stack: benign request returns 200, SQLi returns 403
+cd src/backend && uv run pytest -m e2e tests/e2e/test_policy_apply.py  # Policy apply changes live WAF behavior
 ```
 
 ## Security Testing

--- a/README.testing.md
+++ b/README.testing.md
@@ -39,6 +39,21 @@ The smoke test sends `Host: app.local` because the reference HAProxy
 configuration rejects unknown hosts before WAF inspection. The same smoke test
 also runs nightly and on demand through `.github/workflows/smoke.yml`.
 
+### Policy Apply E2E
+
+The policy apply e2e test starts an isolated Compose project, seeds an admin,
+creates a policy-backed `app.local` vhost, applies runtime config, and verifies
+that disabling and re-enabling CRS rule `913100` changes live request behavior.
+
+Run locally from the backend directory:
+
+```sh
+uv run pytest -m e2e tests/e2e/test_policy_apply.py
+```
+
+The test uses the same prerequisites as the smoke test and is wired into the
+nightly smoke workflow. Normal backend pytest runs exclude tests marked `e2e`.
+
 ## Test Data
 
 - Payloads: `benchmarks/payloads/` (sqli.txt, xss.txt, legitimate.txt)

--- a/deploy/docker/coraza-supervisor.sh
+++ b/deploy/docker/coraza-supervisor.sh
@@ -4,7 +4,15 @@ set -eu
 SPOA_BIN=/usr/local/bin/coraza-spoa
 SPOA_CONFIG=/etc/coraza-spoa/coraza-spoa.yaml
 RUNTIME_DIR=/runtime
+LOG_DIR=/var/log/coraza
+POLL_INTERVAL_SECONDS=1
 SPOA_PID=""
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "$LOG_DIR"
+    chown -R coraza:coraza "$LOG_DIR"
+    exec su-exec coraza "$0" "$@"
+fi
 
 start_spoa() {
     "$SPOA_BIN" -config "$SPOA_CONFIG" &
@@ -25,15 +33,19 @@ on_term() {
 
 trap on_term TERM INT
 
-start_spoa
+current_release() {
+    readlink "$RUNTIME_DIR/current" 2>/dev/null || echo "<missing>"
+}
 
-while changed=$(inotifywait -q -e moved_to,create --format '%f' "$RUNTIME_DIR"); do
-    [ "$changed" = "current" ] || continue
-    echo "[supervisor] current symlink changed — restarting coraza-spoa" >&2
+start_spoa
+LAST_RELEASE="$(current_release)"
+
+while true; do
+    sleep "$POLL_INTERVAL_SECONDS"
+    CURRENT_RELEASE="$(current_release)"
+    [ "$CURRENT_RELEASE" != "$LAST_RELEASE" ] || continue
+    LAST_RELEASE="$CURRENT_RELEASE"
+    echo "[supervisor] current release changed — restarting coraza-spoa" >&2
     stop_spoa
     start_spoa
 done
-
-# inotifywait exited unexpectedly — let Compose restart the container
-stop_spoa
-exit 1

--- a/deploy/docker/coraza-supervisor.sh
+++ b/deploy/docker/coraza-supervisor.sh
@@ -7,45 +7,74 @@ RUNTIME_DIR=/runtime
 LOG_DIR=/var/log/coraza
 POLL_INTERVAL_SECONDS=1
 SPOA_PID=""
+WATCH_PID=""
 
 if [ "$(id -u)" = "0" ]; then
+    # Fresh Compose log volumes are root-owned. Fix ownership once, then drop
+    # privileges before running coraza-spoa.
     mkdir -p "$LOG_DIR"
-    chown -R coraza:coraza "$LOG_DIR"
+    if [ "$(stat -c '%U:%G' "$LOG_DIR")" != "coraza:coraza" ]; then
+        chown -R coraza:coraza "$LOG_DIR"
+    fi
     exec su-exec coraza "$0" "$@"
 fi
+
+current_release() {
+    readlink "$RUNTIME_DIR/current" 2>/dev/null || echo "<missing>"
+}
 
 start_spoa() {
     "$SPOA_BIN" -config "$SPOA_CONFIG" &
     SPOA_PID=$!
 }
 
-stop_spoa() {
-    [ -n "$SPOA_PID" ] || return 0
-    kill -TERM "$SPOA_PID" 2>/dev/null || true
-    wait "$SPOA_PID" 2>/dev/null || true
-    SPOA_PID=""
+watch_release() {
+    spoa_pid="$1"
+    last_release="$2"
+
+    while true; do
+        sleep "$POLL_INTERVAL_SECONDS"
+        current_release="$(current_release)"
+        [ "$current_release" != "$last_release" ] || continue
+        echo "[supervisor] current release changed — restarting coraza-spoa" >&2
+        kill -TERM "$spoa_pid" 2>/dev/null || true
+        exit 0
+    done
+}
+
+stop_process() {
+    pid="$1"
+    [ -n "$pid" ] || return 0
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
 }
 
 on_term() {
-    stop_spoa
+    stop_process "$WATCH_PID"
+    stop_process "$SPOA_PID"
     exit 143
 }
 
 trap on_term TERM INT
 
-current_release() {
-    readlink "$RUNTIME_DIR/current" 2>/dev/null || echo "<missing>"
-}
-
-start_spoa
 LAST_RELEASE="$(current_release)"
 
 while true; do
-    sleep "$POLL_INTERVAL_SECONDS"
-    CURRENT_RELEASE="$(current_release)"
-    [ "$CURRENT_RELEASE" != "$LAST_RELEASE" ] || continue
-    LAST_RELEASE="$CURRENT_RELEASE"
-    echo "[supervisor] current release changed — restarting coraza-spoa" >&2
-    stop_spoa
     start_spoa
+    watch_release "$SPOA_PID" "$LAST_RELEASE" &
+    WATCH_PID=$!
+
+    wait "$SPOA_PID" 2>/dev/null || true
+    stop_process "$WATCH_PID"
+    WATCH_PID=""
+    SPOA_PID=""
+
+    CURRENT_RELEASE="$(current_release)"
+    if [ "$CURRENT_RELEASE" != "$LAST_RELEASE" ]; then
+        LAST_RELEASE="$CURRENT_RELEASE"
+        continue
+    fi
+
+    echo "[supervisor] coraza-spoa exited — letting Compose restart container" >&2
+    exit 1
 done

--- a/deploy/docker/coraza.Dockerfile
+++ b/deploy/docker/coraza.Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/corazawaf/coraza-spoa:0.6.1 AS upstream
 
 FROM alpine:3.19
 
-RUN apk add --no-cache inotify-tools tini
+RUN apk add --no-cache su-exec tini
 
 COPY --from=upstream /coraza-spoa /usr/local/bin/coraza-spoa
 COPY configs/coraza/coraza-spoa.yaml /etc/coraza-spoa/coraza-spoa.yaml
@@ -15,12 +15,12 @@ COPY deploy/docker/coraza-supervisor.sh /usr/local/bin/coraza-supervisor
 
 RUN addgroup -S coraza && adduser -S -G coraza coraza
 
-RUN chmod +x /usr/local/bin/coraza-supervisor
+RUN mkdir -p /var/log/coraza \
+    && chown -R coraza:coraza /var/log/coraza \
+    && chmod +x /usr/local/bin/coraza-supervisor
 # Verify the binary is executable; fails the build if the upstream image
 # switches to a dynamically-linked binary that can't run on musl/alpine.
 RUN /usr/local/bin/coraza-spoa --version >/dev/null
-
-USER coraza
 
 EXPOSE 9000
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -51,6 +51,7 @@ plugins = ["pydantic.mypy"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+# E2E tests need Docker Compose and must be opted in with `pytest -m e2e`.
 addopts = "-m 'not e2e'"
 markers = [
     "e2e: full Docker Compose end-to-end tests excluded from default pytest runs",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -51,3 +51,7 @@ plugins = ["pydantic.mypy"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+addopts = "-m 'not e2e'"
+markers = [
+    "e2e: full Docker Compose end-to-end tests excluded from default pytest runs",
+]

--- a/src/backend/tests/e2e/test_policy_apply.py
+++ b/src/backend/tests/e2e/test_policy_apply.py
@@ -1,0 +1,480 @@
+"""E2E test for DB-backed policy apply behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pytest
+
+ADMIN_EMAIL = "policy-apply-admin@example.com"
+ADMIN_PASSWORD = "policy-apply-password-123"
+HOST_HEADER = "app.local"
+SCANNER_USER_AGENT = "nuclei"
+SCANNER_RULE_ID = 913100
+HTTP_TIMEOUT_SECONDS = 5
+SERVICE_TIMEOUT_SECONDS = 180
+RELOAD_TIMEOUT_SECONDS = 45
+
+
+def _find_repo_root() -> Path:
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "deploy/docker/docker-compose.yml").is_file():
+            return candidate
+    raise RuntimeError("Could not locate repository root")
+
+
+REPO_ROOT = _find_repo_root()
+COMPOSE_FILE = REPO_ROOT / "deploy/docker/docker-compose.yml"
+ENV_FILE = REPO_ROOT / "deploy/docker/.env"
+CRS_RULES_DIR = REPO_ROOT / "configs/coraza/crs/rules"
+
+
+@dataclass(frozen=True)
+class ComposeStack:
+    command: list[str]
+    env: dict[str, str]
+    base_url: str
+
+
+@pytest.fixture()
+def compose_stack() -> ComposeStack:
+    _require_e2e_prerequisites()
+
+    project_name = f"guard-proxy-policy-apply-{uuid.uuid4().hex[:8]}"
+    port = _free_tcp_port()
+    stack = ComposeStack(
+        command=_compose_command(project_name),
+        env={
+            **os.environ,
+            "HAPROXY_HTTP_PORT": str(port),
+        },
+        base_url=f"http://127.0.0.1:{port}",
+    )
+
+    _run(
+        stack.command
+        + ["up", "-d", "--build", "postgres", "backend", "coraza", "haproxy"],
+        env=stack.env,
+        timeout=600,
+    )
+
+    try:
+        for service in ("postgres", "backend", "coraza", "haproxy"):
+            _wait_for_healthy(stack, service)
+        _seed_admin(stack)
+        yield stack
+    except BaseException:
+        print("\nPolicy apply e2e failed. Recent service logs:")
+        print(_compose_logs(stack))
+        raise
+    finally:
+        _run(stack.command + ["down", "-v"], env=stack.env, check=False, timeout=180)
+
+
+@pytest.mark.e2e
+def test_policy_apply_rule_override_flips_runtime_waf_behavior(
+    compose_stack: ComposeStack,
+) -> None:
+    token = _login(compose_stack)
+
+    policy = _api_json(
+        compose_stack,
+        "POST",
+        "/policies",
+        token=token,
+        expected_status=201,
+        payload={
+            "name": "Policy apply e2e",
+            "paranoia_level": 1,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 4,
+            "enforcement_mode": "block",
+        },
+    )
+    policy_id = policy["id"]
+
+    _api_json(
+        compose_stack,
+        "POST",
+        "/vhosts",
+        token=token,
+        expected_status=201,
+        payload={
+            "domain": HOST_HEADER,
+            "backend_url": "http://backend:8000",
+            "ssl_enabled": False,
+            "is_active": True,
+            "policy_id": policy_id,
+        },
+    )
+
+    applied = _apply_config(compose_stack, token)
+    assert "SecRuleEngine On" in applied["generated_config"]["crs_setup_conf"]
+    assert f"SecRuleRemoveById {SCANNER_RULE_ID}" not in applied["generated_config"][
+        "rule_overrides_conf"
+    ]
+    _wait_for_scanner_status(compose_stack, 403, "scanner request before override")
+
+    override = _api_json(
+        compose_stack,
+        "POST",
+        f"/policies/{policy_id}/rules",
+        token=token,
+        expected_status=201,
+        payload={
+            "rule_id": SCANNER_RULE_ID,
+            "action": "disable",
+            "comment": "E2E proves DB override reaches Coraza",
+        },
+    )
+
+    applied = _apply_config(compose_stack, token)
+    assert (
+        f"SecRuleRemoveById {SCANNER_RULE_ID}"
+        in applied["generated_config"]["rule_overrides_conf"]
+    )
+    _wait_for_scanner_status(
+        compose_stack,
+        200,
+        "scanner request after disable override",
+    )
+
+    _api_json(
+        compose_stack,
+        "PATCH",
+        f"/policies/{policy_id}/rules/{override['id']}",
+        token=token,
+        payload={"action": "enable"},
+    )
+
+    applied = _apply_config(compose_stack, token)
+    assert f"SecRuleRemoveById {SCANNER_RULE_ID}" not in applied["generated_config"][
+        "rule_overrides_conf"
+    ]
+    _wait_for_scanner_status(compose_stack, 403, "scanner request after re-enable")
+
+
+def _require_e2e_prerequisites() -> None:
+    if not ENV_FILE.is_file():
+        pytest.fail(f"Missing {ENV_FILE}. Copy the example env file into place.")
+    if not CRS_RULES_DIR.is_dir():
+        pytest.fail(
+            "Missing CRS submodule content. Run "
+            "`git submodule update --init --recursive` from the repository root."
+        )
+    if shutil.which("docker") is None:
+        pytest.fail("Docker is required for policy apply e2e tests.")
+    if not _command_ok(["docker", "compose", "version"]) and shutil.which(
+        "docker-compose"
+    ) is None:
+        pytest.fail("Docker Compose is required for policy apply e2e tests.")
+
+
+def _compose_command(project_name: str) -> list[str]:
+    if _command_ok(["docker", "compose", "version"]):
+        return [
+            "docker",
+            "compose",
+            "-f",
+            str(COMPOSE_FILE),
+            "--env-file",
+            str(ENV_FILE),
+            "--project-name",
+            project_name,
+        ]
+
+    docker_compose = shutil.which("docker-compose")
+    if docker_compose is None:
+        raise RuntimeError("Docker Compose is required")
+    return [
+        docker_compose,
+        "-f",
+        str(COMPOSE_FILE),
+        "--env-file",
+        str(ENV_FILE),
+        "--project-name",
+        project_name,
+    ]
+
+
+def _command_ok(command: list[str]) -> bool:
+    return (
+        subprocess.run(command, capture_output=True, text=True, check=False).returncode
+        == 0
+    )
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run(
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    input_text: str | None = None,
+    timeout: int = 120,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"Command failed ({result.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _wait_for_healthy(stack: ComposeStack, service: str) -> None:
+    deadline = time.monotonic() + SERVICE_TIMEOUT_SECONDS
+    last_status = "unknown"
+
+    while time.monotonic() < deadline:
+        container_id = _container_id(stack, service)
+        if container_id:
+            last_status = _container_status(container_id)
+            if last_status == "healthy":
+                return
+            if last_status in {"dead", "exited"}:
+                pytest.fail(
+                    f"{service} container is {last_status}.\n{_compose_logs(stack)}"
+                )
+        time.sleep(2)
+
+    pytest.fail(
+        f"Timed out waiting for {service} to become healthy; "
+        f"last status: {last_status}.\n{_compose_logs(stack)}"
+    )
+
+
+def _container_id(stack: ComposeStack, service: str) -> str:
+    result = _run(
+        stack.command + ["ps", "-q", service],
+        env=stack.env,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def _container_status(container_id: str) -> str:
+    result = _run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            (
+                "{{if .State.Health}}{{.State.Health.Status}}"
+                "{{else}}{{.State.Status}}{{end}}"
+            ),
+            container_id,
+        ],
+        check=False,
+    )
+    return result.stdout.strip() or "unknown"
+
+
+def _seed_admin(stack: ComposeStack) -> None:
+    _run(
+        stack.command
+        + [
+            "exec",
+            "-T",
+            "backend",
+            "/app/.venv/bin/python",
+            "scripts/seed_admin.py",
+            "--email",
+            ADMIN_EMAIL,
+            "--password",
+            ADMIN_PASSWORD,
+            "--full-name",
+            "Policy Apply Test Admin",
+        ],
+        env=stack.env,
+    )
+
+
+def _login(stack: ComposeStack) -> str:
+    response = _api_json(
+        stack,
+        "POST",
+        "/auth/login",
+        payload={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+    )
+    return str(response["access_token"])
+
+
+def _apply_config(stack: ComposeStack, token: str) -> dict[str, Any]:
+    response = _api_json(stack, "POST", "/config/apply", token=token)
+    assert response["status"] == "success"
+    return response
+
+
+def _api_json(
+    stack: ComposeStack,
+    method: str,
+    path: str,
+    *,
+    token: str | None = None,
+    payload: dict[str, Any] | None = None,
+    expected_status: int = 200,
+) -> dict[str, Any]:
+    status, body = _backend_http_request(
+        stack,
+        path,
+        method=method,
+        token=token,
+        payload=payload,
+    )
+    if status != expected_status:
+        pytest.fail(
+            f"{method} {path}: expected HTTP {expected_status}, got {status}.\n{body}"
+        )
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+def _backend_http_request(
+    stack: ComposeStack,
+    path: str,
+    *,
+    method: str,
+    token: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    request = {
+        "method": method,
+        "url": f"http://127.0.0.1:8000{path}",
+        "token": token,
+        "payload": payload,
+    }
+    script = r"""
+import json
+import sys
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+request_data = json.loads(sys.stdin.read())
+headers = {"Accept": "application/json"}
+body = None
+if request_data["payload"] is not None:
+    body = json.dumps(request_data["payload"]).encode("utf-8")
+    headers["Content-Type"] = "application/json"
+if request_data["token"] is not None:
+    headers["Authorization"] = "Bearer " + request_data["token"]
+
+request = Request(
+    request_data["url"],
+    data=body,
+    headers=headers,
+    method=request_data["method"],
+)
+try:
+    with urlopen(request, timeout=5) as response:
+        result = {
+            "status": response.status,
+            "body": response.read().decode("utf-8", errors="replace"),
+        }
+except HTTPError as error:
+    result = {
+        "status": error.code,
+        "body": error.read().decode("utf-8", errors="replace"),
+    }
+
+print(json.dumps(result))
+"""
+    result = _run(
+        stack.command
+        + ["exec", "-T", "backend", "/app/.venv/bin/python", "-c", script],
+        env=stack.env,
+        input_text=json.dumps(request),
+    )
+    response = json.loads(result.stdout)
+    return int(response["status"]), str(response["body"])
+
+
+def _wait_for_scanner_status(
+    stack: ComposeStack,
+    expected_status: int,
+    description: str,
+) -> None:
+    deadline = time.monotonic() + RELOAD_TIMEOUT_SECONDS
+    last_status: int | str = "unknown"
+
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _http_request(
+                f"{stack.base_url}/docs",
+                method="GET",
+                headers={"User-Agent": SCANNER_USER_AGENT},
+            )
+            last_status = status
+            if status == expected_status:
+                return
+        except URLError as error:
+            last_status = str(error)
+        time.sleep(1)
+
+    pytest.fail(
+        f"{description}: expected HTTP {expected_status}, got {last_status}.\n"
+        f"{_compose_logs(stack)}"
+    )
+
+
+def _http_request(
+    url: str,
+    *,
+    method: str,
+    token: str | None = None,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, str]:
+    request_headers = {
+        "Host": HOST_HEADER,
+        **(headers or {}),
+    }
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    if token is not None:
+        request_headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(url, data=data, headers=request_headers, method=method)
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return response.status, response.read().decode("utf-8", errors="replace")
+    except HTTPError as error:
+        return error.code, error.read().decode("utf-8", errors="replace")
+
+
+def _compose_logs(stack: ComposeStack) -> str:
+    result = _run(
+        stack.command + ["logs", "--tail=80", "backend", "haproxy", "coraza"],
+        env=stack.env,
+        check=False,
+    )
+    return result.stdout + result.stderr

--- a/src/backend/tests/e2e/test_policy_apply.py
+++ b/src/backend/tests/e2e/test_policy_apply.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -24,6 +25,8 @@ SCANNER_USER_AGENT = "nuclei"
 SCANNER_RULE_ID = 913100
 HTTP_TIMEOUT_SECONDS = 5
 SERVICE_TIMEOUT_SECONDS = 180
+# Coraza's supervisor polls /runtime/current every second before restarting SPOA.
+# Keep this timeout comfortably above that lower bound plus container scheduling.
 RELOAD_TIMEOUT_SECONDS = 45
 
 
@@ -124,6 +127,7 @@ def test_policy_apply_rule_override_flips_runtime_waf_behavior(
     assert f"SecRuleRemoveById {SCANNER_RULE_ID}" not in applied["generated_config"][
         "rule_overrides_conf"
     ]
+    _assert_coraza_runtime_override(compose_stack, should_exist=False)
     _wait_for_scanner_status(compose_stack, 403, "scanner request before override")
 
     override = _api_json(
@@ -144,6 +148,9 @@ def test_policy_apply_rule_override_flips_runtime_waf_behavior(
         f"SecRuleRemoveById {SCANNER_RULE_ID}"
         in applied["generated_config"]["rule_overrides_conf"]
     )
+    _assert_coraza_runtime_override(compose_stack, should_exist=True)
+    # The runtime-file assertion proves the override reached Coraza's mount;
+    # the HTTP verdict is still the user-visible contract for issue #114.
     _wait_for_scanner_status(
         compose_stack,
         200,
@@ -162,6 +169,7 @@ def test_policy_apply_rule_override_flips_runtime_waf_behavior(
     assert f"SecRuleRemoveById {SCANNER_RULE_ID}" not in applied["generated_config"][
         "rule_overrides_conf"
     ]
+    _assert_coraza_runtime_override(compose_stack, should_exist=False)
     _wait_for_scanner_status(compose_stack, 403, "scanner request after re-enable")
 
 
@@ -175,30 +183,15 @@ def _require_e2e_prerequisites() -> None:
         )
     if shutil.which("docker") is None:
         pytest.fail("Docker is required for policy apply e2e tests.")
-    if not _command_ok(["docker", "compose", "version"]) and shutil.which(
-        "docker-compose"
-    ) is None:
+    try:
+        _docker_compose_prefix()
+    except RuntimeError:
         pytest.fail("Docker Compose is required for policy apply e2e tests.")
 
 
 def _compose_command(project_name: str) -> list[str]:
-    if _command_ok(["docker", "compose", "version"]):
-        return [
-            "docker",
-            "compose",
-            "-f",
-            str(COMPOSE_FILE),
-            "--env-file",
-            str(ENV_FILE),
-            "--project-name",
-            project_name,
-        ]
-
-    docker_compose = shutil.which("docker-compose")
-    if docker_compose is None:
-        raise RuntimeError("Docker Compose is required")
     return [
-        docker_compose,
+        *_docker_compose_prefix(),
         "-f",
         str(COMPOSE_FILE),
         "--env-file",
@@ -206,6 +199,17 @@ def _compose_command(project_name: str) -> list[str]:
         "--project-name",
         project_name,
     ]
+
+
+@lru_cache
+def _docker_compose_prefix() -> tuple[str, ...]:
+    if _command_ok(["docker", "compose", "version"]):
+        return ("docker", "compose")
+
+    docker_compose = shutil.which("docker-compose")
+    if docker_compose is None:
+        raise RuntimeError("Docker Compose is required")
+    return (docker_compose,)
 
 
 def _command_ok(command: list[str]) -> bool:
@@ -330,6 +334,25 @@ def _apply_config(stack: ComposeStack, token: str) -> dict[str, Any]:
     response = _api_json(stack, "POST", "/config/apply", token=token)
     assert response["status"] == "success"
     return response
+
+
+def _assert_coraza_runtime_override(stack: ComposeStack, *, should_exist: bool) -> None:
+    result = _run(
+        stack.command
+        + [
+            "exec",
+            "-T",
+            "coraza",
+            "cat",
+            "/runtime/current/rule-overrides.conf",
+        ],
+        env=stack.env,
+    )
+    expected = f"SecRuleRemoveById {SCANNER_RULE_ID}"
+    if should_exist:
+        assert expected in result.stdout
+    else:
+        assert expected not in result.stdout
 
 
 def _api_json(


### PR DESCRIPTION
## Summary
- add a Docker Compose-backed e2e test for DB-backed CRS rule overrides
- wire the e2e into the nightly/manual smoke workflow while excluding it from default pytest runs
- fix Coraza runtime reload and fresh log-volume permissions exposed by the e2e

## Validation
- .venv/bin/pytest -m e2e tests/e2e/test_policy_apply.py -vv
- .venv/bin/pytest --cov=app
- .venv/bin/mypy app/
- .venv/bin/ruff check app/ tests/e2e/test_policy_apply.py
- git diff --check

Closes https://github.com/bihius/guard-proxy/issues/114