### PR TITLE
fix(config-generator): use vhost id for HAProxy identifiers; add cross-context uniqueness check

### DIFF
--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -88,25 +88,27 @@ def _pick_active_policy(
 
 
 def _to_haproxy_context(vhost: VHost) -> HaproxyRenderContext:
-    domain_slug = _slug(vhost.domain)
+    if vhost.id is None:
+        raise ValueError(f"Active vhost {vhost.domain!r} has no persisted id")
+    # Use the database id as the naming suffix so that domain names that only
+    # differ by '.' vs '-' (e.g. "app.local" and "app-local") never produce
+    # colliding ACL or backend identifiers.  This matches the strategy used
+    # by RuntimeStatusService._to_haproxy_route.
+    suffix = f"vhost_{vhost.id}"
     backend_address = _extract_backend_address(vhost.backend_url)
     return HaproxyRenderContext(
         routes=(
             HaproxyRoute(
-                vhost_acl_name=f"host_{domain_slug}",
+                vhost_acl_name=f"host_{suffix}",
                 vhost_hosts=(vhost.domain,),
                 backend=HaproxyBackend(
-                    name=f"be_{domain_slug}",
-                    server_name=f"srv_{domain_slug}",
+                    name=f"be_{suffix}",
+                    server_name=f"srv_{suffix}",
                     address=backend_address,
                 ),
             ),
         )
     )
-
-
-def _slug(value: str) -> str:
-    return value.replace(".", "_").replace("-", "_")
 
 
 def _to_crs_policy_context(policy: Policy) -> CrsPolicyRenderContext:

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -146,8 +146,26 @@ def render_haproxy_cfg(context: HaproxyRenderContext) -> str:
 
 
 def render_haproxy_cfg_multi(vhost_contexts: list[HaproxyRenderContext]) -> str:
-    """Render haproxy.cfg from one or many prepared vhost contexts."""
+    """Render haproxy.cfg from one or many prepared vhost contexts.
+
+    Raises ValueError if any ACL name, backend name, or server name is
+    duplicated across the merged set of contexts.  Each HaproxyRenderContext
+    only validates uniqueness within itself; this function performs the
+    cross-context check.
+    """
     routes = tuple(route for context in vhost_contexts for route in context.routes)
+    _ensure_unique(
+        (route.vhost_acl_name for route in routes),
+        "render_haproxy_cfg_multi routes.vhost_acl_name",
+    )
+    _ensure_unique(
+        (route.backend.name for route in routes),
+        "render_haproxy_cfg_multi routes.backend.name",
+    )
+    _ensure_unique(
+        (route.backend.server_name for route in routes),
+        "render_haproxy_cfg_multi routes.backend.server_name",
+    )
     return _render_haproxy_routes(routes)
 
 

--- a/src/backend/tests/unit/test_config_generator.py
+++ b/src/backend/tests/unit/test_config_generator.py
@@ -1,7 +1,10 @@
+import pytest
+
 from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.vhost import VHost
 from app.services.config_generator import generate
+from app.services.config_renderer import HaproxyBackend, HaproxyRenderContext, HaproxyRoute, render_haproxy_cfg_multi
 
 
 def test_generate_empty_db() -> None:
@@ -27,15 +30,17 @@ def test_generate_one_vhost_no_policy() -> None:
 
     generated = generate(vhosts=[vhost], policies=[], rule_overrides=[])
 
-    assert "acl host_app_local hdr(host),field(1,:) -i app.local" in generated.haproxy_cfg
-    assert "use_backend be_app_local if host_app_local" in generated.haproxy_cfg
-    assert "server srv_app_local backend:8000 check" in generated.haproxy_cfg
+    # Identifiers are based on vhost.id, not domain slug, to avoid collisions
+    # between domains that only differ in '.' vs '-'.
+    assert "acl host_vhost_1 hdr(host),field(1,:) -i app.local" in generated.haproxy_cfg
+    assert "use_backend be_vhost_1 if host_vhost_1" in generated.haproxy_cfg
+    assert "server srv_vhost_1 backend:8000 check" in generated.haproxy_cfg
     assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
 
 
 def test_generate_one_vhost_with_policy() -> None:
     vhost = VHost(
-        id=1,
+        id=5,
         domain="api.example.com",
         backend_url="http://api-backend:9000",
         is_active=True,
@@ -54,8 +59,8 @@ def test_generate_one_vhost_with_policy() -> None:
 
     generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[])
 
-    assert "acl host_api_example_com hdr(host),field(1,:) -i api.example.com" in generated.haproxy_cfg
-    assert "use_backend be_api_example_com if host_api_example_com" in generated.haproxy_cfg
+    assert "acl host_vhost_5 hdr(host),field(1,:) -i api.example.com" in generated.haproxy_cfg
+    assert "use_backend be_vhost_5 if host_vhost_5" in generated.haproxy_cfg
     assert "SecRuleEngine On" in generated.crs_setup_conf
     assert "setvar:tx.blocking_paranoia_level=2" in generated.crs_setup_conf
 
@@ -88,3 +93,88 @@ def test_generate_one_vhost_with_policy_and_overrides() -> None:
     generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[override])
 
     assert "SecRuleRemoveById 942100" in generated.rule_overrides_conf
