### PR TITLE
Add course documentation and demo stack

### DIFF
--- a/deploy/demo/.env.example
+++ b/deploy/demo/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to .env before running the demo.
+# These values are local-demo defaults only.
+
+POSTGRES_USER=guard_proxy
+POSTGRES_PASSWORD=guard_proxy_demo_password
+POSTGRES_DB=guard_proxy
+
+JWT_SECRET_KEY=guard-proxy-demo-jwt-secret-key-please-change
+LOG_INGEST_SHARED_SECRET=guard-proxy-demo-log-ingest-shared-secret-please-change
+
+CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
+VITE_API_BASE_URL=http://localhost:8000
+HAPROXY_HTTP_PORT=8080
+HAPROXY_HTTPS_PORT=8443
+BACKEND_HTTP_PORT=8000
+FRONTEND_HTTP_PORT=3000
+
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=GuardProxyDemo12345
+ADMIN_FULL_NAME=Demo Administrator
+
+DEMO_DOMAIN=app.local
+DEMO_BACKEND_URL=http://demo-app:8080
+DEMO_SECOND_DOMAIN=api.local
+DEMO_SECOND_BACKEND_URL=http://demo-api:8080

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,94 @@
+# Guard Proxy demo
+
+This directory starts a self-contained local demo stack:
+
+- Guard Proxy backend, frontend, HAProxy, Coraza, log shipper, PostgreSQL
+- two small HTTP echo applications behind HAProxy/Coraza
+- a setup script that creates an admin, creates a demo WAF policy, creates
+  `app.local` and `api.local` vhosts, and applies runtime config
+
+## Run
+
+```bash
+cp deploy/demo/.env.example deploy/demo/.env
+git submodule update --init --recursive
+chmod +x deploy/demo/setup-demo.sh
+./deploy/demo/setup-demo.sh
+```
+
+Open the admin panel:
+
+```text
+http://localhost:3000
+```
+
+The demo exposes the backend directly on `http://localhost:8000` for the admin
+panel and setup script. HAProxy listens on `http://localhost:8080` for HTTP WAF
+traffic and on `https://localhost:8443` for a temporary self-signed TLS demo.
+
+The TLS bind is intentionally a demo-only patch applied after `/config/apply`.
+The next generated config apply can overwrite it.
+
+Default local credentials from `.env.example`:
+
+```text
+admin@example.com
+GuardProxyDemo12345
+```
+
+## Try routing through the WAF
+
+First app:
+
+```bash
+curl -i -H 'Host: app.local' 'http://127.0.0.1:8080/hello?name=demo'
+```
+
+Expected result: HTTP 200 from `demo-frontend-app`.
+
+Second app:
+
+```bash
+curl -i -H 'Host: api.local' 'http://127.0.0.1:8080/v1/status'
+```
+
+Expected result: HTTP 200 from `demo-api-service`.
+
+## Trigger a WAF block
+
+This requires the OWASP CRS submodule to be initialized before building the demo.
+The setup script checks this and stops early if `configs/coraza/crs/rules` is
+missing.
+
+HTTP:
+
+```bash
+curl -i -H 'Host: app.local' "http://127.0.0.1:8080/?id=1%27%20OR%20%271%27%3D%271"
+```
+
+HTTPS:
+
+```bash
+curl -k -i -H 'Host: api.local' "https://127.0.0.1:8443/?id=1%27%20OR%20%271%27%3D%271"
+```
+
+Expected result: HTTP 403 from the WAF.
+
+TLS demo:
+
+```bash
+curl -k -i -H 'Host: app.local' 'https://127.0.0.1:8443/hello?tls=1'
+curl -k -i -H 'Host: api.local' 'https://127.0.0.1:8443/v1/status'
+```
+
+## Stop
+
+```bash
+docker compose --env-file deploy/demo/.env -f deploy/demo/docker-compose.yml down
+```
+
+Remove demo volumes too:
+
+```bash
+docker compose --env-file deploy/demo/.env -f deploy/demo/docker-compose.yml down -v
+```

--- a/deploy/demo/app/Dockerfile
+++ b/deploy/demo/app/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+COPY server.py /app/server.py
+
+EXPOSE 8080
+
+CMD ["python", "/app/server.py"]

