### PR TITLE
feat(m4): policies page CRUD + vhosts UI polish

### DIFF
--- a/src/frontend/src/app/router.tsx
+++ b/src/frontend/src/app/router.tsx
@@ -8,6 +8,7 @@ import { ForbiddenPage } from "@/pages/forbidden/ForbiddenPage";
 import { LoginPage } from "@/pages/login/LoginPage";
 import { NotFoundPage } from "@/pages/not-found/NotFoundPage";
 import { PoliciesPage } from "@/pages/policies/PoliciesPage";
+import { PolicyDetailPage } from "@/pages/policies/PolicyDetailPage";
 import { VHostDetailPage } from "@/pages/vhosts/VHostDetailPage";
 import { VHostsPage } from "@/pages/vhosts/VHostsPage";
 
@@ -51,6 +52,10 @@ export const router = createBrowserRouter([
           {
             path: appRoutes.policies,
             element: <PoliciesPage />,
+          },
+          {
+            path: `${appRoutes.policies}/:policyId`,
+            element: <PolicyDetailPage />,
           },
         ],
       },

--- a/src/frontend/src/app/routes.ts
+++ b/src/frontend/src/app/routes.ts
@@ -10,3 +10,7 @@ export const appRoutes = {
 export function getVHostDetailPath(vhostId: string | number) {
   return `${appRoutes.vhosts}/${vhostId}`;
 }
+
+export function getPolicyDetailPath(policyId: string | number) {
+  return `${appRoutes.policies}/${policyId}`;
+}

--- a/src/frontend/src/components/shared/DataTable.tsx
+++ b/src/frontend/src/components/shared/DataTable.tsx
@@ -64,7 +64,7 @@ export function DataTable<Row>({
                 {columns.map((column) => (
                   <td
                     key={column.key}
-                    className={`px-4 py-3 align-top text-sm text-fg ${column.className ?? ""}`.trim()}
+                    className={`px-4 py-3 align-middle text-sm text-fg ${column.className ?? ""}`.trim()}
                   >
                     {column.cell(row)}
                   </td>

--- a/src/frontend/src/features/policies/DeletePolicyDialog.tsx
+++ b/src/frontend/src/features/policies/DeletePolicyDialog.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { deletePolicy } from "./api";
+import type { Policy } from "./types";
+
+type DeletePolicyDialogProps = {
+  policy: Policy;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function DeletePolicyDialog({ policy, onSuccess, onClose }: DeletePolicyDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await deletePolicy(accessToken, policy.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete policy"
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            className="rounded-[var(--radius-md)] bg-error px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? "Deleting…" : "Delete"}
+          </button>
+        </>
+      }
+    >
+      {serverError && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+        >
+          {serverError}
+        </div>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete{" "}
+        <span className="font-semibold text-fg">{policy.name}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -1,0 +1,221 @@
+import { type FormEvent, useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { createPolicy, updatePolicy } from "./api";
+import type { Policy } from "./types";
+
+type CreateMode = { mode: "create" };
+type EditMode = { mode: "edit"; policy: Policy };
+
+type PolicyFormModalProps = (CreateMode | EditMode) & {
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function PolicyFormModal(props: PolicyFormModalProps) {
+  const { onSuccess, onClose } = props;
+  const { accessToken } = useAuth();
+
+  const initial = props.mode === "edit" ? props.policy : null;
+
+  const [name, setName] = useState(initial?.name ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [enforcementMode, setEnforcementMode] = useState<"block" | "detect_only">(
+    initial?.enforcement_mode ?? "block",
+  );
+  const [paranoiaLevel, setParanoiaLevel] = useState<string>(
+    String(initial?.paranoia_level ?? 1),
+  );
+  const [inboundThreshold, setInboundThreshold] = useState<string>(
+    String(initial?.inbound_anomaly_threshold ?? 5),
+  );
+  const [outboundThreshold, setOutboundThreshold] = useState<string>(
+    String(initial?.outbound_anomaly_threshold ?? 4),
+  );
+  const [isActive, setIsActive] = useState(initial?.is_active ?? true);
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    try {
+      if (props.mode === "edit") {
+        await updatePolicy(accessToken, props.policy.id, {
+          name,
+          description: description || null,
+          enforcement_mode: enforcementMode,
+          paranoia_level: Number(paranoiaLevel) as 1 | 2 | 3 | 4,
+          inbound_anomaly_threshold: Number(inboundThreshold),
+          outbound_anomaly_threshold: Number(outboundThreshold),
+          is_active: isActive,
+        });
+      } else {
+        await createPolicy(accessToken, {
+          name,
+          description: description || null,
+          enforcement_mode: enforcementMode,
+          paranoia_level: Number(paranoiaLevel) as 1 | 2 | 3 | 4,
+          inbound_anomaly_threshold: Number(inboundThreshold),
+          outbound_anomaly_threshold: Number(outboundThreshold),
+        });
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title = props.mode === "create" ? "New policy" : "Edit policy";
+
+  return (
+    <Modal
+      title={title}
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="policy-form"
+            disabled={submitting}
+            className="btn-primary px-4 py-2 text-sm"
+          >
+            {submitting ? "Saving…" : props.mode === "create" ? "Create" : "Save"}
+          </button>
+        </>
+      }
+    >
+      <form id="policy-form" onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        {serverError && (
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <label htmlFor="policy-name" className="block text-sm font-medium text-fg-muted">
+            Name
+          </label>
+          <input
+            id="policy-name"
+            type="text"
+            required
+            maxLength={255}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="input-field"
+            placeholder="My WAF policy"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="policy-description" className="block text-sm font-medium text-fg-muted">
+            Description
+          </label>
+          <input
+            id="policy-description"
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="input-field"
+            placeholder="Optional"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="policy-enforcement-mode" className="block text-sm font-medium text-fg-muted">
+            Enforcement mode
+          </label>
+          <select
+            id="policy-enforcement-mode"
+            value={enforcementMode}
+            onChange={(e) => setEnforcementMode(e.target.value as "block" | "detect_only")}
+            className="input-field"
+          >
+            <option value="block">Block</option>
+            <option value="detect_only">Detect only</option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="policy-paranoia-level" className="block text-sm font-medium text-fg-muted">
+            Paranoia level
+          </label>
+          <select
+            id="policy-paranoia-level"
+            value={paranoiaLevel}
+            onChange={(e) => setParanoiaLevel(e.target.value)}
+            className="input-field"
+          >
+            <option value="1">1 — Minimal</option>
+            <option value="2">2 — Low</option>
+            <option value="3">3 — High</option>
+            <option value="4">4 — Maximum</option>
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <label htmlFor="policy-inbound-threshold" className="block text-sm font-medium text-fg-muted">
+              Inbound threshold
+            </label>
+            <input
+              id="policy-inbound-threshold"
+              type="number"
+              required
+              min={1}
+              value={inboundThreshold}
+              onChange={(e) => setInboundThreshold(e.target.value)}
+              className="input-field"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="policy-outbound-threshold" className="block text-sm font-medium text-fg-muted">
+              Outbound threshold
+            </label>
+            <input
+              id="policy-outbound-threshold"
+              type="number"
+              required
+              min={1}
+              value={outboundThreshold}
+              onChange={(e) => setOutboundThreshold(e.target.value)}
+              className="input-field"
+            />
+          </div>
+        </div>
+
+        {props.mode === "edit" && (
+          <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
+            <input
+              type="checkbox"
+              checked={isActive}
+              onChange={(e) => setIsActive(e.target.checked)}
+              className="h-4 w-4 accent-accent"
+            />
+            Active
+          </label>
+        )}
+      </form>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/policies/api.ts
+++ b/src/frontend/src/features/policies/api.ts
@@ -1,0 +1,27 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { Policy, PolicyCreate, PolicyDetail, PolicyUpdate } from "./types";
+
+export function listPolicies(token: string, signal?: AbortSignal) {
+  return apiRequest<Policy[]>("/policies", { token, signal });
+}
+
+export function getPolicy(token: string, id: number, signal?: AbortSignal) {
+  return apiRequest<PolicyDetail>(`/policies/${id}`, { token, signal });
+}
+
+export function createPolicy(token: string, body: PolicyCreate) {
+  return apiRequest<Policy>("/policies", { method: "POST", token, body });
+}
+
+export function updatePolicy(token: string, id: number, body: PolicyUpdate) {
+  return apiRequest<Policy>(`/policies/${id}`, { method: "PATCH", token, body });
+}
+
+export function deletePolicy(token: string, id: number) {
+  return apiRequest<void>(`/policies/${id}`, {
+    method: "DELETE",
+    token,
+    responseType: "empty",
+  });
+}

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -1,0 +1,45 @@
+export type Policy = {
+  id: number;
+  name: string;
+  description: string | null;
+  paranoia_level: 1 | 2 | 3 | 4;
+  inbound_anomaly_threshold: number;
+  outbound_anomaly_threshold: number;
+  enforcement_mode: "block" | "detect_only";
+  is_active: boolean;
+  created_by: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type RuleOverride = {
+  id: number;
+  policy_id: number;
+  rule_id: number;
+  action: "enable" | "disable";
+  comment: string | null;
+  created_at: string;
+};
+
+export type PolicyDetail = Policy & {
+  rule_overrides: RuleOverride[];
+};
+
+export type PolicyCreate = {
+  name: string;
+  description?: string | null;
+  paranoia_level?: 1 | 2 | 3 | 4;
+  inbound_anomaly_threshold?: number;
+  outbound_anomaly_threshold?: number;
+  enforcement_mode?: "block" | "detect_only";
+};
+
+export type PolicyUpdate = {
+  name?: string;
+  description?: string | null;
+  paranoia_level?: 1 | 2 | 3 | 4;
+  inbound_anomaly_threshold?: number;
+  outbound_anomaly_threshold?: number;
+  enforcement_mode?: "block" | "detect_only";
+  is_active?: boolean;
+};

--- a/src/frontend/src/features/policies/use-policies.ts
+++ b/src/frontend/src/features/policies/use-policies.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { listVHosts } from "@/features/vhosts/api";
+import { useAuth } from "@/hooks/use-auth";
+
+import { listPolicies } from "./api";
+import type { Policy } from "./types";
+
+type PoliciesState = {
+  policies: Policy[];
+  assignedPolicyIds: Set<number>;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+export function usePolicies(): PoliciesState {
+  const { accessToken } = useAuth();
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [assignedPolicyIds, setAssignedPolicyIds] = useState<Set<number>>(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  const fetch = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([
+      listPolicies(accessToken, controller.signal),
+      listVHosts(accessToken, controller.signal),
+    ])
+      .then(([policyList, vhostList]) => {
+        if (generation !== refreshCountRef.current) return;
+        setPolicies(policyList);
+        const ids = new Set(
+          vhostList
+            .map((v) => v.policy_id)
+            .filter((id): id is number => id != null),
+        );
+        setAssignedPolicyIds(ids);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load policies");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken]);
+
+  useEffect(() => {
+    const cleanup = fetch();
+    return cleanup;
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  return { policies, assignedPolicyIds, isLoading, error, refresh };
+}

--- a/src/frontend/src/features/vhosts/VHostFormModal.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.tsx
@@ -25,13 +25,16 @@ export function VHostFormModal(props: VHostFormModalProps) {
   const [domain, setDomain] = useState(initial?.domain ?? "");
   const [backendUrl, setBackendUrl] = useState(initial?.backend_url ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
-  const [sslEnabled, setSslEnabled] = useState(initial?.ssl_enabled ?? false);
   const [isActive, setIsActive] = useState(initial?.is_active ?? true);
   const [policyId, setPolicyId] = useState<string>(
-    initial?.policy_id != null ? String(initial.policy_id) : "",
+    initial?.policy_id != null
+      ? String(initial.policy_id)
+      : String(policies[0]?.id ?? ""),
   );
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
+
+  const noPolicies = props.mode === "create" && policies.length === 0;
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -44,9 +47,9 @@ export function VHostFormModal(props: VHostFormModalProps) {
       domain,
       backend_url: backendUrl,
       description: description || null,
-      ssl_enabled: sslEnabled,
+      ssl_enabled: initial?.ssl_enabled ?? false,
       is_active: isActive,
-      policy_id: policyId ? Number(policyId) : null,
+      policy_id: Number(policyId),
     };
 
     try {
@@ -79,7 +82,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
           <button
             type="submit"
             form="vhost-form"
-            disabled={submitting}
+            disabled={submitting || noPolicies}
             className="btn-primary px-4 py-2 text-sm"
           >
             {submitting ? "Saving…" : props.mode === "create" ? "Create" : "Save"}
@@ -150,40 +153,34 @@ export function VHostFormModal(props: VHostFormModalProps) {
           </label>
           <select
             id="vhost-policy"
+            required
             value={policyId}
             onChange={(e) => setPolicyId(e.target.value)}
             className="input-field"
+            disabled={noPolicies}
           >
-            <option value="">None</option>
             {policies.map((p) => (
               <option key={p.id} value={String(p.id)}>
                 {p.name}
               </option>
             ))}
           </select>
+          {noPolicies && (
+            <p className="text-xs text-fg-muted">
+              No policies yet — create one on the Policies page first.
+            </p>
+          )}
         </div>
 
-        <div className="flex items-center gap-6">
-          <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
-            <input
-              type="checkbox"
-              checked={sslEnabled}
-              onChange={(e) => setSslEnabled(e.target.checked)}
-              className="h-4 w-4 accent-accent"
-            />
-            SSL enabled
-          </label>
-
-          <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
-            <input
-              type="checkbox"
-              checked={isActive}
-              onChange={(e) => setIsActive(e.target.checked)}
-              className="h-4 w-4 accent-accent"
-            />
-            Active
-          </label>
-        </div>
+        <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">
+          <input
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.target.checked)}
+            className="h-4 w-4 accent-accent"
+          />
+          Active
+        </label>
       </form>
     </Modal>
   );

--- a/src/frontend/src/features/vhosts/VHostFormModal.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.tsx
@@ -27,14 +27,10 @@ export function VHostFormModal(props: VHostFormModalProps) {
   const [description, setDescription] = useState(initial?.description ?? "");
   const [isActive, setIsActive] = useState(initial?.is_active ?? true);
   const [policyId, setPolicyId] = useState<string>(
-    initial?.policy_id != null
-      ? String(initial.policy_id)
-      : String(policies[0]?.id ?? ""),
+    initial?.policy_id != null ? String(initial.policy_id) : "",
   );
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
-
-  const noPolicies = props.mode === "create" && policies.length === 0;
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -49,7 +45,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
       description: description || null,
       ssl_enabled: initial?.ssl_enabled ?? false,
       is_active: isActive,
-      policy_id: Number(policyId),
+      policy_id: policyId ? Number(policyId) : null,
     };
 
     try {
@@ -82,7 +78,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
           <button
             type="submit"
             form="vhost-form"
-            disabled={submitting || noPolicies}
+            disabled={submitting}
             className="btn-primary px-4 py-2 text-sm"
           >
             {submitting ? "Saving…" : props.mode === "create" ? "Create" : "Save"}
@@ -153,23 +149,17 @@ export function VHostFormModal(props: VHostFormModalProps) {
           </label>
           <select
             id="vhost-policy"
-            required
             value={policyId}
             onChange={(e) => setPolicyId(e.target.value)}
             className="input-field"
-            disabled={noPolicies}
           >
+            <option value="">None (default policy)</option>
             {policies.map((p) => (
               <option key={p.id} value={String(p.id)}>
                 {p.name}
               </option>
             ))}
           </select>
-          {noPolicies && (
-            <p className="text-xs text-fg-muted">
-              No policies yet — create one on the Policies page first.
-            </p>
-          )}
         </div>
 
         <label className="flex cursor-pointer items-center gap-2 text-sm font-medium text-fg-muted">

--- a/src/frontend/src/layouts/AppLayout.tsx
+++ b/src/frontend/src/layouts/AppLayout.tsx
@@ -6,7 +6,7 @@ export function AppLayout() {
   return (
     <div className="min-h-screen bg-app text-fg">
       <NavBar />
-      <main className="px-6 py-8 lg:px-10">
+      <main className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
         <Outlet />
       </main>
     </div>

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -1,11 +1,190 @@
-import { PagePlaceholder } from "@/components/shared/PagePlaceholder";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import type { DataTableColumn } from "@/components/shared/DataTable";
+import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+import { DeletePolicyDialog } from "@/features/policies/DeletePolicyDialog";
+import { PolicyFormModal } from "@/features/policies/PolicyFormModal";
+import type { Policy } from "@/features/policies/types";
+import { usePolicies } from "@/features/policies/use-policies";
+import { useAuth } from "@/hooks/use-auth";
+import { getPolicyDetailPath } from "@/app/routes";
+
+type ModalState =
+  | null
+  | { type: "create" }
+  | { type: "edit"; policy: Policy }
+  | { type: "delete"; policy: Policy };
 
 export function PoliciesPage() {
+  const { hasRole } = useAuth();
+  const { policies, assignedPolicyIds, isLoading, error, refresh } = usePolicies();
+  const [modal, setModal] = useState<ModalState>(null);
+  const isAdmin = hasRole("admin");
+
+  function closeAndRefresh() {
+    setModal(null);
+    refresh();
+  }
+
+  const columns: DataTableColumn<Policy>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (row) => (
+        <Link
+          to={getPolicyDetailPath(row.id)}
+          className="font-medium text-accent hover:underline"
+        >
+          {row.name}
+        </Link>
+      ),
+    },
+    {
+      key: "enforcement_mode",
+      header: "Enforcement mode",
+      cell: (row) => (
+        <StatusBadge
+          label={row.enforcement_mode === "block" ? "Block" : "Detect only"}
+          tone={row.enforcement_mode === "block" ? "error" : "warning"}
+        />
+      ),
+    },
+    {
+      key: "paranoia_level",
+      header: "Paranoia level",
+      cell: (row) => String(row.paranoia_level),
+    },
+    {
+      key: "thresholds",
+      header: "Anomaly thresholds",
+      cell: (row) => (
+        <span className="tabular-nums text-fg-muted">
+          in {row.inbound_anomaly_threshold} / out {row.outbound_anomaly_threshold}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (row) => (
+        <StatusBadge
+          label={row.is_active ? "Active" : "Inactive"}
+          tone={row.is_active ? "success" : "warning"}
+        />
+      ),
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: Policy) => {
+              const assigned = assignedPolicyIds.has(row.id);
+              return (
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setModal({ type: "edit", policy: row })}
+                    className="rounded-[var(--radius-sm)] border border-border-subtle bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:border-border hover:text-fg"
+                  >
+                    Edit
+                  </button>
+                  <span title={assigned ? "Assigned to a virtual host" : undefined}>
+                    <button
+                      type="button"
+                      disabled={assigned}
+                      onClick={() => setModal({ type: "delete", policy: row })}
+                      className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      Delete
+                    </button>
+                  </span>
+                </div>
+              );
+            },
+          } satisfies DataTableColumn<Policy>,
+        ]
+      : []),
+  ];
+
   return (
-    <PagePlaceholder
-      eyebrow="Policies"
-      title="Policies placeholder"
-      description="This route keeps the information architecture complete from the start, even before the final policy UI exists."
-    />
+    <section className="space-y-8">
+      <PageHeader
+        eyebrow="Policies"
+        title="WAF policies"
+        description="Manage CRS-based WAF policies and assign them to virtual hosts."
+        actions={
+          isAdmin ? (
+            <button
+              type="button"
+              onClick={() => setModal({ type: "create" })}
+              className="btn-primary px-4 py-2 text-sm"
+            >
+              New policy
+            </button>
+          ) : undefined
+        }
+      />
+
+      <SectionCard title="Policies" description="All configured WAF policies and their current settings.">
+        {isLoading ? (
+          <LoadingState label="Loading policies…" />
+        ) : error ? (
+          <ErrorState
+            title="Failed to load policies"
+            description={error}
+            action={
+              <button
+                type="button"
+                onClick={refresh}
+                className="btn-ghost px-4 py-2 text-sm"
+              >
+                Retry
+              </button>
+            }
+          />
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={policies}
+            getRowKey={(row) => String(row.id)}
+            emptyTitle="No policies yet"
+            emptyDescription="Create your first WAF policy to start protecting your virtual hosts."
+          />
+        )}
+      </SectionCard>
+
+      {modal?.type === "create" && (
+        <PolicyFormModal
+          mode="create"
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {modal?.type === "edit" && (
+        <PolicyFormModal
+          mode="edit"
+          policy={modal.policy}
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {modal?.type === "delete" && (
+        <DeletePolicyDialog
+          policy={modal.policy}
+          onSuccess={closeAndRefresh}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </section>
   );
 }

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -51,7 +51,7 @@ export function PoliciesPage() {
       cell: (row) => (
         <StatusBadge
           label={row.enforcement_mode === "block" ? "Block" : "Detect only"}
-          tone={row.enforcement_mode === "block" ? "error" : "warning"}
+          tone={row.enforcement_mode === "block" ? "info" : "warning"}
         />
       ),
     },

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import type { DataTableColumn } from "@/components/shared/DataTable";
@@ -20,7 +20,7 @@ export function PolicyDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const refreshCountRef = useRef(0);
 
-  function load() {
+  const load = useCallback(() => {
     if (!accessToken || !policyId) return;
 
     const controller = new AbortController();
@@ -43,13 +43,12 @@ export function PolicyDetailPage() {
       });
 
     return () => controller.abort();
-  }
+  }, [accessToken, policyId]);
 
   useEffect(() => {
     const cleanup = load();
     return cleanup;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accessToken, policyId]);
+  }, [load]);
 
   const overrideColumns: DataTableColumn<RuleOverride>[] = [
     { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
@@ -108,7 +107,7 @@ export function PolicyDetailPage() {
                 <dd className="mt-1">
                   <StatusBadge
                     label={policy.enforcement_mode === "block" ? "Block" : "Detect only"}
-                    tone={policy.enforcement_mode === "block" ? "error" : "warning"}
+                    tone={policy.enforcement_mode === "block" ? "info" : "warning"}
                   />
                 </dd>
               </div>

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import type { DataTableColumn } from "@/components/shared/DataTable";
+import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+import { getPolicy } from "@/features/policies/api";
+import type { PolicyDetail, RuleOverride } from "@/features/policies/types";
+import { useAuth } from "@/hooks/use-auth";
+
+export function PolicyDetailPage() {
+  const { policyId } = useParams();
+  const { accessToken } = useAuth();
+  const [policy, setPolicy] = useState<PolicyDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  function load() {
+    if (!accessToken || !policyId) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    getPolicy(accessToken, Number(policyId), controller.signal)
+      .then((data) => {
+        if (generation !== refreshCountRef.current) return;
+        setPolicy(data);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load policy");
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken, policyId]);
+
+  const overrideColumns: DataTableColumn<RuleOverride>[] = [
+    { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
+    {
+      key: "action",
+      header: "Action",
+      cell: (row) => (
+        <StatusBadge
+          label={row.action === "enable" ? "Enabled" : "Disabled"}
+          tone={row.action === "enable" ? "success" : "warning"}
+        />
+      ),
+    },
+    {
+      key: "comment",
+      header: "Comment",
+      cell: (row) =>
+        row.comment ? (
+          <span>{row.comment}</span>
+        ) : (
+          <span className="text-fg-subtle">—</span>
+        ),
+    },
+  ];
+
+  return (
+    <section className="space-y-8">
+      <PageHeader
+        eyebrow="Policies"
+        title={policy ? policy.name : "Policy detail"}
+        description={policy?.description ?? undefined}
+      />
+
+      {isLoading ? (
+        <LoadingState label="Loading policy…" />
+      ) : error ? (
+        <ErrorState
+          title="Failed to load policy"
+          description={error}
+          action={
+            <button
+              type="button"
+              onClick={load}
+              className="btn-ghost px-4 py-2 text-sm"
+            >
+              Retry
+            </button>
+          }
+        />
+      ) : policy ? (
+        <>
+          <SectionCard title="Policy settings" description="Current configuration for this WAF policy.">
+            <dl className="grid grid-cols-2 gap-x-8 gap-y-4 text-sm sm:grid-cols-3">
+              <div>
+                <dt className="font-medium text-fg-muted">Enforcement mode</dt>
+                <dd className="mt-1">
+                  <StatusBadge
+                    label={policy.enforcement_mode === "block" ? "Block" : "Detect only"}
+                    tone={policy.enforcement_mode === "block" ? "error" : "warning"}
+                  />
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Status</dt>
+                <dd className="mt-1">
+                  <StatusBadge
+                    label={policy.is_active ? "Active" : "Inactive"}
+                    tone={policy.is_active ? "success" : "warning"}
+                  />
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Paranoia level</dt>
+                <dd className="mt-1 text-fg">{policy.paranoia_level}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Inbound threshold</dt>
+                <dd className="mt-1 text-fg">{policy.inbound_anomaly_threshold}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Outbound threshold</dt>
+                <dd className="mt-1 text-fg">{policy.outbound_anomaly_threshold}</dd>
+              </div>
+            </dl>
+          </SectionCard>
+
+          <SectionCard
+            title="Rule overrides"
+            description="Individual CRS rules enabled or disabled for this policy."
+          >
+            <DataTable
+              columns={overrideColumns}
+              rows={policy.rule_overrides}
+              getRowKey={(row) => String(row.id)}
+              emptyTitle="No rule overrides"
+              emptyDescription="All CRS rules follow the default paranoia level settings."
+            />
+          </SectionCard>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -64,19 +64,20 @@ export function VHostsPage() {
           {
             key: "actions",
             header: "",
+            className: "w-px whitespace-nowrap",
             cell: (row: VHost) => (
               <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={() => setModal({ type: "edit", vhost: row })}
-                  className="btn-ghost rounded-[var(--radius-sm)] px-3 py-1.5 text-xs font-semibold"
+                  className="rounded-[var(--radius-sm)] border border-border-subtle bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:border-border hover:text-fg"
                 >
                   Edit
                 </button>
                 <button
                   type="button"
                   onClick={() => setModal({ type: "delete", vhost: row })}
-                  className="rounded-[var(--radius-sm)] px-3 py-1.5 text-xs font-semibold text-error transition hover:bg-error-soft"
+                  className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft"
                 >
                   Delete
                 </button>

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -22,8 +22,8 @@
   --color-accent-hover: oklch(0.78 0.19 163);
   --color-accent-soft: oklch(0.72 0.19 163 / 0.12);
   --color-accent-fg: oklch(0.15 0.015 160);
-  --color-success: oklch(0.75 0.18 155);
-  --color-success-soft: oklch(0.75 0.18 155 / 0.12);
+  --color-success: oklch(0.68 0.19 155);
+  --color-success-soft: oklch(0.68 0.19 155 / 0.20);
   --color-warning: oklch(0.80 0.16 80);
   --color-warning-soft: oklch(0.80 0.16 80 / 0.12);
   --color-error: oklch(0.70 0.19 25);
@@ -55,8 +55,8 @@
   --color-accent-hover: oklch(0.74 0.17 168);
   --color-accent-soft: oklch(0.68 0.17 168 / 0.14);
   --color-accent-fg: oklch(0.10 0.02 168);
-  --color-success: oklch(0.72 0.18 145);
-  --color-success-soft: oklch(0.72 0.18 145 / 0.14);
+  --color-success: oklch(0.65 0.19 145);
+  --color-success-soft: oklch(0.65 0.19 145 / 0.20);
   --color-warning: oklch(0.80 0.18 75);
   --color-warning-soft: oklch(0.80 0.18 75 / 0.14);
   --color-error: oklch(0.65 0.22 25);


### PR DESCRIPTION
## Summary

- **Policies page (M4)** — full CRUD management UI wired to the existing `/policies` backend: list with enforcement badge / paranoia level / anomaly thresholds, create/edit modal, delete with assignment guard (fetches `/vhosts` to block deletion when a policy is in use), and a read-only `PolicyDetailPage` stub (extended by #125)
- **VHosts form** — policy is now required (no "None" option); SSL checkbox hidden pending MVP decision; empty-policy-list state shows helper text and disables submit
- **Layout** — content area capped at `max-w-7xl` in `AppLayout`
- **DataTable** — rows vertically centered (`align-middle`)
- **Buttons** — Edit gets a visible border + surface background; Delete uses an error-outline style (readable red text on dark bg, no same-hue bg)
- **Badges** — success color adjusted for better contrast (lower lightness, higher soft opacity)
- **Actions column** — pinned to content width (`w-px whitespace-nowrap`)

Closes https://github.com/bihius/guard-proxy/issues/197 and https://github.com/bihius/guard-proxy/issues/125

## Test plan

- [x] Admin: list loads with correct columns; create a policy; edit it; row name link opens detail page; delete an unassigned policy
- [x] Assign a policy to a vhost, confirm Delete is disabled with tooltip on Policies page
- [x] VHosts create: no "None" option in policy select; form blocked when no policies exist
- [x] Viewer: no New/Edit/Delete controls on either page
- [x] Error path: stop backend → error state + Retry renders
