### PR TITLE
feat(coraza): route audit log to stdout, SPOA logs to stderr (#116)

### DIFF
--- a/configs/coraza/README.md
+++ b/configs/coraza/README.md
@@ -34,7 +34,78 @@ git submodule update --init --recursive
 - Response body inspection is disabled for M1, matching ADR-007.
 - Blocking paranoia level is `1`.
 - Inbound and outbound anomaly thresholds are `5`.
-- Relevant audit events are written as JSON to `/var/log/coraza/audit.json`.
+
+## Audit log output
+
+Coraza writes one JSON audit event per line to **stdout** using `SecAuditLogType Serial` + `SecAuditLogFormat JSON`. Each transaction that matches `SecAuditEngine RelevantOnly` (i.e. transactions where at least one rule fired) produces a single JSON object followed by a newline — the format a downstream log shipper can consume directly.
+
+Operational logs from the `coraza-spoa` daemon (startup, health, rule-load messages) go to **stderr**, so the stdout stream is a clean newline-delimited JSON stream.
+
+To inspect events while the stack is running:
+
+```sh
+# stdout only — audit JSON
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env \
+  logs --no-log-prefix coraza | jq -c .
+
+# stderr only — SPOA operational logs
+docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env \
+  logs --no-log-prefix coraza 2>&1 1>/dev/null
+```
+
+### Event schema and ingest mapping
+
+The table below maps each `LogIngestRequest` field (defined in
+`src/backend/app/schemas/log.py`) to its source path inside the Coraza JSON
+event. This is the contract for the future log shipper (not implemented here).
+
+Parts `ABIJDEFHZ` produce a top-level structure like:
+
+```jsonc
+{
+  "transaction": {
+    "id": "...",
+    "timestamp": "...",
+    "client_ip": "...",
+    "is_interrupted": false,
+    "request": {
+      "method": "GET",
+      "uri": "/path",
+      "headers": { "host": "example.com", ... }
+    },
+    "response": { "status": 200 },
+    "variables": {
+      "tx": {
+        "anomaly_score": "5",
+        "paranoia_level": "1"
+      }
+    }
+  },
+  "messages": [
+    {
+      "message": "...",
+      "data": { "id": "941100", "msg": "XSS Attack ...", "severity": "2" }
+    }
+  ]
+}
+```
+
+| `LogIngestRequest` field | Coraza source path | Notes |
+|---|---|---|
+| `producer_event_id` | `transaction.id` | Unique per transaction |
+| `event_at` | `transaction.timestamp` | ISO 8601 string |
+| `vhost` | `transaction.request.headers.host` | Lowercase |
+| `source_ip` | `transaction.client_ip` | |
+| `method` | `transaction.request.method` | Uppercase |
+| `request_uri` | `transaction.request.uri` | |
+| `status_code` | `transaction.response.status` | May be absent for blocked requests |
+| `action` | derived | `deny` if `transaction.is_interrupted` or any `messages[].data.severity` < 2; `monitor` when `SecRuleEngine DetectionOnly`; else `allow` |
+| `rule_id` | `messages[0].data.id` | First (or highest-severity) fired rule |
+| `rule_message` | `messages[0].data.msg` | Corresponding rule message |
+| `anomaly_score` | `transaction.variables.tx.anomaly_score` | String → int; absent when no rules fired |
+| `paranoia_level` | `transaction.variables.tx.paranoia_level` | String → int |
+| `severity` | derived from `messages[0].data.severity` | Numeric Coraza severity: 0–2 → `critical`/`error`; 3–4 → `warning`; ≥5 → `info` |
+| `raw_context` | full Coraza event JSON | Fallback; stores everything not mapped above |
 
 ## Docker Compose mounts
 

--- a/configs/coraza/coraza-spoa.yaml
+++ b/configs/coraza/coraza-spoa.yaml
@@ -2,7 +2,7 @@
 
 bind: 0.0.0.0:9000
 log_level: info
-log_file: /dev/stdout
+log_file: /dev/stderr
 log_format: console
 
 default_application: default
@@ -14,5 +14,5 @@ applications:
     response_check: false
     transaction_ttl_ms: 60000
     log_level: info
-    log_file: /dev/stdout
+    log_file: /dev/stderr
     log_format: console

--- a/configs/coraza/coraza.conf
+++ b/configs/coraza/coraza.conf
@@ -12,7 +12,7 @@ SecResponseBodyAccess Off
 SecAuditEngine RelevantOnly
 SecAuditLogType Serial
 SecAuditLogFormat JSON
-SecAuditLog /var/log/coraza/audit.json
+SecAuditLog /dev/stdout
 SecAuditLogParts ABIJDEFHZ
 
 SecDefaultAction "phase:1,log,auditlog,pass"

--- a/deploy/docker/coraza-supervisor.sh
+++ b/deploy/docker/coraza-supervisor.sh
@@ -4,18 +4,11 @@ set -eu
 SPOA_BIN=/usr/local/bin/coraza-spoa
 SPOA_CONFIG=/etc/coraza-spoa/coraza-spoa.yaml
 RUNTIME_DIR=/runtime
-LOG_DIR=/var/log/coraza
 POLL_INTERVAL_SECONDS=1
 SPOA_PID=""
 WATCH_PID=""
 
 if [ "$(id -u)" = "0" ]; then
-    # Fresh Compose log volumes are root-owned. Fix ownership once, then drop
-    # privileges before running coraza-spoa.
-    mkdir -p "$LOG_DIR"
-    if [ "$(stat -c '%U:%G' "$LOG_DIR")" != "coraza:coraza" ]; then
-        chown -R coraza:coraza "$LOG_DIR"
-    fi
     exec su-exec coraza "$0" "$@"
 fi
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -75,7 +75,6 @@ services:
       backend:
         condition: service_healthy
     volumes:
-      - coraza_logs:/var/log/coraza
       - ../../configs/coraza/coraza-spoa.yaml:/etc/coraza-spoa/coraza-spoa.yaml:ro
       - ../../configs/coraza/coraza.conf:/etc/coraza/coraza.conf:ro
       - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
@@ -131,6 +130,5 @@ volumes:
   pgdata:
   haproxy_logs:
   haproxy_runtime:
-  coraza_logs:
   backend_logs:
   generated_config:

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -25,7 +25,7 @@ def test_default_coraza_spoa_config_uses_info_logging() -> None:
     config = (REPO_ROOT / "configs/coraza/coraza-spoa.yaml").read_text()
 
     assert config.count("log_level: info") == 2
-    assert "log_file: /dev/stdout" in config
+    assert "log_file: /dev/stderr" in config
 
 
 def test_default_docker_compose_does_not_use_debug_flag() -> None:


### PR DESCRIPTION
## Summary

- **`SecAuditLog /dev/stdout`** — Coraza audit events (one JSON object per relevant transaction, serial format) now stream to the container's stdout, ready for a log shipper to consume without filesystem access.
- **SPOA logs → stderr** — both `log_file` entries in `coraza-spoa.yaml` changed from `/dev/stdout` to `/dev/stderr`, so the stdout stream is clean newline-delimited JSON with no interleaved operational text.
- **`coraza_logs` volume removed** — the named volume and its bind-mount are dropped from `docker-compose.yml`; `coraza-supervisor.sh` loses the now-unnecessary `LOG_DIR` variable and `mkdir -p`/`chown` block.
- **README updated** — new *Audit log output* section explains the stream and how to view it via `docker compose logs`; new *Event schema and ingest mapping* table provides the deterministic contract (Coraza JSON path → `LogIngestRequest` field) for the future shipper.
- **One test updated** — `test_default_coraza_spoa_config_uses_info_logging` in `test_waf_debug_reference_config.py` asserted the old `/dev/stdout` value; updated to `/dev/stderr`.

## What's not in this PR

No log shipper, no changes to backend routers/schemas/models, no changes to `crs-setup.conf` or `coraza.Dockerfile`.

## Verification

Verified against the running stack:

- `docker compose build coraza` — image builds cleanly.
- Stack up; Coraza healthy on port 9000; HAProxy routes through SPOA.
- `docker logs docker-coraza-1 2>/dev/null` (stdout only): zero output for benign `GET /`, one JSON object per attack. XSS `?q=<script>alert(1)</script>` → `is_interrupted:true`, score 20, 5 CRS rules (941100, 941110, 941160, 941390, 949110). SQLi `?id=1 UNION SELECT` → `is_interrupted:true`, score 15, 4 rules.
- Every stdout line parsed by `jq -c .` without error.
- `docker logs docker-coraza-1 2>&1 1>/dev/null` (stderr only): only SPOA `INF`/`debug` console lines; no audit JSON.
- `uv run python -m pytest -q` → 289 passed, 1 skipped.

## Test plan

- [x] `docker compose build coraza` succeeds
- [x] `docker compose up -d coraza haproxy backend` — all containers reach healthy
- [x] Benign request → no stdout output from coraza; attack request → valid JSON on stdout
- [x] `docker compose logs coraza 2>&1 1>/dev/null` shows only SPOA operational lines (no JSON audit events)
- [x] `uv run python -m pytest -q` passes