--- a/deploy/demo/app/server.py
+++ b/deploy/demo/app/server.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class EchoHandler(BaseHTTPRequestHandler):
+    server_version = "guard-proxy-demo-echo/0.1"
+
+    def do_GET(self) -> None:
+        self._send_echo()
+
+    def do_POST(self) -> None:
+        self._send_echo()
+
+    def do_PUT(self) -> None:
+        self._send_echo()
+
+    def do_DELETE(self) -> None:
+        self._send_echo()
+
+    def _send_echo(self) -> None:
+        body = {
+            "service": os.getenv("DEMO_APP_NAME", "guard-proxy-demo-echo"),
+            "method": self.command,
+            "path": self.path,
+            "client": self.client_address[0],
+            "headers": {
+                key: value
+                for key, value in self.headers.items()
+                if key.lower()
+                in {
+                    "host",
+                    "user-agent",
+                    "x-forwarded-for",
+                    "x-request-id",
+                    "x-waf-score",
+                }
+            },
+        }
+        payload = json.dumps(body, indent=2, sort_keys=True).encode("utf-8")
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"{self.address_string()} - {format % args}")
+
+
+def main() -> None:
+    app_name = os.getenv("DEMO_APP_NAME", "guard-proxy-demo-echo")
+    server = ThreadingHTTPServer(("0.0.0.0", 8080), EchoHandler)
+    print(f"{app_name} listening on :8080")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/demo/certs/.gitignore
+++ b/deploy/demo/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -1,0 +1,207 @@
+name: guard-proxy-demo
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - gp_internal
+
+  backend:
+    build:
+      context: ../../src/backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
+      GUARD_PROXY_RUNTIME_DIR: /var/lib/guard-proxy/generated
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_HTTP_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - backend_logs:/var/log/guard-proxy
+      - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
+      - generated_config:/var/lib/guard-proxy/generated
+      - haproxy_runtime:/var/run/haproxy
+    networks:
+      - gp_internal
+
+  frontend:
+    build:
+      context: ../../src/frontend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${FRONTEND_HTTP_PORT:-3000}:5173"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:5173 >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - gp_edge
+
+  demo-app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    environment:
+      DEMO_APP_NAME: demo-frontend-app
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/health', timeout=2)\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - gp_internal
+
+  demo-api:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    environment:
+      DEMO_APP_NAME: demo-api-service
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/health', timeout=2)\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - gp_internal
+
+  coraza:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/coraza.Dockerfile
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    volumes:
+      - ../../configs/coraza/coraza-spoa.yaml:/etc/coraza-spoa/coraza-spoa.yaml:ro
+      - ../../configs/coraza/coraza.conf:/etc/coraza/coraza.conf:ro
+      - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
+      - ../../configs/coraza/crs:/etc/coraza/crs:ro
+      - generated_config:/runtime:ro
+      - coraza_audit:/var/log/coraza
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "9000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - gp_internal
+
+  log-shipper:
+    build:
+      context: ../../src/log-shipper
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      INGEST_URL: "http://backend:8000/logs/ingest"
+      CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"
+      SHIPPER_STATE_FILE: "/var/lib/log-shipper/offset"
+    depends_on:
+      backend:
+        condition: service_healthy
+      coraza:
+        condition: service_started
+    volumes:
+      - coraza_audit:/var/log/coraza:ro
+      - shipper_state:/var/lib/log-shipper
+    networks:
+      - gp_internal
+
+  haproxy:
+    image: haproxy:3.0-alpine
+    user: "0:0"
+    command:
+      [
+        "sh",
+        "-c",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+      ]
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+      coraza:
+        condition: service_started
+      demo-app:
+        condition: service_healthy
+      demo-api:
+        condition: service_healthy
+    ports:
+      - "${HAPROXY_HTTP_PORT:-8080}:80"
+      - "${HAPROXY_HTTPS_PORT:-8443}:443"
+    volumes:
+      - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+      - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
+      - ./certs/demo.pem:/etc/haproxy/certs/demo.pem:ro
+      - haproxy_logs:/var/log/haproxy
+      - generated_config:/etc/haproxy/generated
+      - haproxy_runtime:/var/run/haproxy
+    healthcheck:
+      test: ["CMD-SHELL", "haproxy -c -f /etc/haproxy/generated/current/haproxy.cfg"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - gp_edge
+      - gp_internal
+
+networks:
+  gp_edge:
+    driver: bridge
+  gp_internal:
+    driver: bridge
+
+volumes:
+  pgdata:
+  haproxy_logs:
+  haproxy_runtime:
+  backend_logs:
+  generated_config:
+  coraza_audit:
+  shipper_state:

--- a/deploy/demo/setup-demo.sh
+++ b/deploy/demo/setup-demo.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+ENV_FILE="${SCRIPT_DIR}/.env"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-180}"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}. Copy deploy/demo/.env.example to deploy/demo/.env first." >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}")
+else
+  echo "Docker Compose is required." >&2
+  exit 1
+fi
+
+env_value() {
+  local name="$1"
+  local fallback="${2:-}"
+  local value
+
+  value="$(grep -E "^${name}=" "${ENV_FILE}" | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "${value}" ]]; then
+    printf '%s' "${fallback}"
+  else
+    printf '%s' "${value}"
+  fi
+}
+
+json_string() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+api_json() {
+  local method="$1"
+  local path="$2"
+  local token="${3:-}"
+  local body="${4:-}"
+  local response_file
+
+  response_file="$(mktemp)"
+  if [[ -n "${body}" ]]; then
+    http_code="$(
+      curl \
+        --silent \
+        --show-error \
+        --output "${response_file}" \
+        --write-out '%{http_code}' \
+        --request "${method}" \
+        --header "Content-Type: application/json" \
+        ${token:+--header "Authorization: Bearer ${token}"} \
+        --data "${body}" \
+        "${API_BASE_URL}${path}"
+    )"
+  else
+    http_code="$(
+      curl \
+        --silent \
+        --show-error \
+        --output "${response_file}" \
+        --write-out '%{http_code}' \
+        --request "${method}" \
+        ${token:+--header "Authorization: Bearer ${token}"} \
+        "${API_BASE_URL}${path}"
+    )"
+  fi
+
+  if [[ "${http_code}" -lt 200 || "${http_code}" -ge 300 ]]; then
+    echo "API ${method} ${path} failed with HTTP ${http_code}:" >&2
+    cat "${response_file}" >&2
+    rm -f "${response_file}"
+    return 1
+  fi
+
+  cat "${response_file}"
+  rm -f "${response_file}"
+}
+
+container_id() {
+  local service="$1"
+  "${COMPOSE[@]}" ps -q "${service}"
+}
+
+health_status() {
+  local service="$1"
+  local id
+
+  id="$(container_id "${service}")"
+  if [[ -z "${id}" ]]; then
+    echo "missing"
+    return
+  fi
+
+  docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${id}"
+}
+
+wait_for_healthy() {
+  local service="$1"
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local status
+
+  echo "Waiting for ${service}..."
+  while (( SECONDS < deadline )); do
+    status="$(health_status "${service}")"
+    case "${status}" in
+      healthy)
+        echo "${service} is healthy."
+        return 0
+        ;;
+      exited|dead)
+        echo "${service} is ${status}." >&2
+        return 1
+        ;;
+    esac
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${service}; last status: ${status:-unknown}." >&2
+  return 1
+}
+
+ensure_crs_bundle() {
+  if compgen -G "${REPO_ROOT}/configs/coraza/crs/rules/*.conf" >/dev/null; then
+    return
+  fi
+
+  echo "Missing OWASP CRS rules in configs/coraza/crs." >&2
+  echo "Run: git submodule update --init --recursive" >&2
+  echo "Then rerun: ./deploy/demo/setup-demo.sh" >&2
+  exit 1
+}
+
+ADMIN_EMAIL="$(env_value ADMIN_EMAIL admin@example.com)"
+ADMIN_PASSWORD="$(env_value ADMIN_PASSWORD GuardProxyDemo12345)"
+ADMIN_FULL_NAME="$(env_value ADMIN_FULL_NAME 'Demo Administrator')"
+DEMO_DOMAIN="$(env_value DEMO_DOMAIN app.local)"
+DEMO_BACKEND_URL="$(env_value DEMO_BACKEND_URL http://demo-app:8080)"
+DEMO_SECOND_DOMAIN="$(env_value DEMO_SECOND_DOMAIN api.local)"
+DEMO_SECOND_BACKEND_URL="$(env_value DEMO_SECOND_BACKEND_URL http://demo-api:8080)"
+HAPROXY_HTTP_PORT="$(env_value HAPROXY_HTTP_PORT 8080)"
+HAPROXY_HTTPS_PORT="$(env_value HAPROXY_HTTPS_PORT 8443)"
+BACKEND_HTTP_PORT="$(env_value BACKEND_HTTP_PORT 8000)"
+FRONTEND_HTTP_PORT="$(env_value FRONTEND_HTTP_PORT 3000)"
+API_BASE_URL="http://127.0.0.1:${BACKEND_HTTP_PORT}"
+WAF_BASE_URL="http://127.0.0.1:${HAPROXY_HTTP_PORT}"
+WAF_TLS_BASE_URL="https://127.0.0.1:${HAPROXY_HTTPS_PORT}"
+FRONTEND_BASE_URL="http://localhost:${FRONTEND_HTTP_PORT}"
+
+cd "${REPO_ROOT}"
+
+ensure_crs_bundle
+
+ensure_demo_certificate() {
+  local cert_dir="${SCRIPT_DIR}/certs"
+  local cert_file="${cert_dir}/demo.pem"
+  local crt_file="${cert_dir}/demo.crt"
+  local key_file="${cert_dir}/demo.key"
+
+  if [[ -f "${cert_file}" ]]; then
+    return
+  fi
+
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "OpenSSL is required to generate the demo TLS certificate." >&2
+    exit 1
+  fi
+
+  echo "Generating self-signed demo TLS certificate for ${DEMO_DOMAIN} and ${DEMO_SECOND_DOMAIN}..."
+  mkdir -p "${cert_dir}"
+  openssl req \
+    -x509 \
+    -nodes \
+    -newkey rsa:2048 \
+    -days 30 \
+    -subj "/CN=${DEMO_DOMAIN}" \
+    -addext "subjectAltName=DNS:${DEMO_DOMAIN},DNS:${DEMO_SECOND_DOMAIN}" \
+    -keyout "${key_file}" \
+    -out "${crt_file}" \
+    >/dev/null 2>&1
+  cat "${crt_file}" "${key_file}" > "${cert_file}"
+}
+
+enable_demo_https() {
+  echo "Applying temporary demo HTTPS bind to generated HAProxy config..."
+  "${COMPOSE[@]}" exec -T haproxy sh -c \
+    "grep -q 'bind \\*:443 ssl crt /etc/haproxy/certs/demo.pem' /etc/haproxy/generated/current/haproxy.cfg || sed -i '/^[[:space:]]*bind \\*:80$/a\\    bind *:443 ssl crt /etc/haproxy/certs/demo.pem' /etc/haproxy/generated/current/haproxy.cfg"
+  "${COMPOSE[@]}" exec -T haproxy haproxy -c -f /etc/haproxy/generated/current/haproxy.cfg >/dev/null
+  "${COMPOSE[@]}" restart haproxy >/dev/null
+  wait_for_healthy haproxy
+}
+
+ensure_demo_certificate
+"${COMPOSE[@]}" up -d --build
+
+wait_for_healthy backend
+wait_for_healthy demo-app
+wait_for_healthy demo-api
+wait_for_healthy coraza
+wait_for_healthy haproxy
+
+echo "Seeding admin user..."
+"${COMPOSE[@]}" exec -T backend /app/.venv/bin/python scripts/seed_admin.py \
+  --email "${ADMIN_EMAIL}" \
+  --password "${ADMIN_PASSWORD}" \
+  --full-name "${ADMIN_FULL_NAME}"
+
+echo "Logging in..."
+login_body="$(
+  printf '{"email":%s,"password":%s}' \
+    "$(json_string "${ADMIN_EMAIL}")" \
+    "$(json_string "${ADMIN_PASSWORD}")"
+)"
+token="$(
+  api_json POST /auth/login "" "${login_body}" \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])'
+)"
+
+echo "Ensuring demo WAF policy exists..."
+policy_body='{"name":"Demo CRS","description":"Demo policy for app.local and api.local","paranoia_level":1,"inbound_anomaly_threshold":5,"outbound_anomaly_threshold":4,"enforcement_mode":"block"}'
+policy_response="$(api_json POST /policies "${token}" "${policy_body}" || true)"
+if [[ -z "${policy_response}" ]]; then
+  policy_response="$(api_json GET /policies "${token}")"
+fi
+policy_id="$(
+  POLICY_RESPONSE="${policy_response}" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["POLICY_RESPONSE"])
+if isinstance(data, list):
+    for item in data:
+        if item["name"] == "Demo CRS":
+            print(item["id"])
+            break
+    else:
+        raise SystemExit("Demo CRS policy not found")
+else:
+    print(data["id"])
+PY
+)"
+
+ensure_vhost() {
+  local domain="$1"
+  local backend_url="$2"
+  local description="$3"
+  local vhost_body
+  local vhost_response
+  local vhosts_response
+  local vhost_id
+
+  echo "Ensuring vhost ${domain} -> ${backend_url} exists..."
+  vhost_body="$(
+    printf '{"domain":%s,"backend_url":%s,"description":%s,"ssl_enabled":false,"is_active":true,"policy_id":%s}' \
+      "$(json_string "${domain}")" \
+      "$(json_string "${backend_url}")" \
+      "$(json_string "${description}")" \
+      "${policy_id}"
+  )"
+  vhost_response="$(api_json POST /vhosts "${token}" "${vhost_body}" || true)"
+  if [[ -n "${vhost_response}" ]]; then
+    return
+  fi
+
+  vhosts_response="$(api_json GET /vhosts "${token}")"
+  vhost_id="$(
+    VHOSTS_RESPONSE="${vhosts_response}" DEMO_DOMAIN="${domain}" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["VHOSTS_RESPONSE"])
+domain = os.environ["DEMO_DOMAIN"]
+for item in data:
+    if item["domain"] == domain:
+        print(item["id"])
+        break
+else:
+    raise SystemExit(f"vhost {domain!r} not found")
+PY
+    )"
+  vhost_response="$(api_json PATCH "/vhosts/${vhost_id}" "${token}" "${vhost_body}")"
+}
+
+ensure_vhost "${DEMO_DOMAIN}" "${DEMO_BACKEND_URL}" "Demo frontend application"
+ensure_vhost "${DEMO_SECOND_DOMAIN}" "${DEMO_SECOND_BACKEND_URL}" "Demo API application"
+
+echo "Applying generated HAProxy/Coraza config..."
+api_json POST /config/apply "${token}" >/dev/null
+enable_demo_https
+
+echo
+echo "Demo is ready."
+echo "Admin panel: ${FRONTEND_BASE_URL}"
+echo "Backend API:  ${API_BASE_URL}"
+echo "WAF proxy:    ${WAF_BASE_URL}"
+echo "WAF TLS:      ${WAF_TLS_BASE_URL}"
+echo
+echo "Try:"
+echo "  curl -i -H 'Host: ${DEMO_DOMAIN}' '${WAF_BASE_URL}/hello?name=demo'"
+echo "  curl -i -H 'Host: ${DEMO_SECOND_DOMAIN}' '${WAF_BASE_URL}/v1/status'"
+echo "  curl -k -i -H 'Host: ${DEMO_DOMAIN}' '${WAF_TLS_BASE_URL}/hello?tls=1'"
+echo "  curl -k -i -H 'Host: ${DEMO_SECOND_DOMAIN}' '${WAF_TLS_BASE_URL}/v1/status'"

