### PR TITLE
feat(dashboard): apply-config button and live runtime status card (#200)

### DIFF
--- a/src/frontend/src/features/runtime/ApplyConfigButton.test.tsx
+++ b/src/frontend/src/features/runtime/ApplyConfigButton.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError } from "@/lib/api-client";
+
+vi.mock("@/hooks/use-auth");
+vi.mock("./api", () => ({
+  applyConfig: vi.fn(),
+}));
+
+import { useAuth } from "@/hooks/use-auth";
+import { applyConfig } from "./api";
+import type { ConfigApplyResponse } from "./types";
+import { ApplyConfigButton } from "./ApplyConfigButton";
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedApplyConfig = vi.mocked(applyConfig);
+
+function createAccessToken() {
+  return "test-token";
+}
+
+function makeAuth(role: "admin" | "viewer") {
+  return {
+    hasRole: (r: string | string[]) =>
+      Array.isArray(r) ? r.includes(role) : r === role,
+    accessToken: createAccessToken(),
+    user: null,
+    role,
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+  };
+}
+
+const noop = { refresh: vi.fn() };
+
+describe("ApplyConfigButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the button for admin", () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    render(<ApplyConfigButton runtimeStatus={noop} />);
+    expect(screen.getByRole("button", { name: /apply config/i })).toBeInTheDocument();
+  });
+
+  it("returns null for viewer", () => {
+    mockedUseAuth.mockReturnValue(makeAuth("viewer"));
+    const { container } = render(<ApplyConfigButton runtimeStatus={noop} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("disables the button while in-flight and re-enables after", async () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+
+    let resolveApply!: (v: ConfigApplyResponse) => void;
+    mockedApplyConfig.mockReturnValueOnce(
+      new Promise<ConfigApplyResponse>((res) => {
+        resolveApply = res;
+      }),
+    );
+
+    render(<ApplyConfigButton runtimeStatus={noop} />);
+    const btn = screen.getByRole("button", { name: /apply config/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    resolveApply({ status: "ok", correlation_id: "c1", checksum: "abc", message: "Done" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).not.toBeDisabled();
+    });
+  });
+
+  it("calls refresh and onResult with success after apply", async () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    const refreshMock = vi.fn();
+    const onResult = vi.fn();
+
+    mockedApplyConfig.mockResolvedValueOnce({
+      status: "ok",
+      correlation_id: "corr-1",
+      checksum: "abc123",
+      message: "Config applied successfully",
+    });
+
+    render(
+      <ApplyConfigButton
+        runtimeStatus={{ refresh: refreshMock }}
+        onResult={onResult}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /apply config/i }));
+
+    await waitFor(() => {
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+      expect(onResult).toHaveBeenCalledWith({
+        kind: "success",
+        message: "Config applied successfully",
+        correlationId: "corr-1",
+      });
+    });
+  });
+
+  it("calls onResult with error when apply fails", async () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    const onResult = vi.fn();
+
+    mockedApplyConfig.mockRejectedValueOnce(
+      new ApiError(422, "Invalid config: syntax error"),
+    );
+
+    render(
+      <ApplyConfigButton runtimeStatus={noop} onResult={onResult} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /apply config/i }));
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith({
+        kind: "error",
+        message: "Invalid config: syntax error",
+      });
+    });
+  });
+
+  it("ignores duplicate clicks while in-flight", async () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    let resolveApply!: (v: ConfigApplyResponse) => void;
+    mockedApplyConfig.mockReturnValueOnce(
+      new Promise<ConfigApplyResponse>((res) => {
+        resolveApply = res;
+      }),
+    );
+
+    render(<ApplyConfigButton runtimeStatus={noop} />);
+    const btn = screen.getByRole("button", { name: /apply config/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(btn).toBeDisabled());
+
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    resolveApply({ status: "ok", correlation_id: "c1", checksum: "abc", message: "Done" });
+
+    await waitFor(() => expect(btn).not.toBeDisabled());
+    expect(mockedApplyConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/src/features/runtime/ApplyConfigButton.tsx
+++ b/src/frontend/src/features/runtime/ApplyConfigButton.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { applyConfig } from "./api";
+
+type ApplyResult = {
+  kind: "success" | "error";
+  message: string;
+  correlationId?: string;
+};
+
+type ApplyConfigButtonProps = {
+  runtimeStatus: { refresh: () => void };
+  onResult?: (result: ApplyResult) => void;
+};
+
+export function ApplyConfigButton({
+  runtimeStatus,
+  onResult,
+}: ApplyConfigButtonProps) {
+  const { hasRole, accessToken } = useAuth();
+  const [isApplying, setIsApplying] = useState(false);
+
+  if (!hasRole("admin")) return null;
+
+  async function handleClick() {
+    if (isApplying || !accessToken) return;
+
+    setIsApplying(true);
+    try {
+      const result = await applyConfig(accessToken);
+      const applyResult: ApplyResult = {
+        kind: "success",
+        message: result.message,
+        correlationId: result.correlation_id,
+      };
+      onResult?.(applyResult);
+      runtimeStatus.refresh();
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.detail : "Apply failed unexpectedly";
+      onResult?.({ kind: "error", message });
+    } finally {
+      setIsApplying(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={isApplying}
+      onClick={() => void handleClick()}
+      className="inline-flex items-center gap-2 rounded-[var(--radius-md)] bg-accent px-4 py-2 text-sm font-semibold text-white shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {isApplying ? (
+        <>
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+          Applying…
+        </>
+      ) : (
+        "Apply config"
+      )}
+    </button>
+  );
+}
+
+export type { ApplyResult };

--- a/src/frontend/src/features/runtime/RuntimeStatusCard.test.tsx
+++ b/src/frontend/src/features/runtime/RuntimeStatusCard.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { RuntimeStatusResponse } from "./types";
+import { RuntimeStatusCard } from "./RuntimeStatusCard";
+
+function makeStatus(
+  overrides: Partial<{
+    data: RuntimeStatusResponse | null;
+    isLoading: boolean;
+    error: string | null;
+    refresh: () => void;
+  }> = {},
+) {
+  return {
+    data: null,
+    isLoading: false,
+    error: null,
+    refresh: () => undefined,
+    ...overrides,
+  };
+}
+
+function makeRuntimeData(
+  overrides: Partial<RuntimeStatusResponse> = {},
+): RuntimeStatusResponse {
+  return {
+    frontend_contract_version: "1",
+    deployment_state: "deployed",
+    generated_config: {
+      can_generate: true,
+      checksum: "abcdef123456",
+      generated_at: "2026-05-01T12:00:00Z",
+      error: null,
+    },
+    latest_validation: null,
+    latest_reload: null,
+    ...overrides,
+  };
+}
+
+describe("RuntimeStatusCard", () => {
+  it("shows loading state", () => {
+    render(<RuntimeStatusCard status={makeStatus({ isLoading: true })} />);
+    expect(screen.getByText(/loading runtime status/i)).toBeInTheDocument();
+  });
+
+  it("shows error state", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({ error: "Network error" })}
+      />,
+    );
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  it("renders deployed badge and checksum", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({ data: makeRuntimeData() })}
+      />,
+    );
+    expect(screen.getByText("Deployed")).toBeInTheDocument();
+    expect(screen.getByText("abcdef123456".slice(0, 12))).toBeInTheDocument();
+  });
+
+  it("renders never_deployed badge", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({
+          data: makeRuntimeData({ deployment_state: "never_deployed" }),
+        })}
+      />,
+    );
+    expect(screen.getByText("Never deployed")).toBeInTheDocument();
+  });
+
+  it("renders failed badge", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({
+          data: makeRuntimeData({ deployment_state: "failed" }),
+        })}
+      />,
+    );
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("shows reload failure message when latest_reload status is failed", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({
+          data: makeRuntimeData({
+            latest_reload: {
+              id: 1,
+              operation_type: "reload",
+              status: "failed",
+              config_checksum: "deadbeef1234",
+              message: "HAProxy failed to reload: syntax error on line 42",
+              created_at: "2026-05-01T13:00:00Z",
+            },
+          }),
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/HAProxy failed to reload/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows dash when no latest_reload", () => {
+    render(
+      <RuntimeStatusCard
+        status={makeStatus({ data: makeRuntimeData({ latest_reload: null }) })}
+      />,
+    );
+    expect(screen.getByText("Last reload")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/features/runtime/RuntimeStatusCard.tsx
+++ b/src/frontend/src/features/runtime/RuntimeStatusCard.tsx
@@ -1,0 +1,109 @@
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+
+import type { DeploymentState, RuntimeStatusResponse } from "./types";
+
+export type RuntimeStatusState = {
+  data: RuntimeStatusResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+type RuntimeStatusCardProps = {
+  status: RuntimeStatusState;
+};
+
+const deploymentToneMap: Record<
+  DeploymentState,
+  "success" | "error" | "warning"
+> = {
+  deployed: "success",
+  failed: "error",
+  never_deployed: "warning",
+};
+
+const deploymentLabelMap: Record<DeploymentState, string> = {
+  deployed: "Deployed",
+  failed: "Failed",
+  never_deployed: "Never deployed",
+};
+
+function formatTimestamp(iso: string) {
+  return new Date(iso).toLocaleString();
+}
+
+function truncateChecksum(checksum: string | null) {
+  if (!checksum) return "—";
+  return checksum.slice(0, 12);
+}
+
+export function RuntimeStatusCard({ status }: RuntimeStatusCardProps) {
+  if (status.isLoading) {
+    return (
+      <SectionCard title="Runtime status" description="Current WAF deployment state.">
+        <LoadingState label="Loading runtime status…" />
+      </SectionCard>
+    );
+  }
+
+  if (status.error || !status.data) {
+    return (
+      <SectionCard title="Runtime status" description="Current WAF deployment state.">
+        <ErrorState
+          title="Could not load status"
+          description={status.error ?? "Unknown error"}
+        />
+      </SectionCard>
+    );
+  }
+
+  const { deployment_state, generated_config, latest_reload } = status.data;
+  const tone = deploymentToneMap[deployment_state];
+  const label = deploymentLabelMap[deployment_state];
+
+  return (
+    <SectionCard
+      title="Runtime status"
+      description="Current WAF deployment state."
+      actions={<StatusBadge label={label} tone={tone} />}
+    >
+      <div className="space-y-3">
+        <StatusRow
+          label="Generated checksum"
+          value={truncateChecksum(generated_config.checksum)}
+        />
+        {latest_reload ? (
+          <>
+            <StatusRow
+              label="Last reload checksum"
+              value={truncateChecksum(latest_reload.config_checksum)}
+            />
+            <StatusRow
+              label="Last reload"
+              value={formatTimestamp(latest_reload.created_at)}
+            />
+            {latest_reload.status === "failed" && latest_reload.message ? (
+              <div className="rounded-[var(--radius-md)] border border-error/30 bg-error-soft px-4 py-3 text-sm text-error">
+                {latest_reload.message}
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <StatusRow label="Last reload" value="—" />
+        )}
+      </div>
+    </SectionCard>
+  );
+}
+
+function StatusRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-surface p-4">
+      <span className="text-sm font-medium text-fg">{label}</span>
+      <span className="font-mono text-sm text-fg-muted">{value}</span>
+    </div>
+  );
+}

--- a/src/frontend/src/features/runtime/api.ts
+++ b/src/frontend/src/features/runtime/api.ts
@@ -1,0 +1,18 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { ConfigApplyResponse, RuntimeStatusResponse } from "./types";
+
+export function applyConfig(accessToken: string, signal?: AbortSignal) {
+  return apiRequest<ConfigApplyResponse>("/config/apply", {
+    method: "POST",
+    token: accessToken,
+    signal,
+  });
+}
+
+export function getRuntimeStatus(accessToken: string, signal?: AbortSignal) {
+  return apiRequest<RuntimeStatusResponse>("/runtime/status", {
+    token: accessToken,
+    signal,
+  });
+}

--- a/src/frontend/src/features/runtime/types.ts
+++ b/src/frontend/src/features/runtime/types.ts
@@ -1,0 +1,32 @@
+export type DeploymentState = "never_deployed" | "deployed" | "failed";
+
+export type RuntimeGeneratedConfigStatus = {
+  can_generate: boolean;
+  checksum: string | null;
+  generated_at: string | null;
+  error: string | null;
+};
+
+export type RuntimeOperationSnapshot = {
+  id: number;
+  operation_type: string;
+  status: string;
+  config_checksum: string | null;
+  message: string | null;
+  created_at: string;
+};
+
+export type RuntimeStatusResponse = {
+  frontend_contract_version: string;
+  deployment_state: DeploymentState;
+  generated_config: RuntimeGeneratedConfigStatus;
+  latest_validation: RuntimeOperationSnapshot | null;
+  latest_reload: RuntimeOperationSnapshot | null;
+};
+
+export type ConfigApplyResponse = {
+  status: string;
+  correlation_id: string;
+  checksum: string;
+  message: string;
+};

--- a/src/frontend/src/features/runtime/use-runtime-status.ts
+++ b/src/frontend/src/features/runtime/use-runtime-status.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+
+import { getRuntimeStatus } from "./api";
+import type { RuntimeStatusResponse } from "./types";
+
+type RuntimeStatusState = {
+  data: RuntimeStatusResponse | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+export function useRuntimeStatus(): RuntimeStatusState {
+  const { accessToken } = useAuth();
+  const [data, setData] = useState<RuntimeStatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  const fetch = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    getRuntimeStatus(accessToken, controller.signal)
+      .then((result) => {
+        if (generation === refreshCountRef.current) {
+          setData(result);
+          setIsLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (
+          err instanceof Error &&
+          (err.name === "AbortError" ||
+            (err as { name?: string }).name === "AbortError")
+        ) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Failed to load status");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken]);
+
+  useEffect(() => {
+    const cleanup = fetch();
+    return cleanup;
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, isLoading, error, refresh };
+}

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import {
   AlertTriangleIcon,
@@ -11,8 +11,17 @@ import { RoleBadge } from "@/components/shared/RoleBadge";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatCard } from "@/components/shared/StatCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
+import { ApplyConfigButton } from "@/features/runtime/ApplyConfigButton";
+import type { ApplyResult } from "@/features/runtime/ApplyConfigButton";
+import { RuntimeStatusCard } from "@/features/runtime/RuntimeStatusCard";
+import { useRuntimeStatus } from "@/features/runtime/use-runtime-status";
+import { useAuth } from "@/hooks/use-auth";
 
 export function DashboardPage() {
+  const { role } = useAuth();
+  const runtimeStatus = useRuntimeStatus();
+  const [applyResult, setApplyResult] = useState<ApplyResult | null>(null);
+
   return (
     <section className="space-y-8">
       <PageHeader
@@ -21,11 +30,34 @@ export function DashboardPage() {
         description="This starter dashboard shows the shared building blocks for the rest of the team: stat cards, section cards, and consistent status badges."
         actions={
           <>
-            <RoleBadge role="admin" />
+            {role ? <RoleBadge role={role} /> : null}
             <StatusBadge label="Development" tone="info" />
+            <ApplyConfigButton
+              runtimeStatus={runtimeStatus}
+              onResult={(result) => setApplyResult(result)}
+            />
           </>
         }
       />
+
+      {applyResult ? (
+        <div
+          className={`flex items-start justify-between gap-4 rounded-[var(--radius-md)] border px-4 py-3 text-sm font-medium ${
+            applyResult.kind === "success"
+              ? "border-success/30 bg-success-soft text-success"
+              : "border-error/30 bg-error-soft text-error"
+          }`}
+        >
+          <span>{applyResult.message}</span>
+          <button
+            type="button"
+            onClick={() => setApplyResult(null)}
+            className="shrink-0 text-current opacity-60 hover:opacity-100"
+          >
+            ✕
+          </button>
+        </div>
+      ) : null}
 
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         <StatCard
@@ -82,25 +114,7 @@ export function DashboardPage() {
           </div>
         </SectionCard>
 
-        <SectionCard
-          title="Quick status"
-          description="Small composable status block for future platform health indicators."
-        >
-          <div className="space-y-3">
-            <StatusRow
-              label="Frontend shell"
-              badge={<StatusBadge label="Ready" tone="success" />}
-            />
-            <StatusRow
-              label="Auth foundation"
-              badge={<StatusBadge label="Ready" tone="success" />}
-            />
-            <StatusRow
-              label="Dashboard data"
-              badge={<StatusBadge label="Mocked" tone="warning" />}
-            />
-          </div>
-        </SectionCard>
+        <RuntimeStatusCard status={runtimeStatus} />
       </div>
     </section>
   );
@@ -120,20 +134,6 @@ function ActivityRow({ title, description, badge }: ActivityRowProps) {
         {badge}
       </div>
       <p className="text-sm leading-6 text-fg-muted">{description}</p>
-    </div>
-  );
-}
-
-type StatusRowProps = {
-  label: string;
-  badge: ReactNode;
-};
-
-function StatusRow({ label, badge }: StatusRowProps) {
-  return (
-    <div className="flex items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-surface p-4">
-      <span className="text-sm font-medium text-fg">{label}</span>
-      {badge}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Apply Config button** added to Dashboard `PageHeader.actions` (admin-only, returns `null` for viewers). Calls `POST /config/apply`, disables while in-flight to block duplicate submissions, then triggers a status refresh. Result (success message or `ApiError.detail`) surfaces as an inline dismissable banner directly below the header — no new toast system needed.
- **Runtime Status card** replaces the mocked "Quick Status" `SectionCard`. Calls `GET /runtime/status` on mount via `useRuntimeStatus()`, re-fetches after a successful apply. Renders `deployment_state` via `StatusBadge` (`deployed → success`, `failed → error`, `never_deployed → warning`), current generated checksum, last reload checksum + timestamp, and an inline error message when `latest_reload.status === "failed"`.
- **`RoleBadge`** in the header now shows the actual authenticated role instead of the hardcoded `"admin"` placeholder.

## New files

| File | Purpose |
|---|---|
| `features/runtime/types.ts` | TypeScript mirrors of backend Pydantic schemas |
| `features/runtime/api.ts` | `applyConfig()` / `getRuntimeStatus()` typed wrappers |
| `features/runtime/use-runtime-status.ts` | Hook owning `{data, isLoading, error, refresh}` with AbortController |
| `features/runtime/ApplyConfigButton.tsx` | Admin-only button with in-flight state |
| `features/runtime/RuntimeStatusCard.tsx` | Deployment state card |
| `features/runtime/ApplyConfigButton.test.tsx` | 6 tests: admin/viewer visibility, disable, success, error, double-click guard |
| `features/runtime/RuntimeStatusCard.test.tsx` | 7 tests: loading, error, all deployment states, reload failure message |

## Test plan

- [x] `pnpm run type-check && pnpm run lint && pnpm test` — all pass (34 tests)
- [x] Manual (admin): start backend + frontend, Dashboard shows "Apply config" button and Runtime Status card with real data. Click Apply → button disables, banner appears, card checksum/timestamp updates.
- [x] Manual (viewer): button absent; Runtime Status card still renders.
- [x] Failure path: break config or stop HAProxy → Apply returns error → banner shows `detail` string, card reflects failed state.
- [x] Double-click: hammer button while in-flight → only one POST in network tab.