+
+
+# ---------------------------------------------------------------------------
+# MED M9 — domain slug collision: app.local vs app-local must not collide
+# ---------------------------------------------------------------------------
+
+
+def test_generate_dot_dash_domain_siblings_do_not_collide() -> None:
+    """Domains that only differ in '.' vs '-' must get distinct identifiers.
+
+    Previously _slug() replaced both with '_', making 'app.local' and
+    'app-local' both produce 'app_local' and collide.  With id-based naming
+    they are distinct as long as they have different database ids.
+    """
+    vhost_dot = VHost(
+        id=3,
+        domain="app.local",
+        backend_url="http://dot-backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+    vhost_dash = VHost(
+        id=7,
+        domain="app-local",
+        backend_url="http://dash-backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+
+    generated = generate(vhosts=[vhost_dot, vhost_dash], policies=[], rule_overrides=[])
+
+    assert generated.haproxy_cfg is not None
+    assert "host_vhost_3" in generated.haproxy_cfg
+    assert "host_vhost_7" in generated.haproxy_cfg
+    assert "be_vhost_3" in generated.haproxy_cfg
+    assert "be_vhost_7" in generated.haproxy_cfg
+
+
+# ---------------------------------------------------------------------------
+# MED M8 — cross-context uniqueness: render_haproxy_cfg_multi must validate
+# ---------------------------------------------------------------------------
+
+
+def _make_single_route_context(acl_name: str, backend_name: str) -> HaproxyRenderContext:
+    return HaproxyRenderContext(
+        routes=(
+            HaproxyRoute(
+                vhost_acl_name=acl_name,
+                vhost_hosts=("example.com",),
+                backend=HaproxyBackend(
+                    name=backend_name,
+                    server_name=f"srv_{acl_name}",
+                    address="backend:8000",
+                ),
+            ),
+        )
+    )
+
+
+def test_render_haproxy_cfg_multi_raises_on_duplicate_acl_name_across_contexts() -> None:
+    ctx_a = _make_single_route_context("host_a", "be_a")
+    ctx_b = _make_single_route_context("host_a", "be_b")  # duplicate ACL name
+
+    with pytest.raises(ValueError, match="duplicate HAProxy identifier"):
+        render_haproxy_cfg_multi([ctx_a, ctx_b])
+
+
+def test_render_haproxy_cfg_multi_raises_on_duplicate_backend_name_across_contexts() -> None:
+    ctx_a = _make_single_route_context("host_a", "be_shared")
+    ctx_b = _make_single_route_context("host_b", "be_shared")  # duplicate backend name
+
+    with pytest.raises(ValueError, match="duplicate HAProxy identifier"):
+        render_haproxy_cfg_multi([ctx_a, ctx_b])
+
+
+def test_render_haproxy_cfg_multi_succeeds_with_distinct_contexts() -> None:
+    ctx_a = _make_single_route_context("host_a", "be_a")
+    ctx_b = _make_single_route_context("host_b", "be_b")
+
+    result = render_haproxy_cfg_multi([ctx_a, ctx_b])
+
+    assert "host_a" in result
+    assert "host_b" in result


### PR DESCRIPTION
## Summary

Two correctness findings from the retrospective review of PR #177:

- **[MED M9] Domain slug collision for `.` vs `-`** — `_to_haproxy_context` used a `_slug()` helper that replaced both `.` and `-` with `_`. Domains `app.local` and `app-local` both produced `app_local`, colliding on ACL name and backend name in the generated HAProxy config. Switched to `vhost.id`-based suffixes (`host_vhost_3`, `be_vhost_7`, etc.), matching the strategy already used in `RuntimeStatusService._to_haproxy_route`. Removed `_slug`.

- **[MED M8] No cross-context uniqueness validation in `render_haproxy_cfg_multi`** — each `HaproxyRenderContext` validates uniqueness within itself, but when multiple contexts are merged by `render_haproxy_cfg_multi`, cross-context collisions went undetected until `haproxy -c` failed at deploy time. Added three `_ensure_unique` calls (ACL name, backend name, server name) at the merge point so collisions raise `ValueError` at render time with a clear message.

## Test plan

- [x] `uv run pytest tests/` — 293 passed, 1 skipped
- [x] `uv run ruff check app/` — all checks passed
- [x] `uv run mypy app/` — no issues found
- [x] New test: `app.local` and `app-local` (id=3, id=7) generate without collision
- [x] New test: `render_haproxy_cfg_multi` raises on duplicate ACL/backend names across contexts
- [x] Updated tests: single-vhost generate assertions use `host_vhost_<id>` pattern
