### PR TITLE
fix(config-apply): harden apply pipeline — first-apply cleanup, reload regex, rollback re-validation

### DIFF
--- a/src/backend/app/routers/config.py
+++ b/src/backend/app/routers/config.py
@@ -23,7 +23,10 @@ _apply_lock = threading.Lock()
 
 _HTTP_STATUS: dict[ApplyStatus, int] = {
     ApplyStatus.success: status.HTTP_200_OK,
+    ApplyStatus.write_failed: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    ApplyStatus.state_invalid: status.HTTP_500_INTERNAL_SERVER_ERROR,
     ApplyStatus.validation_failed: status.HTTP_422_UNPROCESSABLE_CONTENT,
+    ApplyStatus.reload_failed: status.HTTP_500_INTERNAL_SERVER_ERROR,
     ApplyStatus.reload_failed_rolled_back: status.HTTP_500_INTERNAL_SERVER_ERROR,
     ApplyStatus.rollback_failed: status.HTTP_500_INTERNAL_SERVER_ERROR,
 }

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -18,13 +19,23 @@ from app.services.config_generator import GeneratedConfig
 
 logger = logging.getLogger(__name__)
 
+# Anchored to the start of a line so common benign substrings such as
+# "no error", "failover ready", or "warning: bind ... failed for ipv6,
+# continuing" do not trigger false-positive failure detection.
+_RELOAD_ERROR_RE = re.compile(
+    r"^\s*(error|fail|denied|permission)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 class ApplyStatus(StrEnum):
     """Outcome classes for config apply attempts."""
 
     success = "success"
     write_failed = "write_failed"
+    state_invalid = "state_invalid"
     validation_failed = "validation_failed"
+    reload_failed = "reload_failed"
     reload_failed_rolled_back = "reload_failed_rolled_back"
     rollback_failed = "rollback_failed"
 
@@ -52,7 +63,26 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
     releases_root = runtime_root / "releases"
     candidate_dir = releases_root / correlation_id
     current_link = runtime_root / "current"
-    previous_target = _read_current_symlink(current_link)
+
+    # Clean up any orphaned temp symlinks left by a previous crash.
+    _sweep_orphaned_temp_links(runtime_root)
+
+    try:
+        previous_target = _read_current_symlink(current_link)
+    except RuntimeError as exc:
+        logger.error(
+            "config-apply state-invalid correlation_id=%s error=%s",
+            correlation_id,
+            exc,
+        )
+        return ApplyResult(
+            status=ApplyStatus.state_invalid,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message=f"Runtime directory state is invalid: {exc}",
+            candidate_path=str(candidate_dir),
+            active_path=str(_resolve_current(current_link)),
+        )
 
     logger.info(
         "config-apply start correlation_id=%s checksum=%s",
@@ -121,14 +151,57 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
     )
 
     if previous_target is None:
+        # No previous release to roll back to. Remove the symlink and the
+        # failed candidate so neither a restart nor the next apply sees broken
+        # state. HAProxy is still running from whatever config it loaded at
+        # container start; the symlink simply doesn't exist until the next
+        # successful apply.
+        try:
+            current_link.unlink(missing_ok=True)
+        except OSError:
+            pass
+        shutil.rmtree(candidate_dir, ignore_errors=True)
+        logger.error(
+            "config-apply reload failed, no previous release; candidate cleaned up "
+            "correlation_id=%s",
+            correlation_id,
+        )
+        return ApplyResult(
+            status=ApplyStatus.reload_failed,
+            correlation_id=correlation_id,
+            checksum=checksum,
+            message=(
+                "Reload failed with no previous release to roll back to; "
+                "candidate cleaned up. HAProxy is running from its startup config."
+            ),
+            candidate_path=str(candidate_dir),
+            active_path=None,
+            validation_output=validation.output,
+            reload_output=reload_result.output,
+        )
+
+    # Validate previous release before attempting rollback reload — it may
+    # have been edited out-of-band. If it no longer validates, skip the reload
+    # and leave current pointing at the candidate (which did pass validation)
+    # so that the next HAProxy restart uses a syntactically valid config.
+    prev_validation = _validate_haproxy(previous_target / "haproxy.cfg")
+    if not prev_validation.ok:
+        logger.critical(
+            "config-apply rollback skipped: previous release no longer validates "
+            "correlation_id=%s",
+            correlation_id,
+        )
         return ApplyResult(
             status=ApplyStatus.rollback_failed,
             correlation_id=correlation_id,
             checksum=checksum,
-            message="Reload failed and no previous release exists for rollback.",
+            message=(
+                "Reload failed and previous release no longer validates; "
+                "current left pointing at new candidate."
+            ),
             candidate_path=str(candidate_dir),
             active_path=str(_resolve_current(current_link)),
-            validation_output=validation.output,
+            validation_output=prev_validation.output,
             reload_output=reload_result.output,
         )
 
@@ -228,9 +301,11 @@ def _reload_haproxy() -> CommandResult:
         return CommandResult(ok=False, output=str(error))
 
     output = b"".join(output_chunks).decode("utf-8", errors="replace").strip()
-    output_lower = output.lower()
-    _error_keywords = ("error", "fail", "denied", "permission")
-    is_error = any(kw in output_lower for kw in _error_keywords)
+    # Use an anchored regex so partial-word matches such as "no error" or
+    # "warning: failed for ipv6, continuing" are not classified as errors.
+    # An empty output (HAProxy 2.7+ returns nothing on success) is treated
+    # as success.
+    is_error = bool(_RELOAD_ERROR_RE.search(output))
     return CommandResult(ok=not is_error, output=output)
 
 
@@ -248,10 +323,16 @@ def _read_current_symlink(current_link: Path) -> Path | None:
     if current_link.is_symlink():
         return _resolve_current(current_link)
 
-    backup_dir = current_link.with_name(f"current-backup-{uuid.uuid4().hex}")
-    shutil.move(str(current_link), str(backup_dir))
-    current_link.symlink_to(os.path.relpath(backup_dir, start=current_link.parent))
-    return backup_dir.resolve()
+    # current exists but is a real directory — this is not a supported state.
+    # The seed step (container init) is responsible for creating the initial
+    # symlink; if it left a directory here instead, the runtime directory is
+    # corrupt. Refuse to proceed so the operator is notified immediately
+    # rather than silently corrupting the directory layout with a non-atomic
+    # move + re-symlink.
+    raise RuntimeError(
+        f"{current_link} is a directory, not a symlink. "
+        "Restore the runtime directory to a clean state and restart the container."
+    )
 
 
 def _resolve_current(current_link: Path) -> Path | None:
@@ -261,6 +342,16 @@ def _resolve_current(current_link: Path) -> Path | None:
         return current_link.resolve(strict=True)
     except OSError:
         return None
+
+
+def _sweep_orphaned_temp_links(runtime_root: Path) -> None:
+    """Remove any .current-*.tmp symlinks left by a previous crash."""
+    for p in runtime_root.glob(".current-*.tmp"):
+        try:
+            p.unlink()
+            logger.debug("swept orphaned temp link %s", p)
+        except OSError:
+            pass
 
 
 def _calculate_checksum(generated: GeneratedConfig) -> str:

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -7,6 +7,8 @@ from app.config import settings
 from app.services.config_apply import (
     ApplyStatus,
     CommandResult,
+    _RELOAD_ERROR_RE,
+    _read_current_symlink,
     apply,
 )
 from app.services.config_generator import GeneratedConfig
@@ -192,3 +194,154 @@ def test_apply_logs_attempt_with_correlation_id(
     )
     assert start_record is not None
     assert result.correlation_id in start_record.message
+
+
+# ---------------------------------------------------------------------------
+# HIGH #2 — first-apply reload failure must clean up candidate and symlink
+# ---------------------------------------------------------------------------
+
+
+def test_apply_reload_failure_with_no_previous_cleans_up_and_returns_reload_failed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """When there is no previous release and reload fails, the candidate directory
+    and current symlink must be removed so the next restart uses the startup config."""
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=True, output="valid"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: CommandResult(ok=False, output="reload failed"),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.reload_failed
+    assert result.active_path is None
+    # Candidate dir must be cleaned up
+    releases_root = runtime_root / "releases"
+    remaining = list(releases_root.iterdir()) if releases_root.exists() else []
+    assert remaining == [], f"Expected no leftover candidate dirs, found: {remaining}"
+    # current symlink must not exist
+    assert not (runtime_root / "current").exists()
+    assert not (runtime_root / "current").is_symlink()
+
+
+# ---------------------------------------------------------------------------
+# MED M1 — reload error regex must not false-positive on benign substrings
+# ---------------------------------------------------------------------------
+
+
+def test_reload_error_regex_does_not_match_benign_strings() -> None:
+    benign_outputs = [
+        # Common HAProxy success responses to the master socket reload command.
+        "[1] (SIGTERM->MASTER)",
+        "Success=1 Failure=0",
+        # Mid-sentence occurrences that are not line-leading error keywords.
+        "no error",
+        "failover ready",
+        # IPv6 warning during bind — often emitted but non-fatal; the "failed"
+        # substring is not at the start of the line.
+        "warning: bind to 0.0.0.0:80 failed for ipv6, continuing",
+        "",
+    ]
+    for output in benign_outputs:
+        assert not _RELOAD_ERROR_RE.search(output), (
+            f"Regex incorrectly matched benign output: {output!r}"
+        )
+
+
+def test_reload_error_regex_matches_error_lines() -> None:
+    error_outputs = [
+        "error connecting to backend",
+        "fail to bind",
+        "denied by rule",
+        "permission denied",
+        "  error: something went wrong",
+    ]
+    for output in error_outputs:
+        assert _RELOAD_ERROR_RE.search(output), (
+            f"Regex did not match expected error output: {output!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# MED M3 — non-symlink current directory must raise RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_read_current_symlink_raises_for_plain_directory(tmp_path: Path) -> None:
+    """A real directory at runtime/current is an invalid state and must raise."""
+    current = tmp_path / "current"
+    current.mkdir()
+    (current / "haproxy.cfg").write_text("global\n", encoding="utf-8")
+
+    import pytest
+    with pytest.raises(RuntimeError, match="is a directory"):
+        _read_current_symlink(current)
+
+
+def test_apply_returns_state_invalid_when_current_is_directory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    runtime_root.mkdir(parents=True)
+    current = runtime_root / "current"
+    current.mkdir()
+    (current / "haproxy.cfg").write_text("global\n", encoding="utf-8")
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.state_invalid
+    assert "directory" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# MED M4 — rollback path must validate previous release before reloading
+# ---------------------------------------------------------------------------
+
+
+def test_apply_skips_rollback_reload_when_previous_no_longer_validates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """If the previous release fails haproxy -c, skip the rollback reload and
+    leave current pointing at the candidate (which passed validation)."""
+    runtime_root = tmp_path / "generated"
+    _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+
+    call_count = {"n": 0}
+
+    def _validate_stub(config_path: Path) -> CommandResult:
+        call_count["n"] += 1
+        # First call: candidate validation — succeeds.
+        # Second call: previous release validation in rollback path — fails.
+        if call_count["n"] == 1:
+            return CommandResult(ok=True, output="valid")
+        return CommandResult(ok=False, output="previous config parse error")
+
+    monkeypatch.setattr("app.services.config_apply._validate_haproxy", _validate_stub)
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: CommandResult(ok=False, output="reload failed"),
+    )
+
+    result = apply(_sample_generated())
+
+    assert result.status == ApplyStatus.rollback_failed
+    assert "no longer validates" in result.message
+    # current must still point at the candidate (not the invalid previous)
+    current_resolved = (runtime_root / "current").resolve()
+    releases_root = runtime_root / "releases"
+    candidates = [
+        p for p in releases_root.iterdir()
+        if p.name != "previous" and p.resolve() == current_resolved
+    ]
+    assert candidates, "current should point at the new candidate after rollback skipped"


### PR DESCRIPTION
## Summary

Five correctness findings addressed, all from the retrospective review of PR #185 / #186 / #187:

- **[HIGH] First-apply reload failure left broken candidate live** — when there is no previous release and reload fails, the current symlink was already pointing at the failed candidate with no cleanup. Apply now unlinks `current` and removes the candidate dir. Returns a new `reload_failed` status (no rollback was attempted; `rollback_failed` was misleading).
- **[MED M1] Reload success detection used broad substring scan** — replaced `any(kw in output_lower ...)` with a line-anchored regex `^\s*(error|fail|denied|permission)\b`. Benign strings like `"no error"`, `"failover ready"`, and mid-sentence `"failed for ipv6, continuing"` no longer trigger spurious rollbacks.
- **[MED M2] `write_failed` absent from `_HTTP_STATUS`** — added `write_failed`, `state_invalid`, and `reload_failed` to the router's status map so they return proper 500s instead of falling through.
- **[MED M3] Non-symlink `current` caused non-atomic auto-convert** — replaced `shutil.move` + `symlink_to` with a hard `RuntimeError`. The seed step owns symlink creation. Surfaced as `state_invalid` in the apply response.
- **[MED M4] Rollback reload skipped previous-release re-validation** — `_validate_haproxy` is now called on the previous release before the rollback swap. If it fails, `current` stays pointing at the new candidate (which did pass validation) and returns `rollback_failed` with a clear message.

Also: sweep orphaned `.current-*.tmp` crash-remnant symlinks on each apply call.

## Test plan

- [x] `uv run pytest tests/` — 295 passed, 1 skipped
- [x] `uv run ruff check app/` — all checks passed
- [x] `uv run mypy app/` — no issues found
- [x] New test: first-apply reload failure cleans up candidate and unlinks `current`
- [x] New test: regex benign/error coverage
- [x] New test: `_read_current_symlink` raises on plain directory
- [x] New test: apply returns `state_invalid` when `current` is a directory
- [x] New test: rollback skipped and `rollback_failed` returned when previous no longer validates
