### PR TITLE
docs: update README with current milestone status and cleaner layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,127 @@
 # Guard Proxy
 
-> Self-hosted Reverse Proxy WAF with HAProxy and OWASP Coraza
+> Self-hosted Web Application Firewall — HAProxy + Coraza + React admin panel
 
-## About
+Guard Proxy is a WAF solution built for self-hosted environments. It wires HAProxy 3.0 (reverse proxy) to Coraza WAF (OWASP CRS 4.x) via SPOE, and exposes a FastAPI backend and React admin panel to manage vhosts, policies, rule overrides, and live configuration deployment.
 
-Guard Proxy is a Web Application Firewall (WAF) solution designed for self-hosted environments. It combines HAProxy as a reverse proxy with Coraza WAF engine and OWASP Core Rule Set for threat detection, managed through a web-based admin panel.
+Developed as a master's thesis at Wrocław University DSW.
 
-This project is being developed as a master's thesis at Wroclaw University DSW. 
-
-## Implemented M1 Capabilities
-
-- **HAProxy 3.0** reference reverse proxy with SPOE integration
-- **Coraza SPOA** with OWASP CRS 4.x for request inspection
-- **Fail-closed WAF degraded mode** for unavailable or failed Coraza inspection
-- **FastAPI backend** for auth, vhosts, policies, rule overrides, logs, and health
-- **React admin panel** served by the Docker Compose stack
-- **Docker Compose full-stack deployment** for local development and smoke testing
-
-## Planned/Post-M1 Capabilities
-
-- Generated HAProxy and Coraza configuration from stored policies
-- Policy-driven graceful reload, validation, and rollback
-- Richer per-vhost runtime policy wiring
-- Complete frontend workflows for policy editing, monitoring, and WAF log review
-- Observability with Prometheus, Grafana, and Loki
+---
 
 ## Architecture
 
 ```mermaid
 graph TB
-    C[Clients] -->|HTTP/HTTPS| H[HAProxy]
+    C[Clients] -->|HTTP/HTTPS| H[HAProxy 3.0]
     H -.->|SPOE| CS[Coraza WAF]
-    CS -.->|Allow/Deny| H
+    CS -.->|Allow / Deny| H
     H --> APP[Backend Apps]
 
-    FE[React UI] -->|API| BE[FastAPI]
-    BE -->|Config| H
+    FE[React Admin Panel] -->|REST API| BE[FastAPI]
+    BE -->|Generated config| H
     BE --> DB[(PostgreSQL)]
 ```
 
+---
+
+## What's Implemented
+
+### Milestone 1 — Vertical slice ✅
+- HAProxy 3.0 reverse proxy with SPOE integration
+- Coraza SPOA + OWASP CRS 4.x for request inspection
+- Fail-closed degraded mode when Coraza is unavailable
+- FastAPI backend: auth, vhosts, policies, rule overrides, WAF logs, health
+- React admin panel: dashboard, login, vhost management, policy editing
+- Docker Compose full-stack deployment
+
+### Milestone 2 — Config generator (in progress)
+- Multi-vhost HAProxy + Coraza config generation from stored policies
+- `POST /config/apply` endpoint with atomic swap and automatic rollback
+- inotify-based config reload supervisor (no Docker socket dependency)
+- Live runtime deployment status card in the dashboard
+- Apply-config button in the admin panel
+
+---
+
 ## Tech Stack
 
-- **Proxy**: HAProxy 3.0 with SPOE
-- **WAF**: Coraza SPOA 0.6.1 + OWASP CRS 4.x
-- **Backend**: Python 3.13, FastAPI, SQLAlchemy, PostgreSQL
-- **Frontend**: React, TypeScript, Vite, Tailwind CSS, pnpm
-- **Infrastructure (MVP)**: Docker Compose
-- **Observability (Post-MVP / optional)**: Prometheus, Grafana, Loki
+| Layer | Technology |
+|---|---|
+| Proxy | HAProxy 3.0 with SPOE |
+| WAF | Coraza SPOA 0.6.1 + OWASP CRS 4.x |
+| Backend | Python 3.13, FastAPI, SQLAlchemy, PostgreSQL |
+| Frontend | React, TypeScript, Vite, Tailwind CSS |
+| Package mgmt | uv (Python), pnpm (Node) |
+| Infrastructure | Docker Compose |
 