--- a/docs/course-project-report.md
+++ b/docs/course-project-report.md
@@ -1,0 +1,316 @@
+# Dokumentacja projektu kursowego
+
+## 1. Ogolne zalozenia projektu
+
+Guard Proxy to self-hosted Web Application Firewall, czyli system ochrony ruchu
+HTTP uruchamiany przed aplikacja webowa. System laczy HAProxy jako reverse proxy,
+Coraza WAF z regułami OWASP CRS, backend FastAPI, panel administracyjny React
+oraz baze danych.
+
+Glownym celem projektu jest zarzadzanie konfiguracja WAF z poziomu panelu:
+
+- tworzenie i edycja wirtualnych hostow,
+- tworzenie i edycja polityk WAF,
+- przypisywanie polityk do domen,
+- stosowanie wygenerowanej konfiguracji HAProxy/Coraza,
+- odbieranie i przegladanie logow zdarzen WAF,
+- zabezpieczenie panelu przez logowanie i role uzytkownikow.
+
+## 2. Zastosowane technologie
+
+| Warstwa | Technologie |
+| --- | --- |
+| Reverse proxy | HAProxy 3.0 |
+| WAF | Coraza SPOA, OWASP CRS 4.x |
+| Backend | Python 3.13, FastAPI, SQLAlchemy, Alembic |
+| Baza centralna | PostgreSQL w Docker Compose |
+| Baza lokalna/dev/test | SQLite przez SQLAlchemy |
+| Frontend | React, TypeScript, Vite, Tailwind CSS |
+| Uwierzytelnianie | JWT access token, HttpOnly refresh token cookie |
+| Konteneryzacja | Docker, Docker Compose |
+| Testy | pytest, Vitest |
+
+## 3. Architektura systemu
+
+```mermaid
+graph TB
+    U[Uzytkownik / przegladarka] --> FE[React Admin Panel]
+    FE -->|REST API| BE[FastAPI Backend]
+    BE --> DB[(PostgreSQL)]
+
+    C[Klient HTTP] --> H[HAProxy]
+    H -.->|SPOE| WAF[Coraza WAF + OWASP CRS]
+    WAF -.->|allow / deny| H
+    H --> APP[Aplikacja chroniona]
+
+    WAF --> LOG[Audit log]
+    LOG --> LS[Log shipper]
+    LS -->|POST /logs/ingest| BE
+```
+
+Backend pelni role control plane. Panel React komunikuje sie z nim przez REST API,
+a backend zapisuje konfiguracje i dane w PostgreSQL. HAProxy oraz Coraza tworza
+warstwe runtime, ktora obsluguje rzeczywisty ruch HTTP. Log shipper przesyla
+zdarzenia z Corazy do backendu.
+
+## 4. REST API
+
+API jest udostepnione przez FastAPI. Dokumentacja interaktywna jest dostepna po
+uruchomieniu backendu pod adresem:
+
+```text
+http://127.0.0.1:8000/docs
+```
+
+Najwazniejsze endpointy:
+
+| Metoda | Endpoint | Opis |
+| --- | --- | --- |
+| GET | `/health` | Health check backendu |
+| POST | `/auth/login` | Logowanie uzytkownika |
+| POST | `/auth/refresh` | Odnowienie access tokena z refresh cookie |
+| POST | `/auth/logout` | Wylogowanie |
+| GET | `/auth/me` | Dane aktualnie zalogowanego uzytkownika |
+| GET | `/vhosts` | Lista wirtualnych hostow |
+| POST | `/vhosts` | Utworzenie wirtualnego hosta |
+| GET | `/vhosts/{id}` | Szczegoly wirtualnego hosta |
+| PATCH | `/vhosts/{id}` | Edycja wirtualnego hosta |
+| DELETE | `/vhosts/{id}` | Usuniecie wirtualnego hosta |
+| GET | `/policies` | Lista polityk WAF |
+| POST | `/policies` | Utworzenie polityki WAF |
+| GET | `/policies/{id}` | Szczegoly polityki WAF |
+| PATCH | `/policies/{id}` | Edycja polityki WAF |
+| DELETE | `/policies/{id}` | Usuniecie polityki WAF |
+| GET | `/policies/{policy_id}/rules` | Lista override'ow reguł CRS |
+| POST | `/policies/{policy_id}/rules` | Dodanie override'u reguly CRS |
+| PATCH | `/policies/{policy_id}/rules/{id}` | Edycja override'u reguly CRS |
+| DELETE | `/policies/{policy_id}/rules/{id}` | Usuniecie override'u reguly CRS |
+| GET | `/logs` | Lista logow WAF z filtrami i paginacja |
+| POST | `/logs/ingest` | Przyjmowanie logow z log shippera |
+| POST | `/config/apply` | Wygenerowanie i zastosowanie konfiguracji runtime |
+| GET | `/runtime/status` | Status ostatnich operacji runtime |
+
+### Przykladowe zapytania
+
+Logowanie:
+
+```http
+POST /auth/login
+Content-Type: application/json
+
+{
+  "email": "admin@example.com",
+  "password": "TwojeHaslo12345"
+}
+```
+
+Przykladowa odpowiedz:
+
+```json
+{
+  "access_token": "jwt-token",
+  "token_type": "bearer"
+}
+```
+
+Utworzenie wirtualnego hosta:
+
+```http
+POST /vhosts
+Authorization: Bearer jwt-token
+Content-Type: application/json
+
+{
+  "domain": "app.local",
+  "backend_url": "http://demo-app:8080",
+  "description": "Aplikacja demonstracyjna",
+  "ssl_enabled": false,
+  "is_active": true,
+  "policy_id": 1
+}
+```
+
+Utworzenie polityki WAF:
+
+```http
+POST /policies
+Authorization: Bearer jwt-token
+Content-Type: application/json
+
+{
+  "name": "Default CRS",
+  "description": "Domyslna polityka OWASP CRS",
+  "paranoia_level": 1,
+  "inbound_anomaly_threshold": 5,
+  "outbound_anomaly_threshold": 4,
+  "enforcement_mode": "block"
+}
+```
+
+Pobranie logow:
+
+```http
+GET /logs?page=1&page_size=50&action=deny
+Authorization: Bearer jwt-token
+```
+
+## 5. Schemat bazy danych
+
+Najwazniejsze tabele:
+
+| Tabela | Przeznaczenie |
+| --- | --- |
+| `users` | Konta uzytkownikow panelu, role i status aktywnosci |
+| `vhosts` | Domeny obslugiwane przez HAProxy i ich backendy |
+| `policies` | Polityki WAF: poziom paranoi, progi anomalii, tryb pracy |
+| `rule_overrides` | Wlaczenia/wylaczenia konkretnych reguł OWASP CRS dla polityki |
+| `logs` | Zdarzenia WAF/proxy odebrane przez log shippera |
+| `runtime_operations` | Historia operacji zastosowania konfiguracji runtime |
+
+Glowne relacje:
+
+- `vhosts.policy_id` wskazuje na `policies.id`.
+- `rule_overrides.policy_id` wskazuje na `policies.id`.
+- `vhosts.created_by` i `policies.created_by` wskazuja na `users.id`.
+- `logs.vhost_id` i `logs.policy_id` moga wskazywac na powiazany vhost i polityke.
+
+Migracje bazy sa zarzadzane przez Alembic. W Docker Compose system uzywa
+PostgreSQL. W trybie lokalnym i testowym mozliwe jest uzycie SQLite, bo warstwa
+dostepu do danych jest oparta na SQLAlchemy.
+
+## 6. Operacje CRUD
+
+Projekt spelnia podstawowe wymagania CRUD na centralnej bazie danych:
+
+- `vhosts`: create, read, update, delete,
+- `policies`: create, read, update, delete,
+- `rule_overrides`: create, read, update, delete,
+- `logs`: ingest oraz read z filtrami.
+
+Operacje modyfikujace sa dostepne tylko dla uzytkownikow z rola `admin`.
+Uzytkownik `viewer` moze odczytywac dane, ale nie moze ich zmieniac.
+
+## 7. Uwierzytelnianie i bezpieczenstwo
+
+Panel administracyjny wymaga logowania. Backend stosuje:
+
+- hashowanie hasel,
+- JWT access token do autoryzacji zapytan API,
+- refresh token przechowywany w HttpOnly cookie,
+- role `admin` i `viewer`,
+- zabezpieczenie endpointow przez zaleznosci FastAPI,
+- celowo ogolny komunikat bledu logowania, aby ograniczyc enumeracje kont.
+
+Endpoint `/logs/ingest` jest dodatkowo chroniony wspoldzielonym sekretem w
+naglowku `X-Guard-Proxy-Ingest-Secret`, poniewaz korzysta z niego wewnetrzny
+log shipper, a nie uzytkownik panelu.
+
+## 8. Obsluga bledow
+
+Backend zwraca standardowe kody HTTP, m.in.:
+
+- `401 Unauthorized` przy braku lub blednym tokenie,
+- `403 Forbidden` przy braku wymaganej roli,
+- `404 Not Found` gdy zasob nie istnieje,
+- `409 Conflict` przy konflikcie unikalnosci,
+- `422 Unprocessable Entity` przy blednych danych wejsciowych,
+- `500 Internal Server Error` przy bledach runtime/config apply.
+
+Frontend ma wspolny klient API, ktory rozpoznaje bledy odpowiedzi i pozwala
+wyswietlic komunikat w interfejsie. Widoki korzystaja ze stanow ladowania,
+bledu i pustej listy.
+
+## 9. Frontend
+
+Panel administracyjny jest aplikacja webowa React. Aktualnie obejmuje:
+
+- ekran logowania,
+- ochrone tras wymagajacych zalogowania,
+- dashboard z informacja o roli i stanie runtime,
+- zarzadzanie wirtualnymi hostami,
+- formularze tworzenia, edycji i usuwania vhostow,
+- przycisk zastosowania konfiguracji,
+- wspolne komponenty UI: tabele, status badges, modale, stany ladowania i bledow.
+
+Aplikacja jest responsywna i korzysta z backendowego REST API przez `fetch`.
+
+## 10. Uruchomienie projektu
+
+Przygotowanie konfiguracji:
+
+```bash
+cp deploy/docker/.env.example deploy/docker/.env
+```
+
+Uruchomienie pelnego stacka:
+
+```bash
+make run
+```
+
+Uruchomienie trybu debug:
+
+```bash
+make dev
+```
+
+Utworzenie konta administratora:
+
+```bash
+make seed
+```
+
+Najwazniejsze adresy:
+
+| Usluga | Adres |
+| --- | --- |
+| Panel administracyjny | `http://localhost:3000` |
+| API przez HAProxy | `http://localhost:8080` |
+| Backend lokalny bez proxy | `http://127.0.0.1:8000` |
+| Swagger UI | `http://127.0.0.1:8000/docs` |
+
+## 11. Demo
+
+Projekt zawiera osobny katalog demo w `deploy/demo`. Demo uruchamia Guard Proxy
+razem z dwiema prostymi aplikacjami HTTP echo za WAF-em. Pozwala to pokazac:
+
+- logowanie do panelu,
+- utworzenie polityki WAF,
+- utworzenie dwoch vhostow kierujacych na dwie rozne aplikacje demo,
+- routing po naglowku `Host` (`app.local` oraz `api.local`),
+- zastosowanie konfiguracji,
+- poprawne przepuszczenie zwyklego ruchu HTTP,
+- dzialanie HAProxy, Coraza i backendu jako jednego systemu.
+
+## 12. Testy
+
+Backend ma testy jednostkowe i integracyjne w `src/backend/tests`. Frontend ma
+testy komponentow i klienta API w `src/frontend/src`. Dodatkowo istnieje smoke
+test end-to-end dla stacka Docker Compose.
+
+Przykladowe komendy:
+
+```bash
+cd src/backend
+uv run pytest
+```
+
+```bash
+cd src/frontend
+pnpm run test
+pnpm run type-check
+pnpm run lint
+```
+
+## 13. Screenshoty
+
+Do uzupelnienia przed oddaniem projektu:
+
+- ekran logowania,
+- dashboard,
+- lista vhostow,
+- formularz tworzenia vhosta,
+- lista polityk lub szczegoly polityki,
+- wynik requestu przepuszczonego przez WAF,
+- wynik requestu zablokowanego przez WAF,
+- Swagger UI z endpointami API.


### PR DESCRIPTION
## Summary
- add a Polish course project report covering architecture, API, database, auth, CRUD, frontend, demo, and screenshot placeholders
- add a deploy/demo stack with two echo applications behind HAProxy/Coraza
- add demo setup automation for admin seeding, policy/vhost creation, config apply, temporary self-signed TLS, and CRS presence checks

## Validation
- bash -n deploy/demo/setup-demo.sh
- docker compose --env-file deploy/demo/.env -f deploy/demo/docker-compose.yml config

## Notes
- demo requires OWASP CRS submodule initialization before startup
- temporary TLS bind is demo-only and can be overwritten by a later config apply