### PR TITLE
feat(dashboard): wire StatCards to real API data (M3-08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/backend/*.db
 
 # ===== Logs =====
 logs/
+!src/**/features/logs/
 *.log
 
 # ===== OS =====

--- a/src/frontend/src/components/shared/StatCard.tsx
+++ b/src/frontend/src/components/shared/StatCard.tsx
@@ -6,6 +6,7 @@ type StatCardProps = {
   hint?: string;
   tone?: "neutral" | "success" | "warning" | "error" | "info";
   icon?: ReactNode;
+  isLoading?: boolean;
 };
 
 const toneClassMap = {
@@ -22,15 +23,20 @@ export function StatCard({
   hint,
   tone = "neutral",
   icon,
+  isLoading = false,
 }: StatCardProps) {
   return (
     <article className="shadow-card rounded-[var(--radius-lg)] border border-border bg-surface p-5">
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-2">
           <p className="text-sm font-medium text-fg-muted">{label}</p>
-          <p className="font-mono text-3xl font-semibold tracking-tight text-fg">
-            {value}
-          </p>
+          {isLoading ? (
+            <div className="h-9 w-16 animate-pulse rounded-[var(--radius-sm)] bg-surface-hover" />
+          ) : (
+            <p className="font-mono text-3xl font-semibold tracking-tight text-fg">
+              {value}
+            </p>
+          )}
         </div>
 
         {icon ? (

--- a/src/frontend/src/components/shared/StatCard.tsx
+++ b/src/frontend/src/components/shared/StatCard.tsx
@@ -31,7 +31,11 @@ export function StatCard({
         <div className="space-y-2">
           <p className="text-sm font-medium text-fg-muted">{label}</p>
           {isLoading ? (
-            <div className="h-9 w-16 animate-pulse rounded-[var(--radius-sm)] bg-surface-hover" />
+            <div
+              className="h-9 w-16 animate-pulse rounded-[var(--radius-sm)] bg-surface-hover"
+              role="status"
+              aria-label="Loading"
+            />
           ) : (
             <p className="font-mono text-3xl font-semibold tracking-tight text-fg">
               {value}

--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { listPolicies, listVHosts } from "@/features/vhosts/api";
+import { fetchLogTotal } from "@/features/logs/api";
+import { useAuth } from "@/hooks/use-auth";
+
+type StatValue = {
+  count: number | null;
+  error: boolean;
+};
+
+type DashboardStatsState = {
+  vhosts: StatValue;
+  policies: StatValue;
+  blocked: StatValue;
+  alerts: StatValue;
+  isLoading: boolean;
+  refresh: () => void;
+};
+
+const INITIAL_STAT: StatValue = { count: null, error: false };
+
+export function useDashboardStats(): DashboardStatsState {
+  const { accessToken } = useAuth();
+  const [vhosts, setVHosts] = useState<StatValue>(INITIAL_STAT);
+  const [policies, setPolicies] = useState<StatValue>(INITIAL_STAT);
+  const [blocked, setBlocked] = useState<StatValue>(INITIAL_STAT);
+  const [alerts, setAlerts] = useState<StatValue>(INITIAL_STAT);
+  const [isLoading, setIsLoading] = useState(true);
+  const refreshCountRef = useRef(0);
+
+  const load = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+
+    Promise.allSettled([
+      listVHosts(accessToken, controller.signal),
+      listPolicies(accessToken, controller.signal),
+      fetchLogTotal(accessToken, { action: "deny" }, controller.signal),
+      fetchLogTotal(accessToken, { severity: "critical" }, controller.signal),
+    ]).then(([vhostResult, policyResult, blockedResult, alertsResult]) => {
+      if (generation !== refreshCountRef.current) return;
+
+      setVHosts(
+        vhostResult.status === "fulfilled"
+          ? { count: vhostResult.value.length, error: false }
+          : { count: null, error: true }
+      );
+      setPolicies(
+        policyResult.status === "fulfilled"
+          ? { count: policyResult.value.length, error: false }
+          : { count: null, error: true }
+      );
+      setBlocked(
+        blockedResult.status === "fulfilled"
+          ? { count: blockedResult.value, error: false }
+          : { count: null, error: true }
+      );
+      setAlerts(
+        alertsResult.status === "fulfilled"
+          ? { count: alertsResult.value, error: false }
+          : { count: null, error: true }
+      );
+
+      setIsLoading(false);
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  const refresh = useCallback(() => {
+    load();
+  }, [load]);
+
+  return { vhosts, policies, blocked, alerts, isLoading, refresh };
+}

--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { listPolicies, listVHosts } from "@/features/vhosts/api";
 import { fetchLogTotal } from "@/features/logs/api";
+import type { LogAction, LogSeverity } from "@/features/logs/types";
+import { listPolicies, listVHosts } from "@/features/vhosts/api";
 import { useAuth } from "@/hooks/use-auth";
 
-type StatValue = {
+export type StatValue = {
   count: number | null;
   error: boolean;
+  isLoading: boolean;
 };
 
 type DashboardStatsState = {
@@ -14,64 +16,66 @@ type DashboardStatsState = {
   policies: StatValue;
   blocked: StatValue;
   alerts: StatValue;
-  isLoading: boolean;
   refresh: () => void;
 };
 
-const INITIAL_STAT: StatValue = { count: null, error: false };
+const LOADING: StatValue = { count: null, error: false, isLoading: true };
+
+function ok(count: number): StatValue {
+  return { count, error: false, isLoading: false };
+}
+
+function failed(): StatValue {
+  return { count: null, error: true, isLoading: false };
+}
+
+function isAbortError(e: unknown): boolean {
+  return e instanceof Error && e.name === "AbortError";
+}
 
 export function useDashboardStats(): DashboardStatsState {
   const { accessToken } = useAuth();
-  const [vhosts, setVHosts] = useState<StatValue>(INITIAL_STAT);
-  const [policies, setPolicies] = useState<StatValue>(INITIAL_STAT);
-  const [blocked, setBlocked] = useState<StatValue>(INITIAL_STAT);
-  const [alerts, setAlerts] = useState<StatValue>(INITIAL_STAT);
-  const [isLoading, setIsLoading] = useState(true);
-  const refreshCountRef = useRef(0);
+  const [vhosts, setVHosts] = useState<StatValue>(LOADING);
+  const [policies, setPolicies] = useState<StatValue>(LOADING);
+  const [blocked, setBlocked] = useState<StatValue>(LOADING);
+  const [alerts, setAlerts] = useState<StatValue>(LOADING);
+  const generationRef = useRef(0);
 
   const load = useCallback(() => {
     if (!accessToken) return;
 
     const controller = new AbortController();
-    const generation = ++refreshCountRef.current;
+    const generation = ++generationRef.current;
 
-    setIsLoading(true);
+    setVHosts(LOADING);
+    setPolicies(LOADING);
+    setBlocked(LOADING);
+    setAlerts(LOADING);
 
-    Promise.allSettled([
-      listVHosts(accessToken, controller.signal),
-      listPolicies(accessToken, controller.signal),
-      fetchLogTotal(accessToken, { action: "deny" }, controller.signal),
-      fetchLogTotal(accessToken, { severity: "critical" }, controller.signal),
-    ]).then(([vhostResult, policyResult, blockedResult, alertsResult]) => {
-      if (generation !== refreshCountRef.current) return;
+    // Each card resolves independently so fast cards aren't blocked by slow ones.
+    // Aborted fetches are silently dropped (not surfaced as errors).
+    const guard =
+      (setter: (v: StatValue) => void) => (value: StatValue) => {
+        if (generation === generationRef.current) setter(value);
+      };
 
-      setVHosts(
-        vhostResult.status === "fulfilled"
-          ? { count: vhostResult.value.length, error: false }
-          : { count: null, error: true }
-      );
-      setPolicies(
-        policyResult.status === "fulfilled"
-          ? { count: policyResult.value.length, error: false }
-          : { count: null, error: true }
-      );
-      setBlocked(
-        blockedResult.status === "fulfilled"
-          ? { count: blockedResult.value, error: false }
-          : { count: null, error: true }
-      );
-      setAlerts(
-        alertsResult.status === "fulfilled"
-          ? { count: alertsResult.value, error: false }
-          : { count: null, error: true }
-      );
+    listVHosts(accessToken, controller.signal)
+      .then((list) => guard(setVHosts)(ok(list.length)))
+      .catch((e) => { if (!isAbortError(e)) guard(setVHosts)(failed()); });
 
-      setIsLoading(false);
-    });
+    listPolicies(accessToken, controller.signal)
+      .then((list) => guard(setPolicies)(ok(list.length)))
+      .catch((e) => { if (!isAbortError(e)) guard(setPolicies)(failed()); });
 
-    return () => {
-      controller.abort();
-    };
+    fetchLogTotal(accessToken, { action: "deny" as LogAction }, controller.signal)
+      .then((total) => guard(setBlocked)(ok(total)))
+      .catch((e) => { if (!isAbortError(e)) guard(setBlocked)(failed()); });
+
+    fetchLogTotal(accessToken, { severity: "critical" as LogSeverity }, controller.signal)
+      .then((total) => guard(setAlerts)(ok(total)))
+      .catch((e) => { if (!isAbortError(e)) guard(setAlerts)(failed()); });
+
+    return () => controller.abort();
   }, [accessToken]);
 
   useEffect(() => {
@@ -79,9 +83,7 @@ export function useDashboardStats(): DashboardStatsState {
     return cleanup;
   }, [load]);
 
-  const refresh = useCallback(() => {
-    load();
-  }, [load]);
+  const refresh = useCallback(() => { load(); }, [load]);
 
-  return { vhosts, policies, blocked, alerts, isLoading, refresh };
+  return { vhosts, policies, blocked, alerts, refresh };
 }

--- a/src/frontend/src/features/logs/api.ts
+++ b/src/frontend/src/features/logs/api.ts
@@ -1,6 +1,6 @@
 import { apiRequest } from "@/lib/api-client";
 
-import type { LogAction, LogListResponse } from "./types";
+import type { LogAction, LogListResponse, LogSeverity } from "./types";
 
 export type ListLogsParams = {
   page: number;
@@ -38,7 +38,7 @@ export function listLogs(token: string, params: ListLogsParams, signal?: AbortSi
 
 type LogTotalParams = {
   action?: LogAction;
-  severity?: string;
+  severity?: LogSeverity;
 };
 
 export function fetchLogTotal(

--- a/src/frontend/src/features/logs/api.ts
+++ b/src/frontend/src/features/logs/api.ts
@@ -1,0 +1,23 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { LogListResponse } from "./types";
+
+type LogTotalParams = {
+  action?: string;
+  severity?: string;
+};
+
+export function fetchLogTotal(
+  token: string,
+  params: LogTotalParams,
+  signal?: AbortSignal
+): Promise<number> {
+  const query = new URLSearchParams({ page_size: "1" });
+  if (params.action) query.set("action", params.action);
+  if (params.severity) query.set("severity", params.severity);
+
+  return apiRequest<LogListResponse>(`/logs?${query.toString()}`, {
+    token,
+    signal,
+  }).then((res) => res.total);
+}

--- a/src/frontend/src/features/logs/types.ts
+++ b/src/frontend/src/features/logs/types.ts
@@ -1,0 +1,6 @@
+export type LogListResponse = {
+  items: unknown[];
+  total: number;
+  page: number;
+  page_size: number;
+};

--- a/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as logsApi from "@/features/logs/api";
+import * as vhostsApi from "@/features/vhosts/api";
+
+import { DashboardPage } from "./DashboardPage";
+
+vi.mock("@/features/logs/api");
+vi.mock("@/features/vhosts/api");
+vi.mock("@/features/runtime/use-runtime-status", () => ({
+  useRuntimeStatus: () => ({ data: null, isLoading: false, error: null, refresh: vi.fn() }),
+}));
+vi.mock("@/features/runtime/ApplyConfigButton", () => ({
+  ApplyConfigButton: () => null,
+}));
+vi.mock("@/features/runtime/RuntimeStatusCard", () => ({
+  RuntimeStatusCard: () => null,
+}));
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockVHosts = [{ id: 1 }, { id: 2 }];
+const mockPolicies = [{ id: 1 }];
+
+function renderPage() {
+  return render(
+    <AuthContext.Provider value={makeAuthContext()}>
+      <DashboardPage />
+    </AuthContext.Provider>,
+  );
+}
+
+describe("DashboardPage StatCards", () => {
+  it("shows loading skeletons while all fetches are in-flight", () => {
+    vi.mocked(vhostsApi.listVHosts).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(logsApi.fetchLogTotal).mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+
+    expect(screen.getAllByRole("status", { name: /loading/i })).toHaveLength(4);
+  });
+
+  it("renders real counts after data loads", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies as never);
+    vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(42);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.queryAllByRole("status", { name: /loading/i })).toHaveLength(0),
+    );
+    expect(screen.getByText("2")).toBeInTheDocument();  // vhosts
+    expect(screen.getByText("1")).toBeInTheDocument();  // policies
+    expect(screen.getAllByText("42")).toHaveLength(2);   // blocked + alerts
+  });
+
+  it("shows — only for the card whose endpoint fails, real counts for others", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
+    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+    vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(7);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.queryAllByRole("status", { name: /loading/i })).toHaveLength(0),
+    );
+    expect(screen.getByText("2")).toBeInTheDocument();   // vhosts resolved
+    expect(screen.getByText("—")).toBeInTheDocument();   // policies failed
+    expect(screen.getAllByText("7")).toHaveLength(2);    // blocked + alerts resolved
+  });
+
+  it("shows — for all cards when all endpoints fail", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockRejectedValue(new Error("down"));
+    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("down"));
+    vi.mocked(logsApi.fetchLogTotal).mockRejectedValue(new Error("down"));
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.queryAllByRole("status", { name: /loading/i })).toHaveLength(0),
+    );
+    expect(screen.getAllByText("—")).toHaveLength(4);
+  });
+});

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -71,7 +71,7 @@ export function DashboardPage() {
           hint="Number of virtual hosts currently configured in the WAF."
           tone="info"
           icon={<ServerIcon />}
-          isLoading={stats.isLoading}
+          isLoading={stats.vhosts.isLoading}
         />
         <StatCard
           label="Active policies"
@@ -83,7 +83,7 @@ export function DashboardPage() {
           hint="Policies define the WAF behaviour applied to host traffic."
           tone="success"
           icon={<ShieldIcon />}
-          isLoading={stats.isLoading}
+          isLoading={stats.policies.isLoading}
         />
         <StatCard
           label="Blocked requests"
@@ -95,7 +95,7 @@ export function DashboardPage() {
           hint="Total requests denied by Coraza rules (action: deny)."
           tone="warning"
           icon={<AlertTriangleIcon />}
-          isLoading={stats.isLoading}
+          isLoading={stats.blocked.isLoading}
         />
         <StatCard
           label="Critical alerts"
@@ -107,7 +107,7 @@ export function DashboardPage() {
           hint="Log entries with severity: critical across all hosts."
           tone="error"
           icon={<PulseIcon />}
-          isLoading={stats.isLoading}
+          isLoading={stats.alerts.isLoading}
         />
       </div>
 

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -15,11 +15,13 @@ import { ApplyConfigButton } from "@/features/runtime/ApplyConfigButton";
 import type { ApplyResult } from "@/features/runtime/ApplyConfigButton";
 import { RuntimeStatusCard } from "@/features/runtime/RuntimeStatusCard";
 import { useRuntimeStatus } from "@/features/runtime/use-runtime-status";
+import { useDashboardStats } from "@/features/dashboard/use-dashboard-stats";
 import { useAuth } from "@/hooks/use-auth";
 
 export function DashboardPage() {
   const { role } = useAuth();
   const runtimeStatus = useRuntimeStatus();
+  const stats = useDashboardStats();
   const [applyResult, setApplyResult] = useState<ApplyResult | null>(null);
 
   return (
@@ -61,31 +63,51 @@ export function DashboardPage() {
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         <StatCard
           label="Protected vhosts"
-          value="12"
-          hint="Soon this card will be fed by the real VHosts endpoint."
+          value={
+            stats.vhosts.error || stats.vhosts.count === null
+              ? "—"
+              : String(stats.vhosts.count)
+          }
+          hint="Number of virtual hosts currently configured in the WAF."
           tone="info"
           icon={<ServerIcon />}
+          isLoading={stats.isLoading}
         />
         <StatCard
           label="Active policies"
-          value="4"
-          hint="Policies define the WAF behavior applied to host traffic."
+          value={
+            stats.policies.error || stats.policies.count === null
+              ? "—"
+              : String(stats.policies.count)
+          }
+          hint="Policies define the WAF behaviour applied to host traffic."
           tone="success"
           icon={<ShieldIcon />}
+          isLoading={stats.isLoading}
         />
         <StatCard
           label="Blocked requests"
-          value="128"
-          hint="This is placeholder data for the future monitoring view."
+          value={
+            stats.blocked.error || stats.blocked.count === null
+              ? "—"
+              : String(stats.blocked.count)
+          }
+          hint="Total requests denied by Coraza rules (action: deny)."
           tone="warning"
           icon={<AlertTriangleIcon />}
+          isLoading={stats.isLoading}
         />
         <StatCard
           label="Critical alerts"
-          value="0"
-          hint="Good example of a stat card that can stay calm until needed."
+          value={
+            stats.alerts.error || stats.alerts.count === null
+              ? "—"
+              : String(stats.alerts.count)
+          }
+          hint="Log entries with severity: critical across all hosts."
           tone="error"
           icon={<PulseIcon />}
+          isLoading={stats.isLoading}
         />
       </div>
 


### PR DESCRIPTION
## Summary

Closes #199

Replaces the four hardcoded StatCard values on the Dashboard with live counts fetched from the backend:

| Card | Endpoint | Notes |
|---|---|---|
| Protected vhosts | `GET /vhosts` | `array.length` |
| Active policies | `GET /policies` | `array.length` |
| Blocked requests | `GET /logs?action=deny&page_size=1` | reads `total`; `deny` is the backend's equivalent of BLOCK |
| Critical alerts | `GET /logs?severity=critical&page_size=1` | reads `total` |

The existing `RuntimeStatusCard` (driven by `GET /runtime/status`) already satisfies the runtime-status indicator criterion — no changes there.

## What changed

- **`features/logs/types.ts` + `api.ts`** — new minimal logs client (`fetchLogTotal`) that hits `GET /logs` with filters and returns `total`
- **`features/dashboard/use-dashboard-stats.ts`** — new hook; fetches all four counts via `Promise.allSettled` so one failing endpoint shows `—` on its own card without crashing the dashboard; follows the established generation-counter + AbortController pattern
- **`components/shared/StatCard.tsx`** — added optional `isLoading` prop; renders an `animate-pulse` skeleton in place of the value while in-flight
- **`pages/dashboard/DashboardPage.tsx`** — calls `useDashboardStats()`, passes real values and `isLoading` to each card
- **`.gitignore`** — added `!src/**/features/logs/` negation; the bare `logs/` rule was silently blocking the new feature directory

## Behaviour

- Each card shows a pulsing skeleton while data loads
- A card shows `—` if its fetch fails (e.g. network error); the rest render normally
- "Recent activity" section and `RuntimeStatusCard` are untouched

## Test plan

- [x] Log in; Dashboard shows pulsing skeletons briefly, then real counts
- [x] Counts match: vhosts card = row count on VHosts page; policies card = row count on Policies page
- [x] Blocked/alerts counts match `GET /logs?action=deny` and `GET /logs?severity=critical` `total` fields
- [x] Stop the backend → all four cards degrade to `—`; page does not crash
- [x] `tsc -b --pretty false` and `eslint .` both pass clean
