### PR TITLE
fix(runtime-status): correct deployment_state and remove policy-id-0 sentinel

### DIFF
--- a/src/backend/app/schemas/runtime_status.py
+++ b/src/backend/app/schemas/runtime_status.py
@@ -20,6 +20,10 @@ class RuntimeGeneratedConfigStatus(BaseModel):
     checksum: str | None = None
     generated_at: datetime | None = None
     error: str | None = None
+    # Domains of active vhosts that have no policy assigned. They will be
+    # served using the default CRS context. Listed here as a visibility aid
+    # so operators know which vhosts are running without an explicit policy.
+    unbound_vhost_domains: list[str] | None = None
 
 
 class RuntimeOperationSnapshot(BaseModel):

--- a/src/backend/app/services/runtime_status_service.py
+++ b/src/backend/app/services/runtime_status_service.py
@@ -64,6 +64,11 @@ class RuntimeStatusService:
             self.db.query(RuleOverride).order_by(RuleOverride.id.asc()).all()
         )
         active_vhosts = [vhost for vhost in vhosts if vhost.is_active]
+        # Compute before calling _pick_active_policy so they appear in the
+        # response regardless of whether generation succeeds or fails.
+        unbound_vhost_domains = [
+            v.domain for v in active_vhosts if v.policy_id is None
+        ] or None
 
         try:
             active_policy, active_overrides = self._pick_active_policy(
@@ -79,6 +84,7 @@ class RuntimeStatusService:
             return RuntimeGeneratedConfigStatus(
                 can_generate=False,
                 error=str(error),
+                unbound_vhost_domains=unbound_vhost_domains,
             )
 
         return RuntimeGeneratedConfigStatus(
@@ -89,6 +95,7 @@ class RuntimeStatusService:
                 rule_overrides_conf,
             ),
             generated_at=datetime.now(UTC),
+            unbound_vhost_domains=unbound_vhost_domains,
         )
 
     def _get_latest_operation(
@@ -110,18 +117,14 @@ class RuntimeStatusService:
         latest_reload: RuntimeOperationSnapshot | None,
     ) -> DeploymentState:
         if latest_reload is None:
+            # No reload has ever been attempted via the API.
             return "never_deployed"
         if latest_reload.status == RuntimeOperationStatus.success:
             return "deployed"
-
-        latest_successful_reload = (
-            self.db.query(RuntimeOperation.id)
-            .filter(RuntimeOperation.operation_type == RuntimeOperationType.reload)
-            .filter(RuntimeOperation.status == RuntimeOperationStatus.success)
-            .first()
-        )
-        if latest_successful_reload is None:
-            return "never_deployed"
+        # Latest reload was not successful. Whether or not a prior apply ever
+        # succeeded, the current state is "failed" — not "never_deployed".
+        # Returning "never_deployed" here was incorrect because a reload WAS
+        # attempted; it just failed.
         return "failed"
 
     @staticmethod
@@ -153,7 +156,10 @@ class RuntimeStatusService:
         effective_policy_ids: set[int] = set()
         for vhost in active_vhosts:
             if vhost.policy_id is None:
-                effective_policy_ids.add(0)
+                # Policy-less vhosts are served using the default CRS context.
+                # Do NOT add a sentinel 0 here — that caused "policy id 0" to
+                # appear in the multiple-policy error message when mixed with
+                # policy-bound vhosts.
                 continue
 
             policy = policies_by_id.get(vhost.policy_id)
@@ -178,8 +184,9 @@ class RuntimeStatusService:
                 f"found effective policies: {policy_list}"
             )
 
