### PR TITLE
fix(haproxy): revert master socket to mode 660 and restore fall 3 on Coraza SPOA server

### DIFF
--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -94,7 +94,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       [
         "sh",
         "-c",
-        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
       ]
     restart: unless-stopped
     depends_on:

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -106,7 +106,7 @@ backend coraza-spoa
     option spop-check
     timeout connect 5s
     timeout server  3m
-    server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none
+    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
 # --- Local stats endpoint (dev convenience, not exposed publicly) -
 listen stats

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -154,11 +154,11 @@ def test_reference_haproxy_config_fails_closed_when_coraza_is_unavailable() -> N
     )
 
 
-def test_reference_haproxy_config_marks_coraza_down_quickly() -> None:
+def test_reference_haproxy_config_has_coraza_health_parameters() -> None:
     config = (REPO_ROOT / "configs/haproxy/haproxy.cfg").read_text()
 
     assert (
-        "server coraza coraza:9000 check inter 2s fall 1 rise 2 init-addr last,libc,none"
+        "server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none"
         in config
     )
 


### PR DESCRIPTION
## Summary

- **Security (HIGH):** `deploy/docker/docker-compose.yml` — reverts HAProxy master socket from `mode,666` (world-writable) back to `mode,660`. The world-writable socket allowed any process in the HAProxy container to issue runtime API commands (reload, server drain, stats). No reason for `mode,666` was documented; it was introduced without explanation in PR #191.
- **Reliability (MED):** `configs/haproxy/haproxy.cfg` + `src/backend/app/templates/haproxy.cfg.j2` — restores `fall 3` on the Coraza SPOA server health-check (was `fall 1` since PR #183). `fall 1` caused a ~2 s degraded-mode window on every rule apply and config reload, producing spurious 503s. `fall 3` matches the app-backend check threshold and is a more appropriate production setting; smoke-test stability should instead come from the test assertions, not from a production-risky threshold.

## Test plan

- [x] 289 backend unit/integration tests pass (`uv run pytest tests/`)
- [x] `uv run ruff check app/` — all checks passed
- [x] `uv run mypy app/` — no issues found
- [x] TypeScript type-check and lint pass
- [x] Manually verify `ls -l /var/run/haproxy/master.sock` shows `srw-rw----` (660) after `docker compose up`
- [x] Run smoke suite — confirm no false 503 on a single Coraza restart with `fall 3`