-## Project Status
+---
 
-**Status**: In development — backend MVP
+## Roadmap
 
-See [project board](https://github.com/users/bihius/projects/1) for detailed task breakdown.
-Or view [milestones](https://github.com/bihius/guard-proxy/milestones)
+| Milestone | Scope | Status |
+|---|---|---|
+| M0 | Cleanup & scaffolding | Done |
+| M1 | Vertical slice — full stack end-to-end | Done |
+| M2 | Config generator & live apply | In progress |
+| M3 | WAF log viewer & alerting | Planned |
+| M4 | Policy hardening & per-vhost rule tuning | Planned |
+| M5 | Admin panel hardening | Planned |
+| M6 | Thesis evaluation — benchmarks, ZAP, Nuclei, CRS suite, ModSecurity/NAXSI comparison | Planned |
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Docker + Docker Compose
+- `make`
+
+### Run
+
+```bash
+cp deploy/docker/.env.example deploy/docker/.env
+# Edit deploy/docker/.env and set your secrets
+
+make run       # normal mode
+make dev       # HAProxy + Coraza debug logging
+```
+
+### Access
+
+| Service | URL |
+|---|---|
+| Admin panel | http://localhost:3000 |
+| API (via HAProxy) | http://localhost:8080 |
+| Health check | `curl http://localhost:8080/health` |
+
+### WAF smoke test
+
+```bash
+curl -i -H 'Host: app.local' \
+  "http://localhost:8080/?id=1%27%20OR%20%271%27=%271"
+# Expected: 403 Forbidden
+```
+
+### Teardown
+
+```bash
+make down    # stop containers, keep volumes
+make clean   # stop containers and remove all volumes
+```
+
+---
 
 ## Documentation
 
-- [Architecture](README.architecture.md) - System architecture and data flow
-- [Development Commands](README.commands.md) - All development commands
-- [Testing Strategy](README.testing.md) - Testing approach and targets
-- [Course team handoff](docs/course-team-handoff.md) - Setup, task assignments, and PR checklist for course contributors
+- [Architecture](README.architecture.md) — system architecture and data flow
+- [Development Commands](README.commands.md) — all dev commands
+- [Testing Strategy](README.testing.md) — testing approach and targets
+- [Project board](https://github.com/users/bihius/projects/1) — task breakdown
+- [Milestones](https://github.com/bihius/guard-proxy/milestones)
 
-## Run Full Stack (Docker Compose)
-
-1. Prepare environment file:
-   - `cp deploy/docker/.env.example deploy/docker/.env`
-   - Update secrets in `deploy/docker/.env`
-2. Start the stack:
-   - `make run` for normal mode
-   - `make dev` for HAProxy and Coraza debug logging
-3. Access services:
-   - Frontend: `http://localhost:3000`
-   - API via HAProxy: `http://localhost:8080`
-   - Backend health via HAProxy: `curl http://localhost:8080/health`
-4. Optional WAF smoke test:
-   - `curl -i -H 'Host: app.local' "http://localhost:8080/?id=1%27%20OR%20%271%27=%271"` should return `403 Forbidden`
-
-Use `make down` to stop containers (keeps named volumes such as Postgres data).
-
-Use `make clean` to stop containers and remove volumes (full local reset).
+---
 
 ## License
 
-MIT License - see [LICENSE](LICENSE)
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Replaces the stale "Implemented M1 Capabilities / Planned Post-M1" structure with a milestone table (M0–M6) showing accurate statuses
- M2 (config generator + live apply) is reflected as in-progress with the concrete work already merged
- Tech stack and services are now tables for easier scanning
- Quick-start section cleaned up with a services table and WAF smoke test block
- Roadmap includes M6 (thesis evaluation benchmarks) as the critical path deliverable

## What changed

The README was last updated at M1 and described M2 work as "planned". Since then the config generator, `POST /config/apply`, inotify reload supervisor, runtime status endpoint, and dashboard apply-config card have all landed. This brings the README in sync with the current state of the repo.

## Reviewer notes

No code changes — docs only.