-        effective_policy_id = next(iter(effective_policy_ids), 0)
-        if effective_policy_id == 0:
+        effective_policy_id = next(iter(effective_policy_ids), None)
+        if effective_policy_id is None:
+            # No policy-bound vhosts; use the default CRS context.
             return (
                 CrsPolicyRenderContext(
                     paranoia_level=1,

--- a/src/backend/tests/unit/test_runtime_status_service.py
+++ b/src/backend/tests/unit/test_runtime_status_service.py
@@ -57,9 +57,11 @@ def test_deployment_state_is_deployed_when_latest_reload_succeeded(db: Session) 
     assert status.latest_reload.status == RuntimeOperationStatus.success
 
 
-def test_deployment_state_stays_never_deployed_with_only_failed_reloads(
+def test_deployment_state_is_failed_with_only_failed_reloads_and_no_prior_success(
     db: Session,
 ) -> None:
+    """A failed reload with no prior successful reload is 'failed', not 'never_deployed'.
+    The API was called and a reload was attempted; that attempt failed."""
     _add_operation(
         db,
         operation_type=RuntimeOperationType.reload,
@@ -70,7 +72,7 @@ def test_deployment_state_stays_never_deployed_with_only_failed_reloads(
 
     status = service.get_runtime_status()
 
-    assert status.deployment_state == "never_deployed"
+    assert status.deployment_state == "failed"
     assert status.latest_reload is not None
     assert status.latest_reload.status == RuntimeOperationStatus.failed
 
@@ -294,3 +296,83 @@ def test_checksum_changes_when_generated_content_changes() -> None:
     )
 
     assert checksum_a != checksum_b
+
+
+# ---------------------------------------------------------------------------
+# MED M6 — policy-less vhosts must not cause "policy id 0" error
+# ---------------------------------------------------------------------------
+
+
+def test_generated_config_allows_policy_less_vhost_alongside_policy_bound(
+    db: Session,
+) -> None:
+    """A mix of policy-less and policy-bound active vhosts should not raise.
+    Previously this caused 'found effective policies: 0, <id>' due to sentinel 0."""
+    policy = _add_policy(db, name="Production")
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        policy_id=policy.id,
+    )
+    _add_vhost(
+        db,
+        domain="api.example.com",
+        backend_url="http://api-backend:8000",
+        policy_id=None,  # policy-less
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is True
+    assert status.generated_config.error is None
+    # The policy-less vhost should be reported in the warning field
+    assert status.generated_config.unbound_vhost_domains == ["api.example.com"]
+
+
+def test_generated_config_reports_unbound_vhost_domains(db: Session) -> None:
+    """All policy-less active vhosts are listed in unbound_vhost_domains."""
+    _add_vhost(
+        db,
+        domain="a.example.com",
+        backend_url="http://a-backend:8000",
+        policy_id=None,
+    )
+    _add_vhost(
+        db,
+        domain="b.example.com",
+        backend_url="http://b-backend:8000",
+        policy_id=None,
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is True
+    assert status.generated_config.unbound_vhost_domains is not None
+    assert set(status.generated_config.unbound_vhost_domains) == {
+        "a.example.com",
+        "b.example.com",
+    }
+
+
+def test_generated_config_unbound_vhost_domains_is_none_when_all_bound(
+    db: Session,
+) -> None:
+    policy = _add_policy(db, name="Strict")
+    _add_vhost(
+        db,
+        domain="app.example.com",
+        backend_url="http://app-backend:8000",
+        policy_id=policy.id,
+    )
+    db.commit()
+    service = RuntimeStatusService(db)
+
+    status = service.get_runtime_status()
+
+    assert status.generated_config.can_generate is True
+    assert status.generated_config.unbound_vhost_domains is None


### PR DESCRIPTION
## Summary

Two correctness findings from the retrospective review of PR #178:

- **[MED M5] `deployment_state` returned `"never_deployed"` when a reload was attempted and failed** — `_derive_deployment_state` did a secondary "was there ever a successful reload?" query and returned `"never_deployed"` if not. A failed reload attempt is not "never deployed" — the API was called, a reload was issued, it failed. `"never_deployed"` is now reserved for `latest_reload is None` (no reload record at all). The redundant sub-query is removed.
- **[MED M6] `_pick_active_policy` added sentinel `0` for policy-less vhosts** — this caused `"found effective policies: 0, 5"` when a policy-less and a policy-bound vhost were both active. Policy-less vhosts are now skipped when building `effective_policy_ids` (they get the default CRS context). Their domains are surfaced in a new `unbound_vhost_domains` field on `RuntimeGeneratedConfigStatus` for operator visibility.

## Test plan

- [x] `uv run pytest tests/` — 292 passed, 1 skipped
- [x] `uv run ruff check app/` — all checks passed
- [x] `uv run mypy app/` — no issues found
- [x] Updated test: `test_deployment_state_stays_never_deployed_with_only_failed_reloads` → now asserts `"failed"`
- [x] New test: policy-less vhost alongside policy-bound vhost generates successfully
- [x] New test: `unbound_vhost_domains` populated and None when all vhosts are bound
