### PR TITLE
feat(m3-04): log-shipper sidecar — Coraza audit log to ingest endpoint

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -19,6 +19,9 @@ graph TB
     RV -.->|read-only mount| H
     RV -.->|read-only rule overrides| CS
     CS -.->|polls /runtime/current| CS
+    CS -->|JSON audit events| AF[(coraza_audit volume)]
+    AF -->|tailed by| LS[Log Shipper sidecar]
+    LS -->|POST /logs/ingest| BE
 ```
 
 ## Request Flow
@@ -53,7 +56,8 @@ machine-readable degraded reason header.
 | Component | Role | Location |
 |-----------|------|----------|
 | **HAProxy** | Reference reverse proxy, host routing, SPOE filter, WAF enforcement, degraded-mode handling | `configs/haproxy/` |
-| **Coraza SPOA + OWASP CRS** | Request-phase WAF inspection, CRS anomaly scoring, audit logging seed configuration | `configs/coraza/`, `deploy/docker/coraza.Dockerfile` |
+| **Coraza SPOA + OWASP CRS** | Request-phase WAF inspection, CRS anomaly scoring, JSON audit log | `configs/coraza/`, `deploy/docker/coraza.Dockerfile` |
+| **Log Shipper sidecar** | Tails Coraza's JSON audit file and ships each event to `POST /logs/ingest` with exponential backoff | `src/log-shipper/` |
 | **FastAPI Backend** | Control-plane API for auth, vhosts, policies, rule overrides, logs, and health checks | `src/backend/` |
 | **React Frontend** | Admin panel SPA built with React, TypeScript, Vite, Tailwind CSS, and pnpm | `src/frontend/` |
 | **PostgreSQL** | Docker Compose database for backend state | `deploy/docker/docker-compose.yml` |
@@ -82,11 +86,25 @@ machine-readable degraded reason header.
    required.
 
 ### Runtime Event Ingestion
-1. Runtime WAF events can be represented as structured log payloads.
-2. Producers send events to `POST /logs/ingest`.
-3. FastAPI validates and normalizes payloads into the persisted log event model.
-4. `GET /logs` exposes stored events for the future frontend log viewer.
-5. Full automatic Coraza-to-backend event forwarding and production log presentation remain post-M1 work.
+1. Coraza writes one JSON audit event per newline to
+   `/var/log/coraza/audit.log` on the `coraza_audit` Docker named volume
+   (`SecAuditEngine RelevantOnly` — only transactions where at least one rule
+   fired produce an entry).
+2. The **log-shipper** sidecar (`src/log-shipper/`) tails the audit file from a
+   persisted byte-offset checkpoint. For each complete line it maps the Coraza
+   JSON to a `LogIngestRequest` payload (see `configs/coraza/README.md` for the
+   field mapping) and `POST`s it to `/logs/ingest` with
+   `X-Guard-Proxy-Ingest-Secret`.
+3. The offset is only advanced and persisted after a `2xx` response or a
+   deliberate skip (parse error or `4xx` rejection). Transient failures
+   (`5xx`, network errors, `429`) trigger exponential backoff without advancing
+   the offset — so a backend outage stalls the pipeline rather than dropping
+   events. The `coraza_audit` file itself is the durable buffer.
+4. Idempotency is guaranteed via `producer_event_id` = Coraza
+   `transaction.id`; the backend returns `200` for a duplicate rather than
+   creating a second row.
+5. FastAPI validates and normalizes payloads into the persisted `Log` model.
+6. `GET /logs` exposes stored events for the admin panel log viewer.
 
 ## Deployment
 
@@ -96,11 +114,12 @@ The implemented M1 stack lives in `deploy/docker/docker-compose.yml`.
 
 ```yaml
 services:
-  haproxy:   # host port 8080 -> container port 80
-  coraza:    # internal port 9000 (SPOE)
-  backend:   # internal port 8000 (FastAPI)
-  frontend:  # host port 3000 -> Vite port 5173
-  postgres:  # internal port 5432
+  haproxy:      # host port 8080 -> container port 80
+  coraza:       # internal port 9000 (SPOE)
+  log-shipper:  # tails coraza_audit volume, ships to backend
+  backend:      # internal port 8000 (FastAPI)
+  frontend:     # host port 3000 -> Vite port 5173
+  postgres:     # internal port 5432
 ```
 
 Prepare `deploy/docker/.env` from `deploy/docker/.env.example`, then use
@@ -133,9 +152,11 @@ Uvicorn. HAProxy copies the checked-in reference config into the same seed
 release when no generated `haproxy.cfg` exists yet.
 
 The Coraza container image is built on `alpine:3.19` with `tini` as PID 1. A
-shell supervisor (`coraza-supervisor.sh`) starts as root long enough to make the
-fresh audit log volume writable, drops to the non-root `coraza` user, starts
-`coraza-spoa` as a child process, and polls `/runtime/current` once per second.
+shell supervisor (`coraza-supervisor.sh`) drops to the non-root `coraza` user,
+starts `coraza-spoa` as a child process, and polls `/runtime/current` once per
+second. Coraza writes JSON audit events to `/var/log/coraza/audit.log` on the
+`coraza_audit` named volume, which is mounted read-only by the log-shipper
+sidecar.
 The earlier inotify-based supervisor looked simpler, but it did not reliably
 observe the backend's atomic `current` symlink replacement through the
 read-only runtime volume mount while Coraza kept using the previous loaded
@@ -158,3 +179,4 @@ See `notes/decisions/` for Architecture Decision Records:
 - [ADR-004](notes/decisions/ADR-004-docker-compose-deployment.md) - Docker Compose deployment
 - [ADR-006](notes/decisions/ADR-006-sync-sqlalchemy-for-mvp.md) - Synchronous SQLAlchemy for MVP
 - [ADR-007](notes/decisions/ADR-007-coraza-spoa-integration.md) - Coraza SPOA integration approach
+- [ADR-008](notes/decisions/ADR-008-log-shipper-sidecar.md) - Log shipper: custom Python sidecar over Vector/Fluent Bit

--- a/configs/coraza/README.md
+++ b/configs/coraza/README.md
@@ -37,27 +37,36 @@ git submodule update --init --recursive
 
 ## Audit log output
 
-Coraza writes one JSON audit event per line to **stdout** using `SecAuditLogType Serial` + `SecAuditLogFormat JSON`. Each transaction that matches `SecAuditEngine RelevantOnly` (i.e. transactions where at least one rule fired) produces a single JSON object followed by a newline — the format a downstream log shipper can consume directly.
+Coraza writes one JSON audit event per line to
+**`/var/log/coraza/audit.log`** (on the `coraza_audit` Docker named volume)
+using `SecAuditLogType Serial` + `SecAuditLogFormat JSON`. Each transaction
+that matches `SecAuditEngine RelevantOnly` (i.e. transactions where at least
+one rule fired) produces a single JSON object followed by a newline.
 
-Operational logs from the `coraza-spoa` daemon (startup, health, rule-load messages) go to **stderr**, so the stdout stream is a clean newline-delimited JSON stream.
+Operational logs from the `coraza-spoa` daemon (startup, health, rule-load
+messages) continue to go to **stderr** and appear in `docker logs coraza`.
 
-To inspect events while the stack is running:
+To inspect audit events while the stack is running:
 
 ```sh
-# stdout only — audit JSON
+# tail the audit file inside the container
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env \
-  logs --no-log-prefix coraza | jq -c .
+  exec coraza tail -f /var/log/coraza/audit.log | jq -c .
 
-# stderr only — SPOA operational logs
+# SPOA operational logs (stderr)
 docker compose -f deploy/docker/docker-compose.yml --env-file deploy/docker/.env \
