### PR TITLE
fix: allow PATCH in Coraza, hide outbound threshold, remove eyebrow badges, fix edit button border

### DIFF
--- a/configs/coraza/crs-setup.conf
+++ b/configs/coraza/crs-setup.conf
@@ -32,6 +32,15 @@ SecAction \
     setvar:tx.outbound_anomaly_score_threshold=5"
 
 SecAction \
+    "id:900200,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:'tx.allowed_methods=GET HEAD POST PUT DELETE PATCH OPTIONS'"
+
+SecAction \
     "id:900990,\
     phase:1,\
     pass,\

--- a/src/backend/app/templates/crs-setup.conf.j2
+++ b/src/backend/app/templates/crs-setup.conf.j2
@@ -34,6 +34,15 @@ SecAction \
     setvar:tx.outbound_anomaly_score_threshold={{ policy.outbound_anomaly_threshold }}"
 
 SecAction \
+    "id:900200,\
+    phase:1,\
+    pass,\
+    nolog,\
+    tag:'OWASP_CRS',\
+    ver:'OWASP_CRS/4.25.0',\
+    setvar:'tx.allowed_methods=GET HEAD POST PUT DELETE PATCH OPTIONS'"
+
+SecAction \
     "id:900990,\
     phase:1,\
     pass,\

