### PR TITLE
feat(vhosts): wire VHostsPage to real /vhosts API with admin CRUD

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/vite": "^4.1.14",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.5.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.5.2
         version: 24.12.0
@@ -683,6 +686,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2201,6 +2210,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 

--- a/src/frontend/src/components/shared/Modal.test.tsx
+++ b/src/frontend/src/components/shared/Modal.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Modal } from "./Modal";
+
+describe("Modal", () => {
+  it("renders title and children", () => {
+    render(
+      <Modal title="Test dialog" onClose={vi.fn()}>
+        <p>Modal content</p>
+      </Modal>,
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Test dialog")).toBeInTheDocument();
+    expect(screen.getByText("Modal content")).toBeInTheDocument();
+  });
+
+  it("calls onClose when backdrop is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <Modal title="Dialog" onClose={onClose}>
+        <p>Content</p>
+      </Modal>,
+    );
+    await userEvent.click(screen.getByLabelText("Close dialog"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    render(
+      <Modal title="Dialog" onClose={onClose}>
+        <p>Content</p>
+      </Modal>,
+    );
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders footer when provided", () => {
+    render(
+      <Modal title="Dialog" onClose={vi.fn()} footer={<button>OK</button>}>
+        <p>Content</p>
+      </Modal>,
+    );
+    expect(screen.getByRole("button", { name: "OK" })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/shared/Modal.tsx
+++ b/src/frontend/src/components/shared/Modal.tsx
@@ -1,0 +1,34 @@
+import { useEffect, type ReactNode } from "react";
+
+type ModalProps = {
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  onClose: () => void;
+};
+
+export function Modal({ title, children, footer, onClose }: ModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-label="Close dialog"
+      />
+      <div className="absolute left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-[var(--radius-xl)] border border-border bg-surface p-6 shadow-card-lg">
+        <h2 className="mb-4 text-lg font-bold text-fg">{title}</h2>
+        <div className="space-y-4">{children}</div>
+        {footer ? <div className="mt-6 flex justify-end gap-3">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/features/vhosts/DeleteVHostDialog.tsx
+++ b/src/frontend/src/features/vhosts/DeleteVHostDialog.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { deleteVHost } from "./api";
+import type { VHost } from "./types";
+
+type DeleteVHostDialogProps = {
+  vhost: VHost;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function DeleteVHostDialog({ vhost, onSuccess, onClose }: DeleteVHostDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await deleteVHost(accessToken, vhost.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete virtual host"
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            className="rounded-[var(--radius-md)] bg-error px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? "Deleting…" : "Delete"}
+          </button>
+        </>
+      }
+    >
+      {serverError && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+        >
+          {serverError}
+        </div>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete{" "}
+        <span className="font-semibold text-fg">{vhost.domain}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/vhosts/VHostFormModal.test.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import { ApiError } from "@/lib/api-client";
+
+import * as api from "./api";
+import { VHostFormModal } from "./VHostFormModal";
+import type { Policy } from "./types";
+
+vi.mock("./api");
+
+const policies: Policy[] = [
+  { id: 1, name: "Default" },
+  { id: 2, name: "Strict" },
+];
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: null,
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderCreateModal(onSuccess = vi.fn(), onClose = vi.fn()) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext()}>
+      <VHostFormModal mode="create" policies={policies} onSuccess={onSuccess} onClose={onClose} />
+    </AuthContext.Provider>,
+  );
+}
+
+describe("VHostFormModal (create)", () => {
+  it("submits create payload with filled fields", async () => {
+    vi.mocked(api.createVHost).mockResolvedValue({
+      id: 1,
+      domain: "new.example.com",
+      backend_url: "https://new.internal",
+      description: null,
+      ssl_enabled: false,
+      is_active: true,
+      policy_id: null,
+      created_by: 1,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    const onSuccess = vi.fn();
+    renderCreateModal(onSuccess);
+
+    await userEvent.type(screen.getByLabelText("Domain"), "new.example.com");
+    await userEvent.type(screen.getByLabelText("Backend URL"), "https://new.internal");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+    expect(api.createVHost).toHaveBeenCalledWith(
+      "test-token",
+      expect.objectContaining({
+        domain: "new.example.com",
+        backend_url: "https://new.internal",
+      }),
+    );
+  });
+
+  it("shows server error detail on rejection", async () => {
+    vi.mocked(api.createVHost).mockRejectedValue(
+      new ApiError(409, "Domain already exists"),
+    );
+
+    renderCreateModal();
+
+    await userEvent.type(screen.getByLabelText("Domain"), "dup.example.com");
+    await userEvent.type(screen.getByLabelText("Backend URL"), "https://dup.internal");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Domain already exists"),
+    );
+  });
+});

--- a/src/frontend/src/features/vhosts/VHostFormModal.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.tsx
@@ -1,0 +1,190 @@
+import { type FormEvent, useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { createVHost, updateVHost } from "./api";
+import type { Policy, VHost } from "./types";
+
+type CreateMode = { mode: "create" };
+type EditMode = { mode: "edit"; vhost: VHost };
+
+type VHostFormModalProps = (CreateMode | EditMode) & {
+  policies: Policy[];
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function VHostFormModal(props: VHostFormModalProps) {
+  const { policies, onSuccess, onClose } = props;
+  const { accessToken } = useAuth();
+
+  const initial = props.mode === "edit" ? props.vhost : null;
+
+  const [domain, setDomain] = useState(initial?.domain ?? "");
+  const [backendUrl, setBackendUrl] = useState(initial?.backend_url ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [sslEnabled, setSslEnabled] = useState(initial?.ssl_enabled ?? false);
+  const [isActive, setIsActive] = useState(initial?.is_active ?? true);
+  const [policyId, setPolicyId] = useState<string>(
+    initial?.policy_id != null ? String(initial.policy_id) : "",
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    const body = {
+      domain,
+      backend_url: backendUrl,
+      description: description || null,
+      ssl_enabled: sslEnabled,
+      is_active: isActive,
+      policy_id: policyId ? Number(policyId) : null,
+    };
+
+    try {
+      if (props.mode === "edit") {
+        await updateVHost(accessToken, props.vhost.id, body);
+      } else {
+        await createVHost(accessToken, body);
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title = props.mode === "create" ? "New virtual host" : "Edit virtual host";
+
+  return (
+    <Modal
+      title={title}
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="vhost-form"
+            disabled={submitting}
+            className="btn-primary px-4 py-2 text-sm"
+          >
+            {submitting ? "Saving…" : props.mode === "create" ? "Create" : "Save"}
+          </button>
+        </>
+      }
+    >
+      <form id="vhost-form" onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        {serverError && (
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <label htmlFor="vhost-domain" className="block text-sm font-medium text-fg-muted">
+            Domain
+          </label>
+          <input
+            id="vhost-domain"
+            type="text"
+            required
+            maxLength={255}
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+            className="input-field"
+            placeholder="example.com"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="vhost-backend-url" className="block text-sm font-medium text-fg-muted">
+            Backend URL
+          </label>
+          <input
+            id="vhost-backend-url"
+            type="url"
+            required
+            maxLength={512}
+            value={backendUrl}
+            onChange={(e) => setBackendUrl(e.target.value)}
+            className="input-field"
+            placeholder="https://backend.internal"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="vhost-description" className="block text-sm font-medium text-fg-muted">
+            Description
+          </label>
+          <input
+            id="vhost-description"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="input-field"
+            placeholder="Optional"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="vhost-policy" className="block text-sm font-medium text-fg-muted">
+            Policy
+          </label>
+          <select
+            id="vhost-policy"
+            value={policyId}
+            onChange={(e) => setPolicyId(e.target.value)}
+            className="input-field"
+          >
+            <option value="">None</option>
+            {policies.map((p) => (
+              <option key={p.id} value={String(p.id)}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center gap-6">
+          <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
+            <input
+              type="checkbox"
+              checked={sslEnabled}
+              onChange={(e) => setSslEnabled(e.target.checked)}
+              className="h-4 w-4 accent-accent"
+            />
+            SSL enabled
+          </label>
+
+          <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
+            <input
+              type="checkbox"
+              checked={isActive}
+              onChange={(e) => setIsActive(e.target.checked)}
+              className="h-4 w-4 accent-accent"
+            />
+            Active
+          </label>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/vhosts/api.ts
+++ b/src/frontend/src/features/vhosts/api.ts
@@ -1,0 +1,27 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { Policy, VHost, VHostCreate, VHostUpdate } from "./types";
+
+export function listVHosts(token: string, signal?: AbortSignal) {
+  return apiRequest<VHost[]>("/vhosts", { token, signal });
+}
+
+export function createVHost(token: string, body: VHostCreate) {
+  return apiRequest<VHost>("/vhosts", { method: "POST", token, body });
+}
+
+export function updateVHost(token: string, id: number, body: VHostUpdate) {
+  return apiRequest<VHost>(`/vhosts/${id}`, { method: "PATCH", token, body });
+}
+
+export function deleteVHost(token: string, id: number) {
+  return apiRequest<void>(`/vhosts/${id}`, {
+    method: "DELETE",
+    token,
+    responseType: "empty",
+  });
+}
+
+export function listPolicies(token: string, signal?: AbortSignal) {
+  return apiRequest<Policy[]>("/policies", { token, signal });
+}

--- a/src/frontend/src/features/vhosts/types.ts
+++ b/src/frontend/src/features/vhosts/types.ts
@@ -6,7 +6,7 @@ export type VHost = {
   ssl_enabled: boolean;
   is_active: boolean;
   policy_id: number | null;
-  created_by: number;
+  created_by: number | null;
   created_at: string;
   updated_at: string;
 };

--- a/src/frontend/src/features/vhosts/types.ts
+++ b/src/frontend/src/features/vhosts/types.ts
@@ -1,0 +1,35 @@
+export type VHost = {
+  id: number;
+  domain: string;
+  backend_url: string;
+  description: string | null;
+  ssl_enabled: boolean;
+  is_active: boolean;
+  policy_id: number | null;
+  created_by: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type VHostCreate = {
+  domain: string;
+  backend_url: string;
+  description?: string | null;
+  ssl_enabled?: boolean;
+  is_active?: boolean;
+  policy_id?: number | null;
+};
+
+export type VHostUpdate = {
+  domain?: string;
+  backend_url?: string;
+  description?: string | null;
+  ssl_enabled?: boolean;
+  is_active?: boolean;
+  policy_id?: number | null;
+};
+
+export type Policy = {
+  id: number;
+  name: string;
+};

--- a/src/frontend/src/features/vhosts/use-vhosts.ts
+++ b/src/frontend/src/features/vhosts/use-vhosts.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+
+import { listPolicies, listVHosts } from "./api";
+import type { Policy, VHost } from "./types";
+
+type VHostsState = {
+  vhosts: VHost[];
+  policies: Policy[];
+  policyNameById: Record<number, string>;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+export function useVHosts(): VHostsState {
+  const { accessToken } = useAuth();
+  const [vhosts, setVHosts] = useState<VHost[]>([]);
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  const fetch = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([
+      listVHosts(accessToken, controller.signal),
+      listPolicies(accessToken, controller.signal),
+    ])
+      .then(([vhostList, policyList]) => {
+        if (generation !== refreshCountRef.current) return;
+        setVHosts(vhostList);
+        setPolicies(policyList);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load vhosts");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken]);
+
+  useEffect(() => {
+    const cleanup = fetch();
+    return cleanup;
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  const policyNameById: Record<number, string> = {};
+  for (const p of policies) {
+    policyNameById[p.id] = p.name;
+  }
+
+  return { vhosts, policies, policyNameById, isLoading, error, refresh };
+}

--- a/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as vhostsApi from "@/features/vhosts/api";
+
+import { VHostsPage } from "./VHostsPage";
+
+vi.mock("@/features/vhosts/api");
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockVHosts = [
+  {
+    id: 1,
+    domain: "app.example.com",
+    backend_url: "https://backend.internal",
+    description: null,
+    ssl_enabled: true,
+    is_active: true,
+    policy_id: 1,
+    created_by: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const mockPolicies = [{ id: 1, name: "Default" }];
+
+function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext(authOverrides)}>
+      <VHostsPage />
+    </AuthContext.Provider>,
+  );
+}
+
+describe("VHostsPage", () => {
+  it("shows loading state initially", () => {
+    vi.mocked(vhostsApi.listVHosts).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+    expect(screen.getByText(/loading virtual hosts/i)).toBeInTheDocument();
+  });
+
+  it("renders rows from API response", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Default")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("shows error state and retry button on failure", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockRejectedValue(new Error("Network error"));
+    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load virtual hosts/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows empty state when no vhosts", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue([]);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/no virtual hosts yet/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("admin sees New vhost button and Edit/Delete actions", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(true) });
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /new vhost/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("viewer does not see New vhost button or Edit/Delete actions", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(false) });
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /new vhost/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("retry button calls refresh after error", async () => {
+    vi.mocked(vhostsApi.listVHosts)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -1,99 +1,165 @@
-import type { DataTableColumn } from "@/components/shared/DataTable";
+import { useState } from "react";
 
+import type { DataTableColumn } from "@/components/shared/DataTable";
 import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
+import { DeleteVHostDialog } from "@/features/vhosts/DeleteVHostDialog";
+import { VHostFormModal } from "@/features/vhosts/VHostFormModal";
+import { useVHosts } from "@/features/vhosts/use-vhosts";
+import type { VHost } from "@/features/vhosts/types";
+import { useAuth } from "@/hooks/use-auth";
 
-type VHostRow = {
-  id: string;
-  domain: string;
-  policy: string;
-  status: "Active" | "Inactive";
-  backendUrl: string;
-};
-
-const vhostRows: VHostRow[] = [
-  {
-    id: "vh-1",
-    domain: "app.example.com",
-    policy: "Default",
-    status: "Active",
-    backendUrl: "https://backend-app.internal",
-  },
-  {
-    id: "vh-2",
-    domain: "admin.example.com",
-    policy: "Strict",
-    status: "Active",
-    backendUrl: "https://backend-admin.internal",
-  },
-  {
-    id: "vh-3",
-    domain: "legacy.example.com",
-    policy: "Permissive",
-    status: "Inactive",
-    backendUrl: "http://legacy.internal:8080",
-  },
-];
-
-const columns: DataTableColumn<VHostRow>[] = [
-  {
-    key: "domain",
-    header: "Domain",
-    cell: (row) => (
-      <div className="space-y-1">
-        <p className="font-medium text-fg">{row.domain}</p>
-        <p className="text-xs text-fg-subtle">{row.id}</p>
-      </div>
-    ),
-  },
-  {
-    key: "policy",
-    header: "Policy",
-    cell: (row) => row.policy,
-  },
-  {
-    key: "status",
-    header: "Status",
-    cell: (row) => (
-      <StatusBadge
-        label={row.status}
-        tone={row.status === "Active" ? "success" : "warning"}
-      />
-    ),
-  },
-  {
-    key: "backendUrl",
-    header: "Backend URL",
-    cell: (row) => (
-      <span className="font-mono text-xs text-fg-muted">{row.backendUrl}</span>
-    ),
-  },
-];
+type ModalState =
+  | null
+  | { type: "create" }
+  | { type: "edit"; vhost: VHost }
+  | { type: "delete"; vhost: VHost };
 
 export function VHostsPage() {
+  const { hasRole } = useAuth();
+  const { vhosts, policies, policyNameById, isLoading, error, refresh } = useVHosts();
+  const [modal, setModal] = useState<ModalState>(null);
+  const isAdmin = hasRole("admin");
+
+  function closeAndRefresh() {
+    setModal(null);
+    refresh();
+  }
+
+  const columns: DataTableColumn<VHost>[] = [
+    {
+      key: "domain",
+      header: "Domain",
+      cell: (row) => (
+        <div className="space-y-1">
+          <p className="font-medium text-fg">{row.domain}</p>
+          <p className="font-mono text-xs text-fg-subtle">{row.backend_url}</p>
+        </div>
+      ),
+    },
+    {
+      key: "policy",
+      header: "Policy",
+      cell: (row) =>
+        row.policy_id != null
+          ? (policyNameById[row.policy_id] ?? `#${row.policy_id}`)
+          : <span className="text-fg-subtle">None</span>,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (row) => (
+        <StatusBadge
+          label={row.is_active ? "Active" : "Inactive"}
+          tone={row.is_active ? "success" : "warning"}
+        />
+      ),
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            cell: (row: VHost) => (
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setModal({ type: "edit", vhost: row })}
+                  className="btn-ghost rounded-[var(--radius-sm)] px-3 py-1.5 text-xs font-semibold"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setModal({ type: "delete", vhost: row })}
+                  className="rounded-[var(--radius-sm)] px-3 py-1.5 text-xs font-semibold text-error transition hover:bg-error-soft"
+                >
+                  Delete
+                </button>
+              </div>
+            ),
+          } satisfies DataTableColumn<VHost>,
+        ]
+      : []),
+  ];
+
   return (
     <section className="space-y-8">
       <PageHeader
         eyebrow="VHosts"
-        title="Virtual hosts inventory"
-        description="This starter screen shows the shared DataTable component in the shape the team will later reuse for real VHost data."
-        actions={<StatusBadge label="Mock data" tone="info" />}
+        title="Virtual hosts"
+        description="Manage the domains, backend targets, and WAF policies for each virtual host."
+        actions={
+          isAdmin ? (
+            <button
+              type="button"
+              onClick={() => setModal({ type: "create" })}
+              className="btn-primary px-4 py-2 text-sm"
+            >
+              New vhost
+            </button>
+          ) : undefined
+        }
       />
 
-      <SectionCard
-        title="Registered hosts"
-        description="Example table layout for domains, assigned policies, and backend targets."
-      >
-        <DataTable
-          columns={columns}
-          rows={vhostRows}
-          getRowKey={(row) => row.id}
-          emptyTitle="No virtual hosts yet"
-          emptyDescription="Once the real API is connected, this table will become the main entry point for browsing configured domains."
-        />
+      <SectionCard title="Registered hosts" description="All configured virtual hosts and their current status.">
+        {isLoading ? (
+          <LoadingState label="Loading virtual hosts…" />
+        ) : error ? (
+          <ErrorState
+            title="Failed to load virtual hosts"
+            description={error}
+            action={
+              <button
+                type="button"
+                onClick={refresh}
+                className="btn-ghost px-4 py-2 text-sm"
+              >
+                Retry
+              </button>
+            }
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={vhosts}
+            getRowKey={(row) => String(row.id)}
+            emptyTitle="No virtual hosts yet"
+            emptyDescription="Create your first virtual host to start routing traffic through Guard Proxy."
+          />
+        )}
       </SectionCard>
+
+      {modal?.type === "create" && (
+        <VHostFormModal
+          mode="create"
+          policies={policies}
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {modal?.type === "edit" && (
+        <VHostFormModal
+          mode="edit"
+          vhost={modal.vhost}
+          policies={policies}
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {modal?.type === "delete" && (
+        <DeleteVHostDialog
+          vhost={modal.vhost}
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces hardcoded mock rows with live data from `GET /vhosts` and `GET /policies`, fetched in parallel via a new `useVHosts` hook
- Adds a reusable `Modal` component (Escape + backdrop close, title/children/footer slots)
- `VHostFormModal` handles both create and edit flows; surfaces `ApiError.detail` inline (e.g. 409 duplicate domain)
- `DeleteVHostDialog` shows domain confirmation before calling `DELETE /vhosts/{id}`
- `VHostsPage` renders loading/error/empty states and gates New/Edit/Delete controls on the admin role; viewer role sees a read-only table

## Test plan

- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm test` — 47 tests pass (11 test files)
- [x] As admin: page loads real vhosts; create, edit, delete work; 409 on duplicate domain shows inline error
- [x] As viewer: no New/Edit/Delete controls visible, table is read-only
- [x] Loading, empty, and error (backend stopped) states all render correctly

Closes #196