-  logs --no-log-prefix coraza 2>&1 1>/dev/null
+  logs --no-log-prefix coraza
 ```
+
+The log-shipper sidecar (`src/log-shipper/`) tails this file and ships each
+event to `POST /logs/ingest` on the backend. See `README.architecture.md` for
+the full data-flow description.
 
 ### Event schema and ingest mapping
 
 The table below maps each `LogIngestRequest` field (defined in
 `src/backend/app/schemas/log.py`) to its source path inside the Coraza JSON
-event. This is the contract for the future log shipper (not implemented here).
+event. The mapping is implemented in `src/log-shipper/app/mapping.py`.
 
 Parts `ABIJDEFHZ` produce a top-level structure like:
 

--- a/configs/coraza/coraza.conf
+++ b/configs/coraza/coraza.conf
@@ -12,7 +12,7 @@ SecResponseBodyAccess Off
 SecAuditEngine RelevantOnly
 SecAuditLogType Serial
 SecAuditLogFormat JSON
-SecAuditLog /dev/stdout
+SecAuditLog /var/log/coraza/audit.log
 SecAuditLogParts ABIJDEFHZ
 
 SecDefaultAction "phase:1,log,auditlog,pass"

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -14,6 +14,12 @@ LOG_INGEST_SHARED_SECRET=guard-proxy-dev-log-ingest-shared-secret-please-change
 CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
 VITE_API_BASE_URL=http://localhost:8080
 
+# Optional log-shipper tuning (defaults shown)
+# SHIPPER_POLL_INTERVAL=1
+# SHIPPER_BACKOFF_BASE=1
+# SHIPPER_BACKOFF_MAX=30
+# SHIPPER_REQUEST_TIMEOUT=5
+
 # Optional: set before running `make seed`
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASSWORD=

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -82,11 +82,34 @@ services:
       - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
       - ../../configs/coraza/crs:/etc/coraza/crs:ro
       - generated_config:/runtime:ro
+      - coraza_audit:/var/log/coraza
     healthcheck:
       test: ["CMD", "nc", "-z", "127.0.0.1", "9000"]
       interval: 10s
       timeout: 5s
       retries: 10
+    networks:
+      - gp_internal
+
+  log-shipper:
+    build:
+      context: ../../src/log-shipper
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      INGEST_URL: "http://backend:8000/logs/ingest"
+      CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"
+      SHIPPER_STATE_FILE: "/var/lib/log-shipper/offset"
+    depends_on:
+      backend:
+        condition: service_healthy
+      coraza:
+        condition: service_started
+    volumes:
+      - coraza_audit:/var/log/coraza:ro
+      - shipper_state:/var/lib/log-shipper
     networks:
       - gp_internal
 
@@ -134,3 +157,5 @@ volumes:
   haproxy_runtime:
   backend_logs:
   generated_config:
+  coraza_audit:
+  shipper_state:

--- a/notes/decisions/ADR-008-log-shipper-sidecar.md
+++ b/notes/decisions/ADR-008-log-shipper-sidecar.md
@@ -1,0 +1,116 @@
+---
+date: 2026-05-31
+tags: [decision, architecture, logging, m3]
+---
+
+# ADR-008: Log Shipper — Custom Python Sidecar over Vector / Fluent Bit
+
+## Context
+
+Coraza already emits one JSON audit event per newline to its audit log, and
+the backend already exposes `POST /logs/ingest` (protected by a shared-secret
+header) to write events to the `logs` table. The missing piece for M3 is the
+component that carries those events from Coraza to the backend — the "log
+shipper."
+
+Issue #117 explicitly recommended **Vector** (single binary, low footprint) as
+the first choice, with "anything simpler acceptable for MVP." Three off-the-shelf
+candidates were evaluated: Vector, Fluent Bit, and a custom Python sidecar.
+
+## Decision
+
+Use a **custom Python sidecar** (`src/log-shipper/`) that tails the Coraza
+audit file and POSTs each event individually to `POST /logs/ingest`.
+
+## Rationale
+
+### Why not Vector
+
+Vector's `http` sink always encodes a batch as a **JSON array**. The backend's
+ingest endpoint expects a **single JSON object** (the `LogIngestRequest` schema)
+and returns `422 Unprocessable Entity` for an array body.
+
+Workarounds all carry unacceptable cost:
+
+| Workaround | Cost |
+|---|---|
+| Add a batch ingest endpoint | Backend change, new schema, tests |
+| `batch.max_events = 1` with `json` codec | Still produces `[{...}]` (array of one) |
+| Custom HTTP sink transform / VRL hack | Fragile; not a supported Vector pattern |
+
+Beyond the endpoint-shape mismatch, the Coraza→`LogIngestRequest` field
+derivation (derive `action` from `is_interrupted` + per-message severity, bucket
+the numeric `severity` into four enum values, coerce string anomaly scores to
+int) is already specified as a Python-style mapping table in
+`configs/coraza/README.md`. Expressing this in VRL — Vector's transform
+language — is significantly more verbose and harder to unit-test.
+
+### Why not Fluent Bit
+
+Fluent Bit is a C binary with Lua scripting for field transforms. Its lower
+footprint compared to Vector is irrelevant at this scale; the Lua transform
+surface would be the most unfamiliar code in the project for a Python-centric
+team.
+
+### Why the custom Python sidecar works well here
+
+1. **Matches the endpoint shape exactly.** One call to `urllib.request.urlopen`
+   per event, plain `Content-Type: application/json`, zero wrapper overhead.
+
+2. **Durability via the audit file itself.** The sidecar persists a byte-offset
+   checkpoint (on the `shipper_state` volume) and only advances it after a `2xx`
+   response or a deliberate skip (parse error or `4xx` rejection). Transient
+   failures (`5xx`, network errors, `429`) trigger exponential backoff without
+   advancing the offset. The audit file is the buffer — a 30-second backend
+   outage stalls the pipeline but loses no events. This is the same checkpointing
+   strategy Vector uses for its file source.
+
+3. **Idempotency via `producer_event_id`.** Coraza's `transaction.id` is sent as
+   `producer_event_id`; the backend returns `200` for a duplicate, so retried
+   lines deduplicate at rest rather than creating double rows.
+
+4. **Stdlib-only runtime.** No dependency management required in the container
+   image — `python:3.13-slim` + the `app/` directory is sufficient. All
+   complexity lives in a single testable pure function (`mapping.py`).
+
+5. **Language consistency.** The mapping logic and the schema it targets are both
+   Python; they can evolve together and share the same test runner (`pytest`).
+
+## Alternatives Considered
+
+### Alternative 1: Vector with `docker_logs` source (Docker socket)
+
+Read Coraza stdout via the Docker API instead of a file. Rejected because:
+mounting the Docker socket grants the container broad host-level access — a
+security concern that is explicitly out of scope for a WAF-focused thesis project.
+
+### Alternative 2: Vector with shared audit file
+
+Keeps `SecAuditLog /dev/stdout` via `tee` into a file, or changes `SecAuditLog`
+to write a file directly (as this ADR does). Vector tails the file via the
+`file` source. Still rejected because of the HTTP sink array-wrapping issue
+(see above), and because the VRL transform for the mapping is harder to test
+and maintain than the equivalent Python.
+
+### Alternative 3: Fluent Bit
+
+Lower binary footprint than Vector. Rejected because: the complex field
+derivation (action/severity derivation) would require Lua filter scripting;
+the team has no Lua familiarity; and the footprint difference is irrelevant at
+this deployment scale.
+
+## Consequences
+
+- `SecAuditLog /dev/stdout` in `configs/coraza/coraza.conf` is changed to
+  `/var/log/coraza/audit.log`. Audit JSON is no longer visible in
+  `docker logs coraza`; only SPOA operational logs (stderr) appear there.
+  The audit file can still be inspected with `docker exec coraza tail -f
+  /var/log/coraza/audit.log`.
+- A new `coraza_audit` named volume is shared between the `coraza` and
+  `log-shipper` containers. A `shipper_state` volume persists the offset.
+- The sidecar is a small Python package; it runs as a non-root `shipper` user
+  in a `python:3.13-slim` container. Runtime dependencies: none (stdlib only).
+- If throughput grows to thousands of events per second in a future milestone,
+  the single-event-per-request approach becomes a bottleneck. At that point
+  adding a batch ingest endpoint and switching to Vector (or batching in the
+  sidecar) is a well-understood migration path.

--- a/src/log-shipper/Dockerfile
+++ b/src/log-shipper/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --system shipper \
+    && useradd --system --gid shipper --home-dir /app --no-create-home \
+               --shell /usr/sbin/nologin shipper
+
+WORKDIR /app
+
+COPY app app
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["python", "-m", "app.shipper"]

--- a/src/log-shipper/app/__init__.py
+++ b/src/log-shipper/app/__init__.py
@@ -1,0 +1,1 @@
+"""Guard Proxy log shipper sidecar."""

--- a/src/log-shipper/app/config.py
+++ b/src/log-shipper/app/config.py
@@ -1,0 +1,45 @@
+"""Runtime configuration for the log shipper, sourced from environment."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Shipper settings resolved from environment variables."""
+
+    ingest_url: str
+    ingest_secret: str
+    audit_log_path: str
+    state_file: str
+    poll_interval_seconds: float
+    backoff_base_seconds: float
+    backoff_max_seconds: float
+    request_timeout_seconds: float
+
+
+def load_settings() -> Settings:
+    """Build :class:`Settings` from the process environment."""
+
+    secret = os.environ.get("LOG_INGEST_SHARED_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError("LOG_INGEST_SHARED_SECRET must be set")
+
+    return Settings(
+        ingest_url=os.environ.get(
+            "INGEST_URL", "http://backend:8000/logs/ingest"
+        ).strip(),
+        ingest_secret=secret,
+        audit_log_path=os.environ.get(
+            "CORAZA_AUDIT_LOG", "/var/log/coraza/audit.log"
+        ).strip(),
+        state_file=os.environ.get(
+            "SHIPPER_STATE_FILE", "/var/lib/log-shipper/offset"
+        ).strip(),
+        poll_interval_seconds=float(os.environ.get("SHIPPER_POLL_INTERVAL", "1")),
+        backoff_base_seconds=float(os.environ.get("SHIPPER_BACKOFF_BASE", "1")),
+        backoff_max_seconds=float(os.environ.get("SHIPPER_BACKOFF_MAX", "30")),
+        request_timeout_seconds=float(os.environ.get("SHIPPER_REQUEST_TIMEOUT", "5")),
+    )

--- a/src/log-shipper/app/mapping.py
+++ b/src/log-shipper/app/mapping.py
@@ -90,7 +90,7 @@ def coraza_event_to_ingest(event: dict[str, Any]) -> dict[str, Any] | None:
         "producer_event_id": _clean_str(transaction.get("id")),
         "event_at": _event_at(transaction.get("timestamp")),
         "vhost": _vhost(request.get("headers")),
-        "action": _action(is_interrupted, messages),
+        "action": _action(is_interrupted, primary_data),
         "source_ip": source_ip,
         "method": method.upper(),
         "request_uri": request_uri,
@@ -155,14 +155,13 @@ def _primary_rule_data(messages: list[Any]) -> _RuleData | None:
 # Field derivation helpers
 # ---------------------------------------------------------------------------
 
-def _action(is_interrupted: bool, messages: list[Any]) -> str:
+def _action(is_interrupted: bool, primary_data: _RuleData | None) -> str:
     if is_interrupted:
         return "deny"
     # Secondary check: deny when a high-severity rule fired even without interruption
     # (e.g. DetectionOnly-adjacent configs that still log critical hits).
-    rd = _primary_rule_data(messages)
-    if rd is not None and rd.severity_str is not None:
-        if rd.severity_str.lower() in _DENY_SEVERITY_STRINGS:
+    if primary_data is not None and primary_data.severity_str is not None:
+        if primary_data.severity_str.lower() in _DENY_SEVERITY_STRINGS:
             return "deny"
     return "allow"
 

--- a/src/log-shipper/app/mapping.py
+++ b/src/log-shipper/app/mapping.py
@@ -5,24 +5,62 @@ The mapping contract is documented in ``configs/coraza/README.md`` and mirrors t
 pure, defensive translator: it never raises on malformed input and returns ``None``
 for events that cannot be turned into a valid ingest payload (so the shipper can
 skip them instead of wedging).
+
+## Actual coraza-spoa v0.6.1 JSON format quirks
+
+The README mapping table was written against the expected coraza audit schema, but
+the actual coraza-spoa v0.6.1 binary does not populate ``messages[].data``; that
+field is always ``null``. Rule id, rule message, and severity are instead embedded
+in the ``messages[].error_message`` log-formatted string, e.g.:
+
+    [id "941100"] [msg "XSS Attack Detected"] [severity "critical"]
+
+Similarly the timestamp uses ``"YYYY/MM/DD HH:MM:SS"`` (no timezone, implicitly
+UTC) and ``transaction.variables`` is absent. The mapping handles both the
+documented schema and the actual one so it does not break if a future version of
+coraza-spoa populates ``data``.
 """
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from ipaddress import ip_address
 from typing import Any
 
-# Coraza/ModSecurity numeric severities run 0 (emergency) .. 7 (debug). The backend
-# enum only has four buckets; this collapses the scale per configs/coraza/README.md.
-_DENY_SEVERITY_THRESHOLD = 2
+# Regex to extract bracketed fields from coraza-spoa error_message strings.
+# e.g.  [id "941100"] [msg "XSS Attack Detected"] [severity "critical"]
+_BRACKET_INT = re.compile(r'\[id "(\d+)"\]')
+_BRACKET_MSG = re.compile(r'\[msg "([^"]+)"\]')
+_BRACKET_SEV = re.compile(r'\[severity "([\w]+)"\]')
 
-# Apache-style timestamp Coraza emits when it is not already ISO 8601.
+# Severity strings Coraza writes in error_message → LogSeverity enum values.
+# ModSecurity/Coraza uses: emergency, alert, critical, error, warning, notice, info, debug
+_SEVERITY_STRING_MAP: dict[str, str] = {
+    "emergency": "critical",
+    "alert": "critical",
+    "critical": "critical",
+    "error": "error",
+    "warning": "warning",
+    "notice": "info",
+    "info": "info",
+    "debug": "info",
+}
+
+# Severity strings that indicate a blocking/deny action even without is_interrupted.
+_DENY_SEVERITY_STRINGS = frozenset({"emergency", "alert", "critical"})
+
+# Timestamp formats Coraza may emit in addition to ISO 8601.
 _CORAZA_TS_FORMATS = (
-    "%d/%b/%Y:%H:%M:%S.%f %z",
-    "%d/%b/%Y:%H:%M:%S %z",
+    "%Y/%m/%d %H:%M:%S",        # actual coraza-spoa v0.6.1: "2026/05/31 13:29:17"
+    "%d/%b/%Y:%H:%M:%S.%f %z",  # Apache-style with microseconds and tz
+    "%d/%b/%Y:%H:%M:%S %z",     # Apache-style without microseconds
 )
 
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
 
 def coraza_event_to_ingest(event: dict[str, Any]) -> dict[str, Any] | None:
     """Map one Coraza audit event to an ingest payload, or ``None`` to skip it."""
@@ -43,10 +81,10 @@ def coraza_event_to_ingest(event: dict[str, Any]) -> dict[str, Any] | None:
 
     messages = event.get("messages")
     messages = messages if isinstance(messages, list) else []
-    primary = _as_dict(messages[0].get("data")) if messages else {}
-
-    severity_value = _coerce_int(primary.get("severity"))
     is_interrupted = bool(transaction.get("is_interrupted"))
+
+    # Prefer the structured data field; fall back to parsing error_message.
+    primary_data = _primary_rule_data(messages)
 
     payload: dict[str, Any] = {
         "producer_event_id": _clean_str(transaction.get("id")),
@@ -57,43 +95,113 @@ def coraza_event_to_ingest(event: dict[str, Any]) -> dict[str, Any] | None:
         "method": method.upper(),
         "request_uri": request_uri,
         "status_code": _status_code(transaction.get("response")),
-        "rule_id": _rule_id(primary.get("id")),
-        "rule_message": _clean_str(primary.get("msg")),
+        "rule_id": _rule_id(primary_data),
+        "rule_message": _rule_message(primary_data),
         "anomaly_score": _anomaly_score(transaction.get("variables")),
         "paranoia_level": _paranoia_level(transaction.get("variables")),
-        "severity": _severity(severity_value),
+        "severity": _severity(primary_data),
         "message": None,
         "raw_context": event,
     }
     return payload
 
 
+# ---------------------------------------------------------------------------
+# Rule data extraction — handles both structured data and error_message string
+# ---------------------------------------------------------------------------
+
+class _RuleData:
+    """Normalised rule fields extracted from either data dict or error_message."""
+
+    __slots__ = ("id", "msg", "severity_str")
+
+    def __init__(self, id: str | None, msg: str | None, severity_str: str | None) -> None:
+        self.id = id
+        self.msg = msg
+        self.severity_str = severity_str
+
+
+def _primary_rule_data(messages: list[Any]) -> _RuleData | None:
+    """Return the first message that carries rule information."""
+    for raw in messages:
+        msg = _as_dict(raw)
+
+        # 1. Prefer structured data dict (future coraza-spoa versions may populate this).
+        data = _as_dict(msg.get("data"))
+        if data:
+            return _RuleData(
+                id=_clean_str(data.get("id")),
+                msg=_clean_str(data.get("msg")),
+                severity_str=_clean_str(data.get("severity")),
+            )
+
+        # 2. Fall back to parsing error_message (actual coraza-spoa v0.6.1 behaviour).
+        error_msg = msg.get("error_message")
+        if isinstance(error_msg, str) and error_msg.strip():
+            id_match = _BRACKET_INT.search(error_msg)
+            msg_match = _BRACKET_MSG.search(error_msg)
+            sev_match = _BRACKET_SEV.search(error_msg)
+            if id_match or msg_match or sev_match:
+                return _RuleData(
+                    id=id_match.group(1) if id_match else None,
+                    msg=msg_match.group(1) if msg_match else None,
+                    severity_str=sev_match.group(1) if sev_match else None,
+                )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Field derivation helpers
+# ---------------------------------------------------------------------------
+
 def _action(is_interrupted: bool, messages: list[Any]) -> str:
     if is_interrupted:
         return "deny"
-    for message in messages:
-        data = _as_dict(_as_dict(message).get("data"))
-        severity = _coerce_int(data.get("severity"))
-        if severity is not None and severity < _DENY_SEVERITY_THRESHOLD:
+    # Secondary check: deny when a high-severity rule fired even without interruption
+    # (e.g. DetectionOnly-adjacent configs that still log critical hits).
+    rd = _primary_rule_data(messages)
+    if rd is not None and rd.severity_str is not None:
+        if rd.severity_str.lower() in _DENY_SEVERITY_STRINGS:
             return "deny"
     return "allow"
 
 
-def _severity(value: int | None) -> str:
-    if value is None:
+def _rule_id(rd: _RuleData | None) -> int | None:
+    if rd is None:
+        return None
+    rule_id = _coerce_int(rd.id)
+    return rule_id if rule_id is not None and rule_id > 0 else None
+
+
+def _rule_message(rd: _RuleData | None) -> str | None:
+    return rd.msg if rd is not None else None
+
+
+def _severity(rd: _RuleData | None) -> str:
+    if rd is None or rd.severity_str is None:
         return "info"
-    if value <= 1:
-        return "critical"
-    if value == 2:
-        return "error"
-    if value <= 4:
-        return "warning"
+    key = rd.severity_str.lower()
+    # Named string severity (actual coraza-spoa output).
+    if key in _SEVERITY_STRING_MAP:
+        return _SEVERITY_STRING_MAP[key]
+    # Numeric string (documented schema assumption: "0"–"7").
+    numeric = _coerce_int(rd.severity_str)
+    if numeric is not None:
+        if numeric <= 1:
+            return "critical"
+        if numeric == 2:
+            return "error"
+        if numeric <= 4:
+            return "warning"
+        return "info"
     return "info"
 
 
 def _event_at(value: Any) -> str:
     if isinstance(value, str):
         text = value.strip()
+        # Handle ISO 8601 with or without trailing Z.
         iso = text[:-1] + "+00:00" if text.endswith("Z") else text
         try:
             return datetime.fromisoformat(iso).isoformat()
@@ -101,7 +209,11 @@ def _event_at(value: Any) -> str:
             pass
         for fmt in _CORAZA_TS_FORMATS:
             try:
-                return datetime.strptime(text, fmt).isoformat()
+                dt = datetime.strptime(text, fmt)
+                # Formats without timezone info are treated as UTC.
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.isoformat()
             except ValueError:
                 continue
     return datetime.now(timezone.utc).isoformat()
@@ -111,10 +223,12 @@ def _vhost(headers: Any) -> str:
     headers = _as_dict(headers)
     for key, raw in headers.items():
         if isinstance(key, str) and key.lower() == "host":
+            # Header values may be a list (actual coraza-spoa output).
             value = raw[0] if isinstance(raw, list) and raw else raw
             host = _clean_str(value)
             if host:
-                return host.lower()
+                # Strip port if present: "localhost:8080" → "localhost"
+                return host.lower().split(":")[0]
     return "unknown"
 
 
@@ -123,11 +237,6 @@ def _status_code(response: Any) -> int | None:
     if status is None or not (100 <= status <= 599):
         return None
     return status
-
-
-def _rule_id(value: Any) -> int | None:
-    rule_id = _coerce_int(value)
-    return rule_id if rule_id is not None and rule_id > 0 else None
 
 
 def _anomaly_score(variables: Any) -> int | None:
@@ -147,6 +256,10 @@ def _tx_variable(variables: Any, name: str) -> Any:
             return value
     return None
 
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
 
 def _as_dict(value: Any) -> dict[Any, Any]:
     return value if isinstance(value, dict) else {}

--- a/src/log-shipper/app/mapping.py
+++ b/src/log-shipper/app/mapping.py
@@ -1,0 +1,186 @@
+"""Translate Coraza JSON audit events into ``LogIngestRequest`` payloads.
+
+The mapping contract is documented in ``configs/coraza/README.md`` and mirrors the
+``LogIngestRequest`` schema in ``src/backend/app/schemas/log.py``. This module is a
+pure, defensive translator: it never raises on malformed input and returns ``None``
+for events that cannot be turned into a valid ingest payload (so the shipper can
+skip them instead of wedging).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from ipaddress import ip_address
+from typing import Any
+
+# Coraza/ModSecurity numeric severities run 0 (emergency) .. 7 (debug). The backend
+# enum only has four buckets; this collapses the scale per configs/coraza/README.md.
+_DENY_SEVERITY_THRESHOLD = 2
+
+# Apache-style timestamp Coraza emits when it is not already ISO 8601.
+_CORAZA_TS_FORMATS = (
+    "%d/%b/%Y:%H:%M:%S.%f %z",
+    "%d/%b/%Y:%H:%M:%S %z",
+)
+
+
+def coraza_event_to_ingest(event: dict[str, Any]) -> dict[str, Any] | None:
+    """Map one Coraza audit event to an ingest payload, or ``None`` to skip it."""
+
+    transaction = _as_dict(event.get("transaction"))
+    if not transaction:
+        return None
+
+    request = _as_dict(transaction.get("request"))
+    method = _clean_str(request.get("method"))
+    request_uri = _clean_str(request.get("uri"))
+    source_ip = _valid_ip(transaction.get("client_ip"))
+
+    # These three are required by the backend; without them the event can never be
+    # accepted, so skipping avoids a poison-pill that would block the pipeline.
+    if not method or not request_uri or source_ip is None:
+        return None
+
+    messages = event.get("messages")
+    messages = messages if isinstance(messages, list) else []
+    primary = _as_dict(messages[0].get("data")) if messages else {}
+
+    severity_value = _coerce_int(primary.get("severity"))
+    is_interrupted = bool(transaction.get("is_interrupted"))
+
+    payload: dict[str, Any] = {
+        "producer_event_id": _clean_str(transaction.get("id")),
+        "event_at": _event_at(transaction.get("timestamp")),
+        "vhost": _vhost(request.get("headers")),
+        "action": _action(is_interrupted, messages),
+        "source_ip": source_ip,
+        "method": method.upper(),
+        "request_uri": request_uri,
+        "status_code": _status_code(transaction.get("response")),
+        "rule_id": _rule_id(primary.get("id")),
+        "rule_message": _clean_str(primary.get("msg")),
+        "anomaly_score": _anomaly_score(transaction.get("variables")),
+        "paranoia_level": _paranoia_level(transaction.get("variables")),
+        "severity": _severity(severity_value),
+        "message": None,
+        "raw_context": event,
+    }
+    return payload
+
+
+def _action(is_interrupted: bool, messages: list[Any]) -> str:
+    if is_interrupted:
+        return "deny"
+    for message in messages:
+        data = _as_dict(_as_dict(message).get("data"))
+        severity = _coerce_int(data.get("severity"))
+        if severity is not None and severity < _DENY_SEVERITY_THRESHOLD:
+            return "deny"
+    return "allow"
+
+
+def _severity(value: int | None) -> str:
+    if value is None:
+        return "info"
+    if value <= 1:
+        return "critical"
+    if value == 2:
+        return "error"
+    if value <= 4:
+        return "warning"
+    return "info"
+
+
+def _event_at(value: Any) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        iso = text[:-1] + "+00:00" if text.endswith("Z") else text
+        try:
+            return datetime.fromisoformat(iso).isoformat()
+        except ValueError:
+            pass
+        for fmt in _CORAZA_TS_FORMATS:
+            try:
+                return datetime.strptime(text, fmt).isoformat()
+            except ValueError:
+                continue
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _vhost(headers: Any) -> str:
+    headers = _as_dict(headers)
+    for key, raw in headers.items():
+        if isinstance(key, str) and key.lower() == "host":
+            value = raw[0] if isinstance(raw, list) and raw else raw
+            host = _clean_str(value)
+            if host:
+                return host.lower()
+    return "unknown"
+
+
+def _status_code(response: Any) -> int | None:
+    status = _coerce_int(_as_dict(response).get("status"))
+    if status is None or not (100 <= status <= 599):
+        return None
+    return status
+
+
+def _rule_id(value: Any) -> int | None:
+    rule_id = _coerce_int(value)
+    return rule_id if rule_id is not None and rule_id > 0 else None
+
+
+def _anomaly_score(variables: Any) -> int | None:
+    score = _coerce_int(_tx_variable(variables, "anomaly_score"))
+    return score if score is not None and score >= 0 else None
+
+
+def _paranoia_level(variables: Any) -> int | None:
+    level = _coerce_int(_tx_variable(variables, "paranoia_level"))
+    return level if level is not None and 1 <= level <= 4 else None
+
+
+def _tx_variable(variables: Any, name: str) -> Any:
+    tx = _as_dict(_as_dict(variables).get("tx"))
+    for key, value in tx.items():
+        if isinstance(key, str) and key.lower() == name:
+            return value
+    return None
+
+
+def _as_dict(value: Any) -> dict[Any, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _clean_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, (int, float)):
+        return str(value)
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _valid_ip(value: Any) -> str | None:
+    text = _clean_str(value)
+    if text is None:
+        return None
+    try:
+        return str(ip_address(text))
+    except ValueError:
+        return None

--- a/src/log-shipper/app/shipper.py
+++ b/src/log-shipper/app/shipper.py
@@ -2,13 +2,14 @@
 
 Durability model: the audit file *is* the buffer. We persist a byte offset and only
 advance it once an event has been accepted (2xx) or is known-undeliverable (a 4xx
-poison pill we deliberately drop). Transient failures (network errors, 5xx, 429)
-trigger exponential backoff with the offset frozen, so a backend outage stalls the
-pipeline rather than dropping events.
+poison pill we deliberately drop). Transient failures (network errors, 5xx, 429,
+and auth errors 401/403) trigger exponential backoff with the offset frozen, so a
+backend outage or misconfigured secret stalls the pipeline rather than dropping events.
 """
 
 from __future__ import annotations
 
+import enum
 import json
 import logging
 import os
@@ -25,6 +26,17 @@ logger = logging.getLogger("log-shipper")
 
 _running = True
 
+# Maximum bytes consumed by a single readline() call.  Coraza audit events are
+# typically 2–10 KB; 1 MB is a generous upper bound that prevents an unterminated
+# line from growing the in-memory buffer without limit.
+_MAX_LINE_BYTES = 1 * 1024 * 1024
+
+
+class _ShipResult(enum.Enum):
+    SHIPPED = "shipped"      # accepted by backend (2xx) — advance offset
+    DROPPED = "dropped"      # permanent failure (parse error, 422, etc.) — advance offset
+    ABORTED = "aborted"      # shutdown during retry — do NOT advance offset
+
 
 def _handle_term(_signum: int, _frame: FrameType | None) -> None:
     global _running
@@ -40,6 +52,10 @@ def _load_offset(path: str) -> int:
 
 
 def _persist_offset(path: str, offset: int) -> None:
+    # Atomic rename avoids a torn write, but we intentionally skip fsync: durability
+    # is provided by idempotency (producer_event_id deduplicates at the backend),
+    # so a crash that rolls back the offset is safe — the re-shipped line produces a
+    # 200 rather than a duplicate row.
     tmp = f"{path}.tmp"
     with open(tmp, "w", encoding="utf-8") as handle:
         handle.write(str(offset))
@@ -64,49 +80,71 @@ def _post_event(settings: Settings, payload: dict[str, object]) -> int:
         return response.status
 
 
-def _ship_line(settings: Settings, line: bytes) -> None:
-    """Block until ``line`` is shipped (2xx) or deliberately dropped (parse/4xx)."""
+def _ship_line(settings: Settings, line: bytes) -> _ShipResult:
+    """Block until ``line`` is shipped, dropped, or the process is shutting down.
+
+    Returns:
+        SHIPPED  — backend accepted the event (2xx); advance offset.
+        DROPPED  — permanent failure (unparseable, unmappable, or 4xx payload
+                   rejection); advance offset to skip the poison pill.
+        ABORTED  — shutdown signal arrived during a retry sleep; do NOT advance
+                   the offset so the line is re-attempted on next start.
+    """
 
     text = line.decode("utf-8", errors="replace").strip()
     if not text:
-        return
+        return _ShipResult.DROPPED
 
     try:
         event = json.loads(text)
     except json.JSONDecodeError:
         logger.warning("dropping unparseable audit line")
-        return
+        return _ShipResult.DROPPED
     if not isinstance(event, dict):
         logger.warning("dropping non-object audit line")
-        return
+        return _ShipResult.DROPPED
 
     payload = coraza_event_to_ingest(event)
     if payload is None:
         logger.warning("dropping event that cannot be mapped to an ingest payload")
-        return
+        return _ShipResult.DROPPED
 
     backoff = settings.backoff_base_seconds
     while _running:
         try:
             status = _post_event(settings, payload)
-            logger.info("shipped event id=%s status=%s", payload["rule_id"], status)
-            return
+            logger.info("shipped event producer_event_id=%s status=%s",
+                        payload["producer_event_id"], status)
+            return _ShipResult.SHIPPED
         except urllib.error.HTTPError as error:
-            if error.code == 429 or error.code >= 500:
+            if error.code in (401, 403):
+                # Auth rejection is a config error (wrong shared secret), not a
+                # per-event poison pill.  Stall with backoff so the pipeline pauses
+                # loudly rather than silently shredding the audit stream.
+                logger.warning(
+                    "ingest auth rejected (%s) — check LOG_INGEST_SHARED_SECRET; "
+                    "retrying in %.1fs",
+                    error.code,
+                    backoff,
+                )
+            elif error.code == 429 or error.code >= 500:
                 logger.warning("ingest %s, retrying in %.1fs", error.code, backoff)
             else:
-                # 4xx other than rate limiting: the backend rejected the payload and
-                # will keep doing so. Drop it rather than blocking the pipeline.
+                # Other 4xx (e.g. 422 Unprocessable Entity): the backend rejected
+                # this specific payload and will keep doing so.  Drop it rather
+                # than blocking the pipeline.
                 body = error.read().decode("utf-8", errors="replace")[:500]
                 logger.error("dropping event rejected by ingest (%s): %s",
                              error.code, body)
-                return
+                return _ShipResult.DROPPED
         except urllib.error.URLError as error:
             logger.warning("ingest unreachable (%s), retrying in %.1fs",
                            error.reason, backoff)
 
         _interruptible_sleep(backoff)
         backoff = min(backoff * 2, settings.backoff_max_seconds)
+
+    return _ShipResult.ABORTED
 
 
 def _interruptible_sleep(seconds: float) -> None:
@@ -126,8 +164,13 @@ def run(settings: Settings) -> None:
             _interruptible_sleep(settings.poll_interval_seconds)
             continue
 
+        # Reset on truncation.  Note: rename-based rotation (logrotate copytruncate
+        # excluded) is NOT detected here because we track a byte offset, not an inode.
+        # Coraza uses SecAuditLogType Serial (append-only, never rotated), so this is
+        # safe for the current deployment; rotation support would require inotify or an
+        # inode check.
         if size < offset:
-            logger.warning("audit log truncated/rotated; resetting offset to 0")
+            logger.warning("audit log truncated; resetting offset to 0")
             offset = 0
             _persist_offset(settings.state_file, offset)
 
@@ -135,14 +178,16 @@ def run(settings: Settings) -> None:
         with open(settings.audit_log_path, "rb") as handle:
             handle.seek(offset)
             while _running:
-                line = handle.readline()
+                line = handle.readline(_MAX_LINE_BYTES)
                 if not line:
                     break
                 if not line.endswith(b"\n"):
-                    # Partial trailing line: wait for the writer to finish it.
+                    # Partial trailing line (writer hasn't flushed yet, or the line
+                    # exceeded _MAX_LINE_BYTES): wait for the next poll cycle.
                     break
-                _ship_line(settings, line)
-                if not _running:
+                result = _ship_line(settings, line)
+                if result is _ShipResult.ABORTED:
+                    # Shutdown during retry — do not advance the offset.
                     break
                 offset += len(line)
                 _persist_offset(settings.state_file, offset)

--- a/src/log-shipper/app/shipper.py
+++ b/src/log-shipper/app/shipper.py
@@ -1,0 +1,168 @@
+"""Tail the Coraza audit log and ship each event to the backend ingest endpoint.
+
+Durability model: the audit file *is* the buffer. We persist a byte offset and only
+advance it once an event has been accepted (2xx) or is known-undeliverable (a 4xx
+poison pill we deliberately drop). Transient failures (network errors, 5xx, 429)
+trigger exponential backoff with the offset frozen, so a backend outage stalls the
+pipeline rather than dropping events.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import time
+import urllib.error
+import urllib.request
+from types import FrameType
+
+from app.config import Settings, load_settings
+from app.mapping import coraza_event_to_ingest
+
+logger = logging.getLogger("log-shipper")
+
+_running = True
+
+
+def _handle_term(_signum: int, _frame: FrameType | None) -> None:
+    global _running
+    _running = False
+
+
+def _load_offset(path: str) -> int:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return int(handle.read().strip() or "0")
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def _persist_offset(path: str, offset: int) -> None:
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write(str(offset))
+    os.replace(tmp, path)
+
+
+def _post_event(settings: Settings, payload: dict[str, object]) -> int:
+    """POST a single event; return the HTTP status code or raise on transport error."""
+
+    request = urllib.request.Request(
+        settings.ingest_url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Guard-Proxy-Ingest-Secret": settings.ingest_secret,
+        },
+    )
+    with urllib.request.urlopen(
+        request, timeout=settings.request_timeout_seconds
+    ) as response:
+        return response.status
+
+
+def _ship_line(settings: Settings, line: bytes) -> None:
+    """Block until ``line`` is shipped (2xx) or deliberately dropped (parse/4xx)."""
+
+    text = line.decode("utf-8", errors="replace").strip()
+    if not text:
+        return
+
+    try:
+        event = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("dropping unparseable audit line")
+        return
+    if not isinstance(event, dict):
+        logger.warning("dropping non-object audit line")
+        return
+
+    payload = coraza_event_to_ingest(event)
+    if payload is None:
+        logger.warning("dropping event that cannot be mapped to an ingest payload")
+        return
+
+    backoff = settings.backoff_base_seconds
+    while _running:
+        try:
+            status = _post_event(settings, payload)
+            logger.info("shipped event id=%s status=%s", payload["rule_id"], status)
+            return
+        except urllib.error.HTTPError as error:
+            if error.code == 429 or error.code >= 500:
+                logger.warning("ingest %s, retrying in %.1fs", error.code, backoff)
+            else:
+                # 4xx other than rate limiting: the backend rejected the payload and
+                # will keep doing so. Drop it rather than blocking the pipeline.
+                body = error.read().decode("utf-8", errors="replace")[:500]
+                logger.error("dropping event rejected by ingest (%s): %s",
+                             error.code, body)
+                return
+        except urllib.error.URLError as error:
+            logger.warning("ingest unreachable (%s), retrying in %.1fs",
+                           error.reason, backoff)
+
+        _interruptible_sleep(backoff)
+        backoff = min(backoff * 2, settings.backoff_max_seconds)
+
+
+def _interruptible_sleep(seconds: float) -> None:
+    deadline = time.monotonic() + seconds
+    while _running and time.monotonic() < deadline:
+        time.sleep(min(0.5, deadline - time.monotonic()))
+
+
+def run(settings: Settings) -> None:
+    logger.info("log shipper starting; tailing %s", settings.audit_log_path)
+    offset = _load_offset(settings.state_file)
+
+    while _running:
+        try:
+            size = os.path.getsize(settings.audit_log_path)
+        except FileNotFoundError:
+            _interruptible_sleep(settings.poll_interval_seconds)
+            continue
+
+        if size < offset:
+            logger.warning("audit log truncated/rotated; resetting offset to 0")
+            offset = 0
+            _persist_offset(settings.state_file, offset)
+
+        progressed = False
+        with open(settings.audit_log_path, "rb") as handle:
+            handle.seek(offset)
+            while _running:
+                line = handle.readline()
+                if not line:
+                    break
+                if not line.endswith(b"\n"):
+                    # Partial trailing line: wait for the writer to finish it.
+                    break
+                _ship_line(settings, line)
+                if not _running:
+                    break
+                offset += len(line)
+                _persist_offset(settings.state_file, offset)
+                progressed = True
+
+        if not progressed:
+            _interruptible_sleep(settings.poll_interval_seconds)
+
+    logger.info("log shipper stopped at offset %d", offset)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    signal.signal(signal.SIGTERM, _handle_term)
+    signal.signal(signal.SIGINT, _handle_term)
+    run(load_settings())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/log-shipper/docker-entrypoint.sh
+++ b/src/log-shipper/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+STATE_DIR="$(dirname "${SHIPPER_STATE_FILE:-/var/lib/log-shipper/offset}")"
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "${STATE_DIR}"
+    chown -R shipper:shipper "${STATE_DIR}"
+    exec gosu shipper "$@"
+fi
+
+mkdir -p "${STATE_DIR}"
+exec "$@"

--- a/src/log-shipper/pyproject.toml
+++ b/src/log-shipper/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "guard-proxy-log-shipper"
+version = "0.1.0"
+description = "Guard Proxy — Coraza audit log to ingest endpoint sidecar"
+requires-python = ">=3.13"
+dependencies = []   # runtime: stdlib only
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-cov>=6.0.0",
+    "mypy>=1.13.0",
+    "ruff>=0.8.0",
+]
+
+[build-system]
+requires = ["hatchling>=1.26.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/src/log-shipper/tests/test_mapping.py
+++ b/src/log-shipper/tests/test_mapping.py
@@ -7,53 +7,178 @@ from typing import Any
 
 from app.mapping import coraza_event_to_ingest
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _error_message(rule_id: str = "941100",
+                   msg: str = "XSS Attack Detected via libinjection",
+                   severity: str = "critical") -> str:
+    """Build a realistic coraza-spoa error_message string."""
+    return (
+        f'[client "203.0.113.7"] Coraza: Warning. {msg} '
+        f'[file "/etc/coraza/crs/rules/REQUEST-941.conf"] [line "7791"] '
+        f'[id "{rule_id}"] [rev ""] [msg "{msg}"] '
+        f'[data "Matched Data: ..."] [severity "{severity}"] '
+        f'[ver "OWASP_CRS/4.25.0"] [hostname "example.com"] '
+        f'[uri "/search?q=foo"] [unique_id "tx-123"]'
+    )
+
+
+def _message_entry(rule_id: str = "941100",
+                   msg: str = "XSS Attack Detected via libinjection",
+                   severity: str = "critical") -> dict[str, Any]:
+    """Build an actual coraza-spoa v0.6.1 message dict (data is null)."""
+    return {
+        "actionset": "",
+        "message": "",
+        "error_message": _error_message(rule_id, msg, severity),
+        "data": None,
+    }
+
 
 def _base_event(**overrides: Any) -> dict[str, Any]:
+    """Minimal event that mirrors actual coraza-spoa v0.6.1 JSON output."""
     transaction: dict[str, Any] = {
         "id": "tx-123",
-        "timestamp": "02/Jan/2026:15:04:05 +0000",
+        # Actual format: "YYYY/MM/DD HH:MM:SS" — no ISO 8601, no timezone.
+        "timestamp": "2026/05/31 13:29:17",
         "client_ip": "203.0.113.7",
         "is_interrupted": False,
         "request": {
             "method": "get",
             "uri": "/search?q=1",
-            "headers": {"Host": "Example.COM"},
+            # Actual format: header values are lists.
+            "headers": {"Host": ["Example.COM"]},
         },
         "response": {"status": 200},
-        "variables": {"tx": {"anomaly_score": "5", "paranoia_level": "1"}},
     }
     transaction.update(overrides.pop("transaction", {}))
     event: dict[str, Any] = {
         "transaction": transaction,
-        "messages": [
-            {"data": {"id": "941100", "msg": "XSS Attack Detected", "severity": "2"}}
-        ],
+        "messages": [_message_entry()],
     }
     event.update(overrides)
     return event
 
 
+# ---------------------------------------------------------------------------
+# Real-world event fixture (captured from actual coraza-spoa v0.6.1 output)
+# ---------------------------------------------------------------------------
+
+_REAL_EVENT: dict[str, Any] = {
+    "transaction": {
+        "timestamp": "2026/05/31 13:29:17",
+        "unix_timestamp": 1780234157503639608,
+        "id": "76d5cec7-bcbb-4742-8d78-6ab51fac2d06",
+        "client_ip": "192.168.107.1",
+        "client_port": 56306,
+        "host_ip": "192.168.107.3",
+        "host_port": 80,
+        "server_id": "localhost:8080",
+        "request": {
+            "method": "GET",
+            "protocol": "HTTP/1.1",
+            "uri": "/?q=<script>alert(1)</script>",
+            "http_version": "",
+            "headers": {
+                "accept": ["*/*"],
+                "host": ["localhost:8080"],
+                "user-agent": ["curl/8.7.1"],
+            },
+            "body": "",
+            "files": None,
+            "args": {},
+            "length": 0,
+        },
+        "response": {"protocol": "", "status": 0, "headers": {}, "body": ""},
+        "producer": {"connector": "", "version": "", "server": "",
+                     "rule_engine": "On", "stopwatch": "", "rulesets": ["OWASP_CRS/4.25.0"]},
+        "highest_severity": "",
+        "is_interrupted": True,
+    },
+    "messages": [
+        {
+            "actionset": "", "message": "",
+            "error_message": (
+                '[client "192.168.107.1"] Coraza: Warning. XSS Attack Detected via libinjection '
+                '[file "/etc/coraza/crs/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf"] '
+                '[line "7791"] [id "941100"] [rev ""] [msg "XSS Attack Detected via libinjection"] '
+                '[data "Matched Data: XSS data found within ARGS:q: <script>alert(1)</script>"] '
+                '[severity "critical"] [ver "OWASP_CRS/4.25.0"] [maturity "0"] [accuracy "0"] '
+                '[hostname "192.168.107.3"] [uri "/?q=<script>alert(1)</script>"] '
+                '[unique_id "76d5cec7-bcbb-4742-8d78-6ab51fac2d06"]'
+            ),
+            "data": None,
+        },
+        {
+            "actionset": "", "message": "",
+            "error_message": (
+                '[client "192.168.107.1"] Coraza: Access denied (phase 2). '
+                'Inbound Anomaly Score Exceeded (Total Score: 20) '
+                '[file "/etc/coraza/crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] '
+                '[line "11732"] [id "949110"] [rev ""] [msg "Inbound Anomaly Score Exceeded"] '
+                '[data ""] [severity "emergency"] [ver "OWASP_CRS/4.25.0"] '
+                '[hostname "192.168.107.3"] [uri "/?q=<script>alert(1)</script>"] '
+                '[unique_id "76d5cec7-bcbb-4742-8d78-6ab51fac2d06"]'
+            ),
+            "data": None,
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests: real-world event
+# ---------------------------------------------------------------------------
+
+def test_real_event_maps_correctly() -> None:
+    p = coraza_event_to_ingest(_REAL_EVENT)
+    assert p is not None
+    assert p["producer_event_id"] == "76d5cec7-bcbb-4742-8d78-6ab51fac2d06"
+    assert p["source_ip"] == "192.168.107.1"
+    assert p["method"] == "GET"
+    assert p["request_uri"] == "/?q=<script>alert(1)</script>"
+    assert p["vhost"] == "localhost"           # port stripped from "localhost:8080"
+    assert p["action"] == "deny"               # is_interrupted=True
+    assert p["rule_id"] == 941100              # first message
+    assert p["rule_message"] == "XSS Attack Detected via libinjection"
+    assert p["severity"] == "critical"
+    assert p["status_code"] is None            # status=0 out of range
+    assert p["anomaly_score"] is None          # variables absent
+    assert p["raw_context"] is _REAL_EVENT
+
+
+def test_real_event_at_is_iso() -> None:
+    p = coraza_event_to_ingest(_REAL_EVENT)
+    assert p is not None
+    dt = datetime.fromisoformat(p["event_at"])
+    assert dt.year == 2026
+
+
+# ---------------------------------------------------------------------------
+# Tests: core field mapping (error_message path)
+# ---------------------------------------------------------------------------
+
 def test_maps_core_fields() -> None:
     payload = coraza_event_to_ingest(_base_event())
     assert payload is not None
     assert payload["producer_event_id"] == "tx-123"
-    assert payload["vhost"] == "example.com"
+    assert payload["vhost"] == "example.com"   # "Example.COM" → lower + port stripped
     assert payload["source_ip"] == "203.0.113.7"
     assert payload["method"] == "GET"
     assert payload["request_uri"] == "/search?q=1"
     assert payload["status_code"] == 200
     assert payload["rule_id"] == 941100
-    assert payload["rule_message"] == "XSS Attack Detected"
-    assert payload["anomaly_score"] == 5
-    assert payload["paranoia_level"] == 1
+    assert payload["rule_message"] == "XSS Attack Detected via libinjection"
     assert payload["raw_context"]["transaction"]["id"] == "tx-123"
 
 
-def test_event_at_normalized_to_iso() -> None:
+def test_event_at_coraza_format_normalized_to_iso() -> None:
     payload = coraza_event_to_ingest(_base_event())
     assert payload is not None
-    # Re-parseable as ISO 8601.
-    datetime.fromisoformat(payload["event_at"])
+    dt = datetime.fromisoformat(payload["event_at"])
+    assert dt.year == 2026
 
 
 def test_event_at_accepts_iso_input() -> None:
@@ -63,6 +188,27 @@ def test_event_at_accepts_iso_input() -> None:
     assert payload["event_at"].startswith("2026-01-02T15:04:05")
 
 
+def test_vhost_strips_port() -> None:
+    event = _base_event()
+    event["transaction"]["request"]["headers"] = {"host": ["mysite.com:443"]}
+    p = coraza_event_to_ingest(event)
+    assert p is not None
+    assert p["vhost"] == "mysite.com"
+
+
+def test_vhost_string_value_no_port() -> None:
+    """Header value as plain string (not list) should still work."""
+    event = _base_event()
+    event["transaction"]["request"]["headers"] = {"host": "api.example.com"}
+    p = coraza_event_to_ingest(event)
+    assert p is not None
+    assert p["vhost"] == "api.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Tests: action derivation
+# ---------------------------------------------------------------------------
+
 def test_action_deny_when_interrupted() -> None:
     event = _base_event(transaction={"is_interrupted": True})
     payload = coraza_event_to_ingest(event)
@@ -70,33 +216,66 @@ def test_action_deny_when_interrupted() -> None:
     assert payload["action"] == "deny"
 
 
-def test_action_deny_when_high_severity() -> None:
-    event = _base_event()
-    event["messages"][0]["data"]["severity"] = "1"
+def test_action_deny_when_critical_severity_string() -> None:
+    event = _base_event(messages=[_message_entry(severity="critical")])
+    event["transaction"]["is_interrupted"] = False
     payload = coraza_event_to_ingest(event)
     assert payload is not None
     assert payload["action"] == "deny"
-    assert payload["severity"] == "critical"
 
 
-def test_action_allow_when_not_interrupted_and_low_severity() -> None:
-    event = _base_event()
-    event["messages"][0]["data"]["severity"] = "4"
+def test_action_deny_when_emergency_severity_string() -> None:
+    event = _base_event(messages=[_message_entry(severity="emergency")])
+    event["transaction"]["is_interrupted"] = False
+    p = coraza_event_to_ingest(event)
+    assert p is not None
+    assert p["action"] == "deny"
+
+
+def test_action_allow_when_warning_severity_not_interrupted() -> None:
+    event = _base_event(messages=[_message_entry(severity="warning")])
+    event["transaction"]["is_interrupted"] = False
     payload = coraza_event_to_ingest(event)
     assert payload is not None
     assert payload["action"] == "allow"
     assert payload["severity"] == "warning"
 
 
-def test_severity_buckets() -> None:
-    cases = {"0": "critical", "2": "error", "3": "warning", "5": "info"}
-    for raw, expected in cases.items():
-        event = _base_event()
-        event["messages"][0]["data"]["severity"] = raw
-        payload = coraza_event_to_ingest(event)
-        assert payload is not None
-        assert payload["severity"] == expected
+# ---------------------------------------------------------------------------
+# Tests: severity mapping (string form from error_message)
+# ---------------------------------------------------------------------------
 
+def test_severity_string_buckets() -> None:
+    cases = {
+        "emergency": "critical",
+        "alert": "critical",
+        "critical": "critical",
+        "error": "error",
+        "warning": "warning",
+        "notice": "info",
+        "info": "info",
+        "debug": "info",
+    }
+    for sev_str, expected in cases.items():
+        event = _base_event(messages=[_message_entry(severity=sev_str)])
+        p = coraza_event_to_ingest(event)
+        assert p is not None, f"got None for severity={sev_str!r}"
+        assert p["severity"] == expected, f"severity={sev_str!r} → {p['severity']!r}, want {expected!r}"
+
+
+def test_severity_numeric_string_still_works() -> None:
+    """Backward compat: if data dict is populated with numeric severity string."""
+    event = _base_event()
+    event["messages"][0]["data"] = {"id": "941100", "msg": "XSS", "severity": "2"}
+    p = coraza_event_to_ingest(event)
+    assert p is not None
+    assert p["severity"] == "error"
+    assert p["rule_id"] == 941100
+
+
+# ---------------------------------------------------------------------------
+# Tests: edge cases
+# ---------------------------------------------------------------------------
 
 def test_missing_messages_defaults_to_info_and_allow() -> None:
     event = _base_event(messages=[])
@@ -113,6 +292,14 @@ def test_missing_response_yields_no_status() -> None:
     payload = coraza_event_to_ingest(event)
     assert payload is not None
     assert payload["status_code"] is None
+
+
+def test_status_zero_dropped() -> None:
+    """Blocked requests have status=0 in the actual event; must be mapped to None."""
+    event = _base_event(transaction={"response": {"status": 0}})
+    p = coraza_event_to_ingest(event)
+    assert p is not None
+    assert p["status_code"] is None
 
 
 def test_out_of_range_status_dropped() -> None:
@@ -151,8 +338,11 @@ def test_skips_event_without_transaction() -> None:
     assert coraza_event_to_ingest({"messages": []}) is None
 
 
-def test_absent_anomaly_score_is_none() -> None:
-    event = _base_event(transaction={"variables": {}})
+def test_absent_variables_gives_none_score_and_level() -> None:
+    """transaction.variables is absent in actual coraza-spoa v0.6.1 output."""
+    event = _base_event()
+    # no 'variables' key at all
+    event["transaction"].pop("variables", None)
     payload = coraza_event_to_ingest(event)
     assert payload is not None
     assert payload["anomaly_score"] is None

--- a/src/log-shipper/tests/test_mapping.py
+++ b/src/log-shipper/tests/test_mapping.py
@@ -1,0 +1,159 @@
+"""Unit tests for the Coraza -> ingest payload mapping."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.mapping import coraza_event_to_ingest
+
+
+def _base_event(**overrides: Any) -> dict[str, Any]:
+    transaction: dict[str, Any] = {
+        "id": "tx-123",
+        "timestamp": "02/Jan/2026:15:04:05 +0000",
+        "client_ip": "203.0.113.7",
+        "is_interrupted": False,
+        "request": {
+            "method": "get",
+            "uri": "/search?q=1",
+            "headers": {"Host": "Example.COM"},
+        },
+        "response": {"status": 200},
+        "variables": {"tx": {"anomaly_score": "5", "paranoia_level": "1"}},
+    }
+    transaction.update(overrides.pop("transaction", {}))
+    event: dict[str, Any] = {
+        "transaction": transaction,
+        "messages": [
+            {"data": {"id": "941100", "msg": "XSS Attack Detected", "severity": "2"}}
+        ],
+    }
+    event.update(overrides)
+    return event
+
+
+def test_maps_core_fields() -> None:
+    payload = coraza_event_to_ingest(_base_event())
+    assert payload is not None
+    assert payload["producer_event_id"] == "tx-123"
+    assert payload["vhost"] == "example.com"
+    assert payload["source_ip"] == "203.0.113.7"
+    assert payload["method"] == "GET"
+    assert payload["request_uri"] == "/search?q=1"
+    assert payload["status_code"] == 200
+    assert payload["rule_id"] == 941100
+    assert payload["rule_message"] == "XSS Attack Detected"
+    assert payload["anomaly_score"] == 5
+    assert payload["paranoia_level"] == 1
+    assert payload["raw_context"]["transaction"]["id"] == "tx-123"
+
+
+def test_event_at_normalized_to_iso() -> None:
+    payload = coraza_event_to_ingest(_base_event())
+    assert payload is not None
+    # Re-parseable as ISO 8601.
+    datetime.fromisoformat(payload["event_at"])
+
+
+def test_event_at_accepts_iso_input() -> None:
+    event = _base_event(transaction={"timestamp": "2026-01-02T15:04:05Z"})
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["event_at"].startswith("2026-01-02T15:04:05")
+
+
+def test_action_deny_when_interrupted() -> None:
+    event = _base_event(transaction={"is_interrupted": True})
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["action"] == "deny"
+
+
+def test_action_deny_when_high_severity() -> None:
+    event = _base_event()
+    event["messages"][0]["data"]["severity"] = "1"
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["action"] == "deny"
+    assert payload["severity"] == "critical"
+
+
+def test_action_allow_when_not_interrupted_and_low_severity() -> None:
+    event = _base_event()
+    event["messages"][0]["data"]["severity"] = "4"
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["action"] == "allow"
+    assert payload["severity"] == "warning"
+
+
+def test_severity_buckets() -> None:
+    cases = {"0": "critical", "2": "error", "3": "warning", "5": "info"}
+    for raw, expected in cases.items():
+        event = _base_event()
+        event["messages"][0]["data"]["severity"] = raw
+        payload = coraza_event_to_ingest(event)
+        assert payload is not None
+        assert payload["severity"] == expected
+
+
+def test_missing_messages_defaults_to_info_and_allow() -> None:
+    event = _base_event(messages=[])
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["severity"] == "info"
+    assert payload["action"] == "allow"
+    assert payload["rule_id"] is None
+
+
+def test_missing_response_yields_no_status() -> None:
+    event = _base_event()
+    del event["transaction"]["response"]
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["status_code"] is None
+
+
+def test_out_of_range_status_dropped() -> None:
+    event = _base_event(transaction={"response": {"status": 999}})
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["status_code"] is None
+
+
+def test_missing_host_defaults_to_unknown() -> None:
+    event = _base_event()
+    event["transaction"]["request"]["headers"] = {}
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["vhost"] == "unknown"
+
+
+def test_skips_event_without_client_ip() -> None:
+    event = _base_event()
+    del event["transaction"]["client_ip"]
+    assert coraza_event_to_ingest(event) is None
+
+
+def test_skips_event_with_invalid_client_ip() -> None:
+    event = _base_event(transaction={"client_ip": "not-an-ip"})
+    assert coraza_event_to_ingest(event) is None
+
+
+def test_skips_event_without_method_or_uri() -> None:
+    event = _base_event()
+    event["transaction"]["request"]["method"] = ""
+    assert coraza_event_to_ingest(event) is None
+
+
+def test_skips_event_without_transaction() -> None:
+    assert coraza_event_to_ingest({"messages": []}) is None
+
+
+def test_absent_anomaly_score_is_none() -> None:
+    event = _base_event(transaction={"variables": {}})
+    payload = coraza_event_to_ingest(event)
+    assert payload is not None
+    assert payload["anomaly_score"] is None
+    assert payload["paranoia_level"] is None


### PR DESCRIPTION
## Summary

- Adds a **custom Python log-shipper sidecar** (`src/log-shipper/`) that tails Coraza's JSON audit file and ships each event to `POST /logs/ingest`, closing the M3-04 gap that left the `logs` table empty in a running stack.
- Changes `SecAuditLog /dev/stdout` → `/var/log/coraza/audit.log` on a new `coraza_audit` named volume shared with the sidecar.
- Durability: byte-offset checkpoint only advances on `2xx` / deliberate skip; `5xx`/network errors trigger exponential backoff — a 30-second backend outage stalls but never drops events.
- Adds `ADR-008` recording the Vector-vs-Python decision.

Closes #117.

## What changed

| Area | Change |
|---|---|
| `configs/coraza/coraza.conf` | `SecAuditLog /dev/stdout` → `/var/log/coraza/audit.log` |
| `src/log-shipper/` | New sidecar: `mapping.py` (pure Coraza→`LogIngestRequest` translator), `shipper.py` (tail loop, backoff, offset checkpoint), `config.py`, `Dockerfile`, 16 unit tests |
| `deploy/docker/docker-compose.yml` | `coraza_audit` + `shipper_state` volumes; `coraza` service mounts audit volume (rw); new `log-shipper` service |
| `deploy/docker/.env.example` | Optional shipper tuning vars (commented) |
| `notes/decisions/ADR-008-log-shipper-sidecar.md` | Records choosing Python sidecar over Vector/Fluent Bit |
| `README.architecture.md` | Mermaid diagram + components table + Data Flow section updated |
| `configs/coraza/README.md` | Audit output section updated (file path, inspect command, pointer to shipper) |

## Why a custom Python sidecar instead of Vector

Vector's `http` sink always encodes a batch as a **JSON array**. The ingest endpoint expects a **single JSON object** (`LogIngestRequest`) and returns `422` for an array body. Making Vector fit would require a new batch endpoint (backend change) or a VRL hack. The Coraza→`LogIngestRequest` mapping is already spec'd as a Python-style table in `configs/coraza/README.md`; a testable pure function in Python is far simpler. See ADR-008 for full rationale.

## Definition of done checklist

- [x] `POST /logs/ingest` receives a single JSON object per Coraza event within seconds of the request
- [x] Stopping the backend for 30 seconds does not drop events (offset frozen during backoff; audit file is the buffer)
- [x] 16 unit tests cover action derivation, severity bucketing, field mapping, skip conditions, and timestamp normalisation
- [x] Compose validates (`docker compose config --quiet` passes)
- [x] Image builds from scratch
- [x] ADR-008 documents the architectural decision

## Test plan

- [x] `cp deploy/docker/.env.example deploy/docker/.env` and bring up the stack with `--build`
- [x] Send a rule-triggering request: `curl 'http://localhost:8080/?q=<script>alert(1)</script>'`
- [x] Within ~5 s: `docker exec … psql … -c "select id, vhost, action, rule_id, severity from logs order by id desc limit 5;"`  → row appears
- [x] `docker compose stop backend` for 30 s, fire several probes, `start backend` → all events catch up (count matches, no gaps)
- [x] `docker logs coraza` shows SPOA operational logs (stderr); audit JSON no longer mixes in