--- a/src/frontend/src/components/shared/PageHeader.tsx
+++ b/src/frontend/src/components/shared/PageHeader.tsx
@@ -1,37 +1,27 @@
 import type { ReactNode } from "react";
 
 type PageHeaderProps = {
-  eyebrow?: string;
   title: string;
   description?: string;
   actions?: ReactNode;
 };
 
 export function PageHeader({
-  eyebrow,
   title,
   description,
   actions,
 }: PageHeaderProps) {
   return (
     <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-      <div className="space-y-3">
-        {eyebrow ? (
-          <span className="inline-block rounded-[var(--radius-full)] bg-accent-soft px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent">
-            {eyebrow}
-          </span>
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-fg sm:text-4xl">
+          {title}
+        </h1>
+        {description ? (
+          <p className="max-w-3xl text-base leading-7 text-fg-muted">
+            {description}
+          </p>
         ) : null}
-
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight text-fg sm:text-4xl">
-            {title}
-          </h1>
-          {description ? (
-            <p className="max-w-3xl text-base leading-7 text-fg-muted">
-              {description}
-            </p>
-          ) : null}
-        </div>
       </div>
 
       {actions ? (

--- a/src/frontend/src/components/shared/PagePlaceholder.tsx
+++ b/src/frontend/src/components/shared/PagePlaceholder.tsx
@@ -8,18 +8,15 @@ import { StatusBadge } from "./StatusBadge";
 type PagePlaceholderProps = {
   title: string;
   description: string;
-  eyebrow: string;
 };
 
 export function PagePlaceholder({
   title,
   description,
-  eyebrow,
 }: PagePlaceholderProps) {
   return (
     <section className="space-y-8">
       <PageHeader
-        eyebrow={eyebrow}
         title={title}
         description={description}
         actions={<StatusBadge label="Bootstrap" tone="info" />}

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -32,9 +32,7 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
   const [inboundThreshold, setInboundThreshold] = useState<string>(
     String(initial?.inbound_anomaly_threshold ?? 5),
   );
-  const [outboundThreshold, setOutboundThreshold] = useState<string>(
-    String(initial?.outbound_anomaly_threshold ?? 4),
-  );
+  const outboundThreshold = String(initial?.outbound_anomaly_threshold ?? 4);
   const [isActive, setIsActive] = useState(initial?.is_active ?? true);
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -172,36 +172,19 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
           </select>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-1.5">
-            <label htmlFor="policy-inbound-threshold" className="block text-sm font-medium text-fg-muted">
-              Inbound threshold
-            </label>
-            <input
-              id="policy-inbound-threshold"
-              type="number"
-              required
-              min={1}
-              value={inboundThreshold}
-              onChange={(e) => setInboundThreshold(e.target.value)}
-              className="input-field"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <label htmlFor="policy-outbound-threshold" className="block text-sm font-medium text-fg-muted">
-              Outbound threshold
-            </label>
-            <input
-              id="policy-outbound-threshold"
-              type="number"
-              required
-              min={1}
-              value={outboundThreshold}
-              onChange={(e) => setOutboundThreshold(e.target.value)}
-              className="input-field"
-            />
-          </div>
+        <div className="space-y-1.5">
+          <label htmlFor="policy-inbound-threshold" className="block text-sm font-medium text-fg-muted">
+            Inbound threshold
+          </label>
+          <input
+            id="policy-inbound-threshold"
+            type="number"
+            required
+            min={1}
+            value={inboundThreshold}
+            onChange={(e) => setInboundThreshold(e.target.value)}
+            className="input-field"
+          />
         </div>
 
         {props.mode === "edit" && (

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -25,7 +25,6 @@ export function DashboardPage() {
   return (
     <section className="space-y-8">
       <PageHeader
-        eyebrow="Dashboard"
         title="Security operations overview"
         description="This starter dashboard shows the shared building blocks for the rest of the team: stat cards, section cards, and consistent status badges."
         actions={

--- a/src/frontend/src/pages/forbidden/ForbiddenPage.tsx
+++ b/src/frontend/src/pages/forbidden/ForbiddenPage.tsx
@@ -3,7 +3,6 @@ import { PagePlaceholder } from "@/components/shared/PagePlaceholder";
 export function ForbiddenPage() {
   return (
     <PagePlaceholder
-      eyebrow="Access denied"
       title="You do not have permission to view this area"
       description="This route is the shared fallback for role-based navigation guards. It lets us block admin-only screens without crashing the app or bouncing the user back to login."
     />

--- a/src/frontend/src/pages/not-found/NotFoundPage.tsx
+++ b/src/frontend/src/pages/not-found/NotFoundPage.tsx
@@ -14,7 +14,6 @@ export function NotFoundPage() {
     <main className="grid min-h-screen place-items-center bg-app px-6 py-10 text-fg">
       <section className="w-full max-w-3xl space-y-8">
         <PageHeader
-          eyebrow="404"
           title="This page does not exist"
           description="The route could not be matched. Use the shared navigation to get back to a valid part of the app."
         />

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -62,10 +62,10 @@ export function PoliciesPage() {
     },
     {
       key: "thresholds",
-      header: "Anomaly thresholds",
+      header: "Inbound threshold",
       cell: (row) => (
         <span className="tabular-nums text-fg-muted">
-          in {row.inbound_anomaly_threshold} / out {row.outbound_anomaly_threshold}
+          {row.inbound_anomaly_threshold}
         </span>
       ),
     },
@@ -92,7 +92,7 @@ export function PoliciesPage() {
                   <button
                     type="button"
                     onClick={() => setModal({ type: "edit", policy: row })}
-                    className="rounded-[var(--radius-sm)] border border-border-subtle bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:border-border hover:text-fg"
+                    className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
                   >
                     Edit
                   </button>
@@ -117,7 +117,6 @@ export function PoliciesPage() {
   return (
     <section className="space-y-8">
       <PageHeader
-        eyebrow="Policies"
         title="WAF policies"
         description="Manage CRS-based WAF policies and assign them to virtual hosts."
         actions={

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -77,7 +77,6 @@ export function PolicyDetailPage() {
   return (
     <section className="space-y-8">
       <PageHeader
-        eyebrow="Policies"
         title={policy ? policy.name : "Policy detail"}
         description={policy?.description ?? undefined}
       />
@@ -127,10 +126,6 @@ export function PolicyDetailPage() {
               <div>
                 <dt className="font-medium text-fg-muted">Inbound threshold</dt>
                 <dd className="mt-1 text-fg">{policy.inbound_anomaly_threshold}</dd>
-              </div>
-              <div>
-                <dt className="font-medium text-fg-muted">Outbound threshold</dt>
-                <dd className="mt-1 text-fg">{policy.outbound_anomaly_threshold}</dd>
               </div>
             </dl>
           </SectionCard>

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -7,7 +7,6 @@ export function VHostDetailPage() {
 
   return (
     <PagePlaceholder
-      eyebrow="VHosts"
       title={`VHost detail placeholder${vhostId ? ` #${vhostId}` : ""}`}
       description="This route proves we already support a dedicated detail view. Later it can become a read-only page or a drawer entry point for the assigned team task."
     />

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -70,7 +70,7 @@ export function VHostsPage() {
                 <button
                   type="button"
                   onClick={() => setModal({ type: "edit", vhost: row })}
-                  className="rounded-[var(--radius-sm)] border border-border-subtle bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:border-border hover:text-fg"
+                  className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
                 >
                   Edit
                 </button>
@@ -91,7 +91,6 @@ export function VHostsPage() {
   return (
     <section className="space-y-8">
       <PageHeader
-        eyebrow="VHosts"
         title="Virtual hosts"
         description="Manage the domains, backend targets, and WAF policies for each virtual host."
         actions={


### PR DESCRIPTION
## Summary

- **PATCH method unblocked** — CRS rule 911100 was rejecting all `PATCH` requests, making it impossible to edit vhosts or policies. Added `SecAction id:900200` to both `configs/coraza/crs-setup.conf` (static, used directly by Coraza) and `crs-setup.conf.j2` (template, used for dynamically applied configs) to include `PATCH` in `tx.allowed_methods`.
- **Outbound threshold hidden** — MVP does not implement response inspection, so the outbound anomaly threshold field is hidden in `PolicyFormModal`, `PolicyDetailPage`, and the `PoliciesPage` table column. The state variable and API payload are preserved so the value isn't lost on edit.
- **Eyebrow badge spans removed** — Removed the `eyebrow` prop from `PageHeader` and `PagePlaceholder` and cleaned up all call sites across 7 pages.
- **Edit button border** — Changed `border-border-subtle` to `border-border` on the Edit buttons in VHosts and Policies pages so the border is visible at rest (not only on hover).

## After merge

Restart the Coraza container (`docker compose restart coraza`) to pick up the new `crs-setup.conf` — no config apply needed since this change is in the static file.

## Test plan

- [x] Edit a vhost via the UI — should succeed (no more 403 from Coraza)
- [x] Edit a policy via the UI — should succeed
- [x] Policy form (create + edit): only inbound threshold visible
- [x] Policy detail page: only inbound threshold shown
- [x] Policies table: "Inbound threshold" column, no outbound value
- [x] All pages: no coloured eyebrow badge above the heading
- [x] VHosts and Policies pages: Edit button has a visible border at rest
