### PR TITLE
feat(m3-07): LogsPage with filters, pagination, and row detail modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ src/backend/*.db
 # ===== Logs =====
 logs/
 *.log
+# Allow source code directories named logs/
+!src/**/logs/
 
 # ===== OS =====
 .DS_Store

--- a/src/frontend/src/app/router.tsx
+++ b/src/frontend/src/app/router.tsx
@@ -9,6 +9,7 @@ import { LoginPage } from "@/pages/login/LoginPage";
 import { NotFoundPage } from "@/pages/not-found/NotFoundPage";
 import { PoliciesPage } from "@/pages/policies/PoliciesPage";
 import { PolicyDetailPage } from "@/pages/policies/PolicyDetailPage";
+import { LogsPage } from "@/pages/logs/LogsPage";
 import { VHostDetailPage } from "@/pages/vhosts/VHostDetailPage";
 import { VHostsPage } from "@/pages/vhosts/VHostsPage";
 
@@ -56,6 +57,10 @@ export const router = createBrowserRouter([
           {
             path: `${appRoutes.policies}/:policyId`,
             element: <PolicyDetailPage />,
+          },
+          {
+            path: appRoutes.logs,
+            element: <LogsPage />,
           },
         ],
       },

--- a/src/frontend/src/app/routes.ts
+++ b/src/frontend/src/app/routes.ts
@@ -5,6 +5,7 @@ export const appRoutes = {
   forbidden: "/forbidden",
   vhosts: "/vhosts",
   policies: "/policies",
+  logs: "/logs",
 } as const;
 
 export function getVHostDetailPath(vhostId: string | number) {

--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -15,6 +15,7 @@ const navigation = [
   { to: appRoutes.dashboard, label: "Dashboard" },
   { to: appRoutes.vhosts, label: "VHosts" },
   { to: appRoutes.policies, label: "Policies" },
+  { to: appRoutes.logs, label: "Logs" },
 ];
 
 function navLinkClass(isActive: boolean, pill = false) {

--- a/src/frontend/src/features/logs/LogDetailModal.tsx
+++ b/src/frontend/src/features/logs/LogDetailModal.tsx
@@ -1,0 +1,102 @@
+import { Modal } from "@/components/shared/Modal";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+
+import type { Log, LogAction, LogSeverity } from "./types";
+
+type LogDetailModalProps = {
+  log: Log;
+  onClose: () => void;
+};
+
+function actionTone(action: LogAction) {
+  if (action === "deny") return "error" as const;
+  if (action === "monitor") return "warning" as const;
+  return "success" as const;
+}
+
+function severityTone(severity: LogSeverity) {
+  if (severity === "critical" || severity === "error") return "error" as const;
+  if (severity === "warning") return "warning" as const;
+  return "info" as const;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[10rem_1fr] gap-2 py-1.5">
+      <dt className="text-sm font-medium text-fg-muted">{label}</dt>
+      <dd className="text-sm text-fg">{children}</dd>
+    </div>
+  );
+}
+
+function Nullable({ value }: { value: string | number | null | undefined }) {
+  return value !== null && value !== undefined ? <>{value}</> : <span className="text-fg-subtle">—</span>;
+}
+
+export function LogDetailModal({ log, onClose }: LogDetailModalProps) {
+  return (
+    <Modal
+      title="Event details"
+      onClose={onClose}
+      footer={
+        <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+          Close
+        </button>
+      }
+    >
+      <div className="max-h-[60vh] overflow-y-auto">
+        <dl className="divide-y divide-border-subtle">
+          <Field label="Timestamp">{new Date(log.event_at).toLocaleString()}</Field>
+          <Field label="VHost">{log.vhost}</Field>
+          <Field label="Action">
+            <StatusBadge label={log.action} tone={actionTone(log.action)} />
+          </Field>
+          <Field label="Severity">
+            <StatusBadge label={log.severity} tone={severityTone(log.severity)} />
+          </Field>
+          <Field label="Method">
+            <span className="font-mono text-xs">{log.method}</span>
+          </Field>
+          <Field label="Request URI">
+            <span className="break-all font-mono text-xs">{log.request_uri}</span>
+          </Field>
+          <Field label="Source IP">{log.source_ip}</Field>
+          <Field label="Status code">
+            <Nullable value={log.status_code} />
+          </Field>
+          <Field label="Anomaly score">
+            <Nullable value={log.anomaly_score} />
+          </Field>
+          <Field label="Paranoia level">
+            <Nullable value={log.paranoia_level} />
+          </Field>
+          <Field label="Rule ID">
+            <Nullable value={log.rule_id} />
+          </Field>
+          <Field label="Rule message">
+            <Nullable value={log.rule_message} />
+          </Field>
+          <Field label="Message">
+            <Nullable value={log.message} />
+          </Field>
+          <Field label="VHost ID">
+            <Nullable value={log.vhost_id} />
+          </Field>
+          <Field label="Policy ID">
+            <Nullable value={log.policy_id} />
+          </Field>
+          <Field label="Producer event ID">
+            <Nullable value={log.producer_event_id} />
+          </Field>
+          {log.raw_context !== null && (
+            <Field label="Raw context">
+              <pre className="overflow-auto rounded-[var(--radius-md)] bg-surface-hover p-2 text-xs">
+                {JSON.stringify(log.raw_context, null, 2)}
+              </pre>
+            </Field>
+          )}
+        </dl>
+      </div>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/logs/LogDetailModal.tsx
+++ b/src/frontend/src/features/logs/LogDetailModal.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { Modal } from "@/components/shared/Modal";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 
@@ -20,7 +22,7 @@ function severityTone(severity: LogSeverity) {
   return "info" as const;
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="grid grid-cols-[10rem_1fr] gap-2 py-1.5">
       <dt className="text-sm font-medium text-fg-muted">{label}</dt>

--- a/src/frontend/src/features/logs/api.ts
+++ b/src/frontend/src/features/logs/api.ts
@@ -1,0 +1,37 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { LogListResponse } from "./types";
+
+export type ListLogsParams = {
+  page: number;
+  page_size: number;
+  vhost?: string;
+  action?: string;
+  policy_id?: number | null;
+  date_from?: string;
+  date_to?: string;
+};
+
+function toIso(datetimeLocal: string): string | undefined {
+  if (!datetimeLocal) return undefined;
+  const d = new Date(datetimeLocal);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+export function listLogs(token: string, params: ListLogsParams, signal?: AbortSignal) {
+  const query = new URLSearchParams();
+
+  const { date_from, date_to, ...rest } = params;
+
+  for (const [key, value] of Object.entries(rest)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.append(key, String(value));
+  }
+
+  const isoFrom = toIso(date_from ?? "");
+  const isoTo = toIso(date_to ?? "");
+  if (isoFrom) query.append("date_from", isoFrom);
+  if (isoTo) query.append("date_to", isoTo);
+
+  return apiRequest<LogListResponse>(`/logs?${query.toString()}`, { token, signal });
+}

--- a/src/frontend/src/features/logs/api.ts
+++ b/src/frontend/src/features/logs/api.ts
@@ -1,12 +1,12 @@
 import { apiRequest } from "@/lib/api-client";
 
-import type { LogListResponse } from "./types";
+import type { LogAction, LogListResponse } from "./types";
 
 export type ListLogsParams = {
   page: number;
   page_size: number;
   vhost?: string;
-  action?: string;
+  action?: LogAction;
   policy_id?: number | null;
   date_from?: string;
   date_to?: string;

--- a/src/frontend/src/features/logs/types.ts
+++ b/src/frontend/src/features/logs/types.ts
@@ -1,0 +1,46 @@
+export type LogAction = "allow" | "deny" | "monitor";
+export type LogSeverity = "info" | "warning" | "error" | "critical";
+
+export type Log = {
+  id: number;
+  producer_event_id: string | null;
+  event_at: string;
+  vhost: string;
+  action: LogAction;
+  source_ip: string;
+  method: string;
+  request_uri: string;
+  status_code: number | null;
+  rule_id: number | null;
+  rule_message: string | null;
+  anomaly_score: number | null;
+  paranoia_level: number | null;
+  severity: LogSeverity;
+  message: string | null;
+  raw_context: Record<string, unknown> | null;
+  vhost_id: number | null;
+  policy_id: number | null;
+};
+
+export type LogListResponse = {
+  items: Log[];
+  total: number;
+  page: number;
+  page_size: number;
+};
+
+export type LogFilters = {
+  vhost: string;
+  action: LogAction | "";
+  policy_id: number | null;
+  date_from: string;
+  date_to: string;
+};
+
+export const EMPTY_FILTERS: LogFilters = {
+  vhost: "",
+  action: "",
+  policy_id: null,
+  date_from: "",
+  date_to: "",
+};

--- a/src/frontend/src/features/logs/use-logs.ts
+++ b/src/frontend/src/features/logs/use-logs.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+import { listPolicies } from "@/features/vhosts/api";
+import type { Policy } from "@/features/vhosts/types";
+
+import { listLogs } from "./api";
+import type { Log, LogFilters } from "./types";
+import { EMPTY_FILTERS } from "./types";
+
+const PAGE_SIZE = 50;
+
+type LogsState = {
+  logs: Log[];
+  total: number;
+  page: number;
+  pageSize: number;
+  policies: Policy[];
+  policyNameById: Record<number, string>;
+  isLoading: boolean;
+  error: string | null;
+  setPage: (page: number) => void;
+  applyFilters: (filters: LogFilters) => void;
+  refresh: () => void;
+};
+
+export function useLogs(): LogsState {
+  const { accessToken } = useAuth();
+  const [logs, setLogs] = useState<Log[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPageState] = useState(1);
+  const [applied, setApplied] = useState<LogFilters>(EMPTY_FILTERS);
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  const fetch = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    Promise.all([
+      listLogs(
+        accessToken,
+        {
+          page,
+          page_size: PAGE_SIZE,
+          vhost: applied.vhost || undefined,
+          action: applied.action || undefined,
+          policy_id: applied.policy_id ?? undefined,
+          date_from: applied.date_from || undefined,
+          date_to: applied.date_to || undefined,
+        },
+        controller.signal,
+      ),
+      listPolicies(accessToken, controller.signal),
+    ])
+      .then(([logList, policyList]) => {
+        if (generation !== refreshCountRef.current) return;
+        setLogs(logList.items);
+        setTotal(logList.total);
+        setPolicies(policyList);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load logs");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken, page, applied]);
+
+  useEffect(() => {
+    const cleanup = fetch();
+    return cleanup;
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  const setPage = useCallback((nextPage: number) => {
+    setPageState(nextPage);
+  }, []);
+
+  const applyFilters = useCallback((filters: LogFilters) => {
+    setPageState(1);
+    setApplied(filters);
+  }, []);
+
+  const policyNameById: Record<number, string> = {};
+  for (const p of policies) {
+    policyNameById[p.id] = p.name;
+  }
+
+  return {
+    logs,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    policies,
+    policyNameById,
+    isLoading,
+    error,
+    setPage,
+    applyFilters,
+    refresh,
+  };
+}

--- a/src/frontend/src/features/logs/use-logs.ts
+++ b/src/frontend/src/features/logs/use-logs.ts
@@ -51,7 +51,7 @@ export function useLogs(): LogsState {
           page,
           page_size: PAGE_SIZE,
           vhost: applied.vhost || undefined,
-          action: applied.action || undefined,
+          action: applied.action !== "" ? applied.action : undefined,
           policy_id: applied.policy_id ?? undefined,
           date_from: applied.date_from || undefined,
           date_to: applied.date_to || undefined,

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as logsApi from "@/features/logs/api";
+import * as vhostsApi from "@/features/vhosts/api";
+
+import { LogsPage } from "./LogsPage";
+
+vi.mock("@/features/logs/api");
+vi.mock("@/features/vhosts/api");
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockPolicies = [{ id: 1, name: "Default Policy" }];
+
+const mockLog = {
+  id: 42,
+  producer_event_id: null,
+  event_at: "2026-06-01T10:00:00Z",
+  vhost: "app.example.com",
+  action: "deny" as const,
+  source_ip: "203.0.113.10",
+  method: "POST",
+  request_uri: "/login",
+  status_code: 403,
+  rule_id: 942100,
+  rule_message: "SQL injection attack detected",
+  anomaly_score: 15,
+  paranoia_level: 2,
+  severity: "error" as const,
+  message: null,
+  raw_context: null,
+  vhost_id: 1,
+  policy_id: 1,
+};
+
+const mockListResponse = { items: [mockLog], total: 1, page: 1, page_size: 50 };
+const emptyListResponse = { items: [], total: 0, page: 1, page_size: 50 };
+
+function renderPage() {
+  return render(
+    <AuthContext.Provider value={makeAuthContext()}>
+      <LogsPage />
+    </AuthContext.Provider>,
+  );
+}
+
+describe("LogsPage", () => {
+  it("shows loading state initially", () => {
+    vi.mocked(logsApi.listLogs).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+    expect(screen.getByText(/loading logs/i)).toBeInTheDocument();
+  });
+
+  it("renders log rows from API response", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("POST")).toBeInTheDocument();
+    expect(screen.getByText("deny")).toBeInTheDocument();
+    expect(screen.getByText("15")).toBeInTheDocument();
+  });
+
+  it("shows error state on API failure", async () => {
+    vi.mocked(logsApi.listLogs).mockRejectedValue(new Error("Network error"));
+    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load logs/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows empty state when no logs match", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(emptyListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/no events found/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("applying filters re-fetches with filter params", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByLabelText(/vhost/i), "api.example.com");
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(logsApi.listLogs)).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ vhost: "api.example.com", page: 1 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("clearing filters resets to empty params", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByLabelText(/vhost/i), "something");
+    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(logsApi.listLogs)).toHaveBeenLastCalledWith(
+        "test-token",
+        expect.objectContaining({ vhost: undefined, page: 1 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("View button opens detail modal with log fields", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /view/i }));
+
+    expect(screen.getByText("Event details")).toBeInTheDocument();
+    expect(screen.getByText("SQL injection attack detected")).toBeInTheDocument();
+    expect(screen.getByText("203.0.113.10")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -123,8 +123,9 @@ export function LogsPage() {
       <SectionCard title="Filters">
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-fg-muted">VHost</label>
+            <label htmlFor="filter-vhost" className="block text-sm font-medium text-fg-muted">VHost</label>
             <input
+              id="filter-vhost"
               type="text"
               value={draft.vhost}
               onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
@@ -134,8 +135,9 @@ export function LogsPage() {
           </div>
 
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-fg-muted">Action</label>
+            <label htmlFor="filter-action" className="block text-sm font-medium text-fg-muted">Action</label>
             <select
+              id="filter-action"
               value={draft.action}
               onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
               className="input-field"
@@ -148,8 +150,9 @@ export function LogsPage() {
           </div>
 
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-fg-muted">Policy</label>
+            <label htmlFor="filter-policy" className="block text-sm font-medium text-fg-muted">Policy</label>
             <select
+              id="filter-policy"
               value={draft.policy_id ?? ""}
               onChange={(e) =>
                 setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
@@ -166,8 +169,9 @@ export function LogsPage() {
           </div>
 
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-fg-muted">From</label>
+            <label htmlFor="filter-date-from" className="block text-sm font-medium text-fg-muted">From</label>
             <input
+              id="filter-date-from"
               type="datetime-local"
               value={draft.date_from}
               onChange={(e) => setDraft({ ...draft, date_from: e.target.value })}
@@ -176,8 +180,9 @@ export function LogsPage() {
           </div>
 
           <div className="space-y-1.5">
-            <label className="block text-sm font-medium text-fg-muted">To</label>
+            <label htmlFor="filter-date-to" className="block text-sm font-medium text-fg-muted">To</label>
             <input
+              id="filter-date-to"
               type="datetime-local"
               value={draft.date_to}
               onChange={(e) => setDraft({ ...draft, date_to: e.target.value })}

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -1,0 +1,256 @@
+import { useState } from "react";
+
+import type { DataTableColumn } from "@/components/shared/DataTable";
+import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+import { LogDetailModal } from "@/features/logs/LogDetailModal";
+import { useLogs } from "@/features/logs/use-logs";
+import type { Log, LogAction, LogFilters } from "@/features/logs/types";
+import { EMPTY_FILTERS } from "@/features/logs/types";
+
+function actionTone(action: LogAction) {
+  if (action === "deny") return "error" as const;
+  if (action === "monitor") return "warning" as const;
+  return "success" as const;
+}
+
+const columns: DataTableColumn<Log>[] = [
+  {
+    key: "timestamp",
+    header: "Timestamp",
+    cell: (row) => (
+      <span className="whitespace-nowrap text-xs text-fg-muted">
+        {new Date(row.event_at).toLocaleString()}
+      </span>
+    ),
+  },
+  {
+    key: "vhost",
+    header: "VHost",
+    cell: (row) => row.vhost,
+  },
+  {
+    key: "method",
+    header: "Method",
+    cell: (row) => <span className="font-mono text-xs">{row.method}</span>,
+  },
+  {
+    key: "path",
+    header: "Path",
+    cell: (row) => (
+      <span
+        className="block max-w-xs truncate font-mono text-xs"
+        title={row.request_uri}
+      >
+        {row.request_uri}
+      </span>
+    ),
+  },
+  {
+    key: "action",
+    header: "Action",
+    cell: (row) => <StatusBadge label={row.action} tone={actionTone(row.action)} />,
+  },
+  {
+    key: "score",
+    header: "Score",
+    cell: (row) => <span>{row.anomaly_score ?? "—"}</span>,
+  },
+  {
+    // The log model stores a single matched rule per event.
+    key: "rules",
+    header: "Top matched rules",
+    cell: (row) => {
+      if (row.rule_id === null) return <span className="text-fg-subtle">—</span>;
+      const label = row.rule_message
+        ? `#${row.rule_id} — ${row.rule_message}`
+        : `#${row.rule_id}`;
+      return (
+        <span className="block max-w-xs truncate text-xs" title={label}>
+          {label}
+        </span>
+      );
+    },
+  },
+];
+
+export function LogsPage() {
+  const { logs, total, page, pageSize, policies, isLoading, error, setPage, applyFilters, refresh } =
+    useLogs();
+  const [draft, setDraft] = useState<LogFilters>(EMPTY_FILTERS);
+  const [selected, setSelected] = useState<Log | null>(null);
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  function handleApply() {
+    applyFilters(draft);
+  }
+
+  function handleClear() {
+    setDraft(EMPTY_FILTERS);
+    applyFilters(EMPTY_FILTERS);
+  }
+
+  const allColumns: DataTableColumn<Log>[] = [
+    ...columns,
+    {
+      key: "actions",
+      header: "",
+      className: "w-px whitespace-nowrap",
+      cell: (row) => (
+        <button
+          type="button"
+          onClick={() => setSelected(row)}
+          className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
+        >
+          View
+        </button>
+      ),
+    },
+  ];
+
+  return (
+    <section className="space-y-8">
+      <PageHeader
+        title="Logs"
+        description="Browse and filter WAF events captured by Guard Proxy."
+      />
+
+      <SectionCard title="Filters">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-fg-muted">VHost</label>
+            <input
+              type="text"
+              value={draft.vhost}
+              onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
+              className="input-field"
+              placeholder="example.com (exact match)"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-fg-muted">Action</label>
+            <select
+              value={draft.action}
+              onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
+              className="input-field"
+            >
+              <option value="">All actions</option>
+              <option value="allow">Allow</option>
+              <option value="deny">Deny</option>
+              <option value="monitor">Monitor</option>
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-fg-muted">Policy</label>
+            <select
+              value={draft.policy_id ?? ""}
+              onChange={(e) =>
+                setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
+              }
+              className="input-field"
+            >
+              <option value="">All policies</option>
+              {policies.map((p) => (
+                <option key={p.id} value={String(p.id)}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-fg-muted">From</label>
+            <input
+              type="datetime-local"
+              value={draft.date_from}
+              onChange={(e) => setDraft({ ...draft, date_from: e.target.value })}
+              className="input-field"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-fg-muted">To</label>
+            <input
+              type="datetime-local"
+              value={draft.date_to}
+              onChange={(e) => setDraft({ ...draft, date_to: e.target.value })}
+              className="input-field"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 flex gap-3">
+          <button type="button" onClick={handleApply} className="btn-primary px-4 py-2 text-sm">
+            Apply
+          </button>
+          <button type="button" onClick={handleClear} className="btn-ghost px-4 py-2 text-sm">
+            Clear
+          </button>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Events" description="Most recent events first.">
+        {isLoading ? (
+          <LoadingState label="Loading logs…" />
+        ) : error ? (
+          <ErrorState
+            title="Failed to load logs"
+            description={error}
+            action={
+              <button type="button" onClick={refresh} className="btn-ghost px-4 py-2 text-sm">
+                Retry
+              </button>
+            }
+          />
+        ) : (
+          <>
+            <DataTable
+              columns={allColumns}
+              rows={logs}
+              getRowKey={(row) => String(row.id)}
+              emptyTitle="No events found"
+              emptyDescription="No log events match the current filters. Try adjusting or clearing them."
+            />
+
+            {total > 0 && (
+              <div className="mt-4 flex items-center justify-between gap-4">
+                <span className="text-sm text-fg-muted">
+                  Page {page} of {totalPages} · {total} events
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setPage(page - 1)}
+                    disabled={page <= 1}
+                    className="btn-ghost px-4 py-2 text-sm disabled:opacity-40"
+                  >
+                    Prev
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPage(page + 1)}
+                    disabled={page >= totalPages}
+                    className="btn-ghost px-4 py-2 text-sm disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </SectionCard>
+
+      {selected !== null && (
+        <LogDetailModal log={selected} onClose={() => setSelected(null)} />
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #120.

Adds a `/logs` page so operators can browse and filter WAF events captured by Guard Proxy, built entirely on top of the existing paginated `GET /logs` API from M3-05.

- **Filter bar** — vhost (free-text, exact match server-side), action (allow / deny / monitor), policy (select populated from `/policies`), date-from / date-to (`datetime-local` inputs converted to ISO before the API call)
- **DataTable** — columns: timestamp, vhost, method, path, action (StatusBadge), anomaly score, top matched rule (the model stores one rule per event)
- **Prev / Next pagination** with "Page N of M · X events" label wired to the API's `page` param
- **Row detail modal** — clicking View on any row opens `LogDetailModal` showing every field from `LogResponse`, including pretty-printed `raw_context` JSON
- **Route protection** — `/logs` is nested under the existing `ProtectedRoute → AppLayout`, so no extra auth work needed
- **Nav link** — Logs added to the `navigation` array in `NavBar.tsx`, covering both desktop pill nav and the mobile slide-in menu

### File structure
```
src/frontend/src/
  features/logs/
    types.ts            ← Log, LogListResponse, LogFilters, LogAction/LogSeverity
    api.ts              ← listLogs() with URLSearchParams + datetime-local→ISO
    use-logs.ts         ← hook: AbortController + generation guard, owns page + applied filters
    LogDetailModal.tsx  ← full event detail, raw_context JSON, single Close button
  pages/logs/
    LogsPage.tsx        ← filter form, DataTable, pagination, wires to useLogs
```

Three existing files modified: `routes.ts`, `router.tsx`, `NavBar.tsx`.

### Reviewer notes
- `vhost` filter is a **server-side exact lowercased match** — no substring/multi-value support in the current API. Placeholder text says "exact match" to set expectations. A backend follow-up would be needed for fuzzy/multi-value search.
- The issue lists "top matched rules" (plural) but the log model stores a **single rule per event** (`rule_id` + `rule_message`). The column renders the one rule, with a code comment noting this.
- Policies are fetched alongside logs on every page navigation (mirrors the `useVHosts` pattern). No concern at this scale; could be lifted to a separate effect in a follow-up.
- `.gitignore` gets one extra line (`!src/**/logs/`) to unblock the new source directories that were caught by the `logs/` runtime-log pattern.

## Test plan
- [x] `pnpm run type-check` — green ✓
- [x] `pnpm run lint` — green ✓
- [x] `pnpm run test` — 47 + 3 tests pass ✓
- [x] Start stack, navigate to Logs in nav — table renders real rows newest-first
- [x] Apply each filter and verify query params in Network tab
- [x] Page through results with Prev/Next
- [x] Click View — modal shows all fields and JSON context
- [x] Over-restrict filters to get empty state; stop backend to get error state
