### PR TITLE
feat(cli): user management via CLI — create / list / update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COMPOSE_FILE := deploy/docker/docker-compose.yml
 COMPOSE_DEBUG_FILE := deploy/docker/docker-compose.debug.yml
 ENV_FILE := deploy/docker/.env
 
-.PHONY: run dev down clean logs ps seed coraza-build
+.PHONY: run dev down clean logs ps seed users coraza-build
 
 run:
 	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) up --build -d
@@ -24,6 +24,9 @@ ps:
 
 seed:
 	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/seed_admin.py
+
+users:
+	docker-compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(ARGS)
 
 coraza-build:
 	docker build -f deploy/docker/coraza.Dockerfile -t guard-proxy/coraza-spoa:dev .

--- a/src/backend/scripts/manage_users.py
+++ b/src/backend/scripts/manage_users.py
@@ -1,0 +1,435 @@
+"""User management CLI for Guard Proxy.
+
+Subcommands:
+    create  — add a new user account
+    list    — display all users with optional filters
+    update  — modify an existing user by ID or email
+
+Usage (local):
+    uv run python scripts/manage_users.py create \\
+        --email alice@example.com --password changeme1234 --full-name "Alice"
+    uv run python scripts/manage_users.py list --role admin --active
+    uv run python scripts/manage_users.py update alice@example.com --role admin
+    uv run python scripts/manage_users.py update 3 --deactivate
+
+Usage (Docker):
+    docker-compose ... exec backend /app/.venv/bin/python scripts/manage_users.py <cmd>
+    # or via make:
+    make users ARGS="list --json"
+
+See `scripts/manage_users.py <cmd> --help` for per-command details.
+"""
+
+import argparse
+import json as json_module
+import os
+import sys
+
+# Add src/backend/ to PYTHONPATH so `app.*` imports resolve when this script
+# is run directly (mirrors the same pattern used in seed_admin.py).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pydantic import ValidationError  # noqa: E402
+from sqlalchemy.exc import IntegrityError  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models.user import User, UserRole  # noqa: E402
+from app.passwords import hash_password  # noqa: E402
+from app.schemas.user import UserCreate, UserResponse, UserUpdate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_COL_WIDTHS = {"id": 4, "email": 35, "name": 25, "role": 7, "active": 7}
+_TABLE_HEADER = (
+    f"{'ID':<{_COL_WIDTHS['id']}} "
+    f"{'Email':<{_COL_WIDTHS['email']}} "
+    f"{'Name':<{_COL_WIDTHS['name']}} "
+    f"{'Role':<{_COL_WIDTHS['role']}} "
+    f"{'Active':<{_COL_WIDTHS['active']}} "
+    f"Created"
+)
+_TABLE_SEP = "-" * 90
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    """Convert a Pydantic ValidationError to a readable one-line string."""
+    parts: list[str] = []
+    for err in exc.errors():
+        field = ".".join(str(loc) for loc in err["loc"]) if err["loc"] else "value"
+        parts.append(f"{field}: {err['msg']}")
+    return "; ".join(parts)
+
+
+def _row(r: UserResponse) -> str:
+    active_str = "yes" if r.is_active else "no"
+    created = r.created_at.strftime("%Y-%m-%d %H:%M")
+    return (
+        f"{r.id:<{_COL_WIDTHS['id']}} "
+        f"{r.email:<{_COL_WIDTHS['email']}} "
+        f"{r.full_name:<{_COL_WIDTHS['name']}} "
+        f"{r.role:<{_COL_WIDTHS['role']}} "
+        f"{active_str:<{_COL_WIDTHS['active']}} "
+        f"{created}"
+    )
+
+
+def _print_user(user: User) -> None:
+    """Print a single user as a one-row table."""
+    r = UserResponse.model_validate(user)
+    print(_TABLE_HEADER)
+    print(_TABLE_SEP)
+    print(_row(r))
+
+
+def _print_users(users: list[User], *, as_json: bool = False) -> None:
+    """Print a list of users as a table (default) or JSON array."""
+    if as_json:
+        data = [
+            UserResponse.model_validate(u).model_dump(mode="json") for u in users
+        ]
+        print(json_module.dumps(data, indent=2, default=str))
+        return
+
+    print(_TABLE_HEADER)
+    print(_TABLE_SEP)
+    for u in users:
+        print(_row(UserResponse.model_validate(u)))
+    print(f"\n{len(users)} user(s) found.")
+
+
+def _resolve_user(db: Session, identifier: str) -> User | None:
+    """Find a user by numeric ID (string of digits) or email address."""
+    if identifier.isdigit():
+        return db.get(User, int(identifier))
+    return db.query(User).filter(User.email == identifier).first()
+
+
+def _has_other_active_admin(db: Session, exclude_id: int) -> bool:
+    """Return True when at least one *other* active admin exists."""
+    count: int = (
+        db.query(User)
+        .filter(
+            User.role == UserRole.admin,
+            User.is_active.is_(True),
+            User.id != exclude_id,
+        )
+        .count()
+    )
+    return count > 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations (accept an injected Session for testability;
+# main() opens a real SessionLocal and passes it in)
+# ---------------------------------------------------------------------------
+
+
+def cmd_create(
+    db: Session,
+    *,
+    email: str,
+    password: str,
+    full_name: str,
+    role: str,
+) -> None:
+    """Create a new user account."""
+    # Validate via Pydantic (email format, password length, role value).
+    try:
+        validated = UserCreate(
+            email=email,
+            password=password,
+            full_name=full_name,
+            role=UserRole(role),
+        )
+    except ValidationError as exc:
+        print(f"Error: {_format_validation_error(exc)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Pre-check uniqueness to give a friendlier error than IntegrityError.
+    if db.query(User).filter(User.email == str(validated.email)).first() is not None:
+        print(
+            f"Error: email {str(validated.email)!r} is already taken.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    user = User(
+        email=str(validated.email),
+        hashed_password=hash_password(validated.password),
+        full_name=validated.full_name,
+        role=validated.role,
+        is_active=True,
+    )
+    db.add(user)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        print(
+            f"Error: could not create user — "
+            f"database constraint violation: {exc.orig}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    db.refresh(user)
+    print(f"User {str(validated.email)!r} created successfully.")
+    _print_user(user)
+
+
+def cmd_list(
+    db: Session,
+    *,
+    role: str | None = None,
+    active_filter: bool | None = None,
+    as_json: bool = False,
+) -> None:
+    """List users with optional filters."""
+    query = db.query(User)
+    if role is not None:
+        query = query.filter(User.role == UserRole(role))
+    if active_filter is not None:
+        query = query.filter(User.is_active == active_filter)
+    users: list[User] = query.order_by(User.id).all()
+    _print_users(users, as_json=as_json)
+
+
+def cmd_update(
+    db: Session,
+    identifier: str,
+    *,
+    email: str | None = None,
+    full_name: str | None = None,
+    role: str | None = None,
+    password: str | None = None,
+    activate: bool | None = None,
+) -> None:
+    """Update an existing user by ID or email.
+
+    ``activate=True``  → set is_active=True
+    ``activate=False`` → set is_active=False (deactivate)
+    ``activate=None``  → leave is_active unchanged
+    """
+    user = _resolve_user(db, identifier)
+    if user is None:
+        print(f"Error: user {identifier!r} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Build a dict of only the fields the caller wants to change.
+    updates: dict[str, object] = {}
+    if email is not None:
+        updates["email"] = email
+    if full_name is not None:
+        updates["full_name"] = full_name
+    if role is not None:
+        updates["role"] = role
+    if password is not None:
+        updates["password"] = password
+    if activate is not None:
+        updates["is_active"] = activate
+
+    if not updates:
+        print(
+            "Error: specify at least one field to update "
+            "(--email, --full-name, --role, --password, --activate, --deactivate).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Validate provided fields via Pydantic (email format, password length, etc.).
+    try:
+        validated = UserUpdate(**updates)
+    except ValidationError as exc:
+        print(f"Error: {_format_validation_error(exc)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Lockout guard: refuse any change that would leave zero active admins.
+    would_demote = (
+        validated.role is not None
+        and validated.role != UserRole.admin
+        and user.role == UserRole.admin
+    )
+    would_deactivate = (
+        validated.is_active is False
+        and user.is_active
+        and user.role == UserRole.admin
+    )
+    if (would_demote or would_deactivate) and not _has_other_active_admin(
+        db, user.id
+    ):
+        action = "demote" if would_demote else "deactivate"
+        print(
+            f"Error: cannot {action} {user.email!r} — "
+            "they are the last active admin. "
+            "Promote or activate another admin first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Apply the validated changes.
+    if validated.email is not None:
+        user.email = str(validated.email)
+    if validated.full_name is not None:
+        user.full_name = validated.full_name
+    if validated.role is not None:
+        user.role = validated.role
+    if validated.password is not None:
+        user.hashed_password = hash_password(validated.password)
+    if validated.is_active is not None:
+        user.is_active = validated.is_active
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        print(
+            f"Error: could not update user — "
+            f"database constraint violation: {exc.orig}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    db.refresh(user)
+    print(f"User {user.email!r} updated successfully.")
+    _print_user(user)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="manage_users.py",
+        description="Guard Proxy — user management CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s create --email alice@example.com "
+            "--password changeme1234 --full-name 'Alice'\n"
+            "  %(prog)s list --role admin --active\n"
+            "  %(prog)s list --json\n"
+            "  %(prog)s update alice@example.com --role viewer\n"
+            "  %(prog)s update 3 --deactivate\n"
+            "  %(prog)s update 1 --password newpassword12345\n"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+    sub.required = True
+
+    # ── create ──────────────────────────────────────────────────────────────
+    p_create = sub.add_parser("create", help="Create a new user account")
+    p_create.add_argument("--email", required=True, help="Email address (unique)")
+    p_create.add_argument("--password", required=True, help="Password (min 12 chars)")
+    p_create.add_argument("--full-name", required=True, help="Full display name")
+    p_create.add_argument(
+        "--role",
+        choices=[r.value for r in UserRole],
+        default=UserRole.viewer.value,
+        help="Role (default: viewer)",
+    )
+
+    # ── list ─────────────────────────────────────────────────────────────────
+    p_list = sub.add_parser("list", help="List users")
+    p_list.add_argument(
+        "--role",
+        choices=[r.value for r in UserRole],
+        help="Filter by role",
+    )
+    p_list.set_defaults(active_filter=None)
+    active_grp = p_list.add_mutually_exclusive_group()
+    active_grp.add_argument(
+        "--active",
+        dest="active_filter",
+        action="store_true",
+        help="Show only active users",
+    )
+    active_grp.add_argument(
+        "--inactive",
+        dest="active_filter",
+        action="store_false",
+        help="Show only inactive users",
+    )
+    p_list.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output as a JSON array",
+    )
+
+    # ── update ───────────────────────────────────────────────────────────────
+    p_update = sub.add_parser(
+        "update",
+        help="Update an existing user (by ID or email)",
+    )
+    p_update.add_argument(
+        "identifier",
+        help="User ID (numeric) or email address",
+    )
+    p_update.add_argument("--email", help="New email address")
+    p_update.add_argument("--full-name", help="New full name")
+    p_update.add_argument(
+        "--role",
+        choices=[r.value for r in UserRole],
+        help="New role",
+    )
+    p_update.add_argument("--password", help="New password (min 12 chars)")
+    p_update.set_defaults(activate=None)
+    activate_grp = p_update.add_mutually_exclusive_group()
+    activate_grp.add_argument(
+        "--activate",
+        dest="activate",
+        action="store_true",
+        help="Activate the account",
+    )
+    activate_grp.add_argument(
+        "--deactivate",
+        dest="activate",
+        action="store_false",
+        help="Deactivate the account",
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        if args.command == "create":
+            cmd_create(
+                db,
+                email=args.email,
+                password=args.password,
+                full_name=args.full_name,
+                role=args.role,
+            )
+        elif args.command == "list":
+            cmd_list(
+                db,
+                role=args.role,
+                active_filter=args.active_filter,
+                as_json=args.as_json,
+            )
+        elif args.command == "update":
+            cmd_update(
+                db,
+                args.identifier,
+                email=args.email,
+                full_name=args.full_name,
+                role=args.role,
+                password=args.password,
+                activate=args.activate,
+            )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/scripts/manage_users.py
+++ b/src/backend/scripts/manage_users.py
@@ -144,6 +144,9 @@ def cmd_create(
             full_name=full_name,
             role=UserRole(role),
         )
+    except ValueError as exc:
+        print(f"Error: role: {exc}", file=sys.stderr)
+        sys.exit(1)
     except ValidationError as exc:
         print(f"Error: {_format_validation_error(exc)}", file=sys.stderr)
         sys.exit(1)
@@ -190,7 +193,11 @@ def cmd_list(
     """List users with optional filters."""
     query = db.query(User)
     if role is not None:
-        query = query.filter(User.role == UserRole(role))
+        try:
+            query = query.filter(User.role == UserRole(role))
+        except ValueError as exc:
+            print(f"Error: role: {exc}", file=sys.stderr)
+            sys.exit(1)
     if active_filter is not None:
         query = query.filter(User.is_active == active_filter)
     users: list[User] = query.order_by(User.id).all()

--- a/src/backend/scripts/manage_users.py
+++ b/src/backend/scripts/manage_users.py
@@ -7,7 +7,7 @@ Subcommands:
 
 Usage (local):
     uv run python scripts/manage_users.py create \\
-        --email alice@example.com --password changeme1234 --full-name "Alice"
+        --email alice@example.com --password '<password>' --full-name "Alice"
     uv run python scripts/manage_users.py list --role admin --active
     uv run python scripts/manage_users.py update alice@example.com --role admin
     uv run python scripts/manage_users.py update 3 --deactivate
@@ -310,7 +310,7 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  %(prog)s create --email alice@example.com "
-            "--password changeme1234 --full-name 'Alice'\n"
+            "--password '<password>' --full-name 'Alice'\n"
             "  %(prog)s list --role admin --active\n"
             "  %(prog)s list --json\n"
             "  %(prog)s update alice@example.com --role viewer\n"

--- a/src/backend/tests/integration/test_manage_users.py
+++ b/src/backend/tests/integration/test_manage_users.py
@@ -78,7 +78,7 @@ class TestCmdCreate:
         assert user is not None
         assert user.role == UserRole.admin
 
-    def test_default_role_is_viewer(self, db: Session) -> None:
+    def test_creates_viewer_user_with_explicit_role(self, db: Session) -> None:
         cmd_create(
             db,
             email="carol@test.com",

--- a/src/backend/tests/integration/test_manage_users.py
+++ b/src/backend/tests/integration/test_manage_users.py
@@ -1,0 +1,450 @@
+"""Integration tests for scripts/manage_users.py (create / list / update).
+
+Each test receives the function-scoped `db` fixture from conftest — an
+isolated SQLAlchemy session that is rolled back after the test, so there is
+no state leakage between cases.
+
+The cmd_* functions accept an injected Session, so we never touch
+SessionLocal() directly and no real database file is needed.
+"""
+
+import json
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.user import User, UserRole
+from app.passwords import hash_password, verify_password
+from scripts.manage_users import cmd_create, cmd_list, cmd_update
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(
+    db: Session,
+    *,
+    email: str,
+    role: UserRole = UserRole.viewer,
+    is_active: bool = True,
+    password: str = "password12345",
+) -> User:
+    """Insert a User directly (mirrors conftest fixture style)."""
+    user = User(
+        email=email,
+        hashed_password=hash_password(password),
+        full_name=email.split("@")[0].title(),
+        role=role,
+        is_active=is_active,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+# ---------------------------------------------------------------------------
+# cmd_create
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCreate:
+    def test_creates_viewer_user(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cmd_create(
+            db,
+            email="alice@test.com",
+            password="password12345",
+            full_name="Alice",
+            role="viewer",
+        )
+        user = db.query(User).filter(User.email == "alice@test.com").first()
+        assert user is not None
+        assert user.role == UserRole.viewer
+        assert user.is_active is True
+        out, _ = capsys.readouterr()
+        assert "alice@test.com" in out
+
+    def test_creates_admin_user(self, db: Session) -> None:
+        cmd_create(
+            db,
+            email="bob@test.com",
+            password="adminpass12345",
+            full_name="Bob Admin",
+            role="admin",
+        )
+        user = db.query(User).filter(User.email == "bob@test.com").first()
+        assert user is not None
+        assert user.role == UserRole.admin
+
+    def test_default_role_is_viewer(self, db: Session) -> None:
+        cmd_create(
+            db,
+            email="carol@test.com",
+            password="password12345",
+            full_name="Carol",
+            role="viewer",
+        )
+        user = db.query(User).filter(User.email == "carol@test.com").first()
+        assert user is not None
+        assert user.role == UserRole.viewer
+
+    def test_password_is_hashed(self, db: Session) -> None:
+        plaintext = "password12345"
+        cmd_create(
+            db,
+            email="dave@test.com",
+            password=plaintext,
+            full_name="Dave",
+            role="viewer",
+        )
+        user = db.query(User).filter(User.email == "dave@test.com").first()
+        assert user is not None
+        assert user.hashed_password != plaintext
+        assert verify_password(plaintext, user.hashed_password)
+
+    def test_duplicate_email_exits_1(self, db: Session) -> None:
+        _make_user(db, email="existing@test.com", role=UserRole.viewer)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_create(
+                db,
+                email="existing@test.com",
+                password="password12345",
+                full_name="Dup",
+                role="viewer",
+            )
+        assert exc_info.value.code == 1
+
+    def test_duplicate_email_prints_error(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="taken@test.com", role=UserRole.viewer)
+        with pytest.raises(SystemExit):
+            cmd_create(
+                db,
+                email="taken@test.com",
+                password="password12345",
+                full_name="Dup",
+                role="viewer",
+            )
+        _, err = capsys.readouterr()
+        assert "taken@test.com" in err
+
+    def test_short_password_exits_1(self, db: Session) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_create(
+                db,
+                email="eve@test.com",
+                password="short",
+                full_name="Eve",
+                role="viewer",
+            )
+        assert exc_info.value.code == 1
+
+    def test_short_password_prints_error(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            cmd_create(
+                db,
+                email="eve@test.com",
+                password="short",
+                full_name="Eve",
+                role="viewer",
+            )
+        _, err = capsys.readouterr()
+        assert err.strip()  # some error message printed to stderr
+
+    def test_invalid_email_exits_1(self, db: Session) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_create(
+                db,
+                email="not-an-email",
+                password="password12345",
+                full_name="Bad Email",
+                role="viewer",
+            )
+        assert exc_info.value.code == 1
+
+    def test_output_excludes_hashed_password(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cmd_create(
+            db,
+            email="frank@test.com",
+            password="password12345",
+            full_name="Frank",
+            role="viewer",
+        )
+        out, _ = capsys.readouterr()
+        assert "hashed_password" not in out
+        assert "password12345" not in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_list
+# ---------------------------------------------------------------------------
+
+
+class TestCmdList:
+    def test_lists_all_users(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="u1@test.com", role=UserRole.admin)
+        _make_user(db, email="u2@test.com", role=UserRole.viewer)
+        cmd_list(db)
+        out, _ = capsys.readouterr()
+        assert "u1@test.com" in out
+        assert "u2@test.com" in out
+
+    def test_filters_by_role_admin(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="admin1@test.com", role=UserRole.admin)
+        _make_user(db, email="viewer1@test.com", role=UserRole.viewer)
+        cmd_list(db, role="admin")
+        out, _ = capsys.readouterr()
+        assert "admin1@test.com" in out
+        assert "viewer1@test.com" not in out
+
+    def test_filters_by_role_viewer(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="admin2@test.com", role=UserRole.admin)
+        _make_user(db, email="viewer2@test.com", role=UserRole.viewer)
+        cmd_list(db, role="viewer")
+        out, _ = capsys.readouterr()
+        assert "viewer2@test.com" in out
+        assert "admin2@test.com" not in out
+
+    def test_filters_active_only(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="active@test.com", is_active=True)
+        _make_user(db, email="inactive@test.com", is_active=False)
+        cmd_list(db, active_filter=True)
+        out, _ = capsys.readouterr()
+        assert "active@test.com" in out
+        assert "inactive@test.com" not in out
+
+    def test_filters_inactive_only(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="online@test.com", is_active=True)
+        _make_user(db, email="disabled@test.com", is_active=False)
+        cmd_list(db, active_filter=False)
+        out, _ = capsys.readouterr()
+        assert "disabled@test.com" in out
+        assert "online@test.com" not in out
+
+    def test_json_output_is_valid(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="json@test.com")
+        cmd_list(db, as_json=True)
+        out, _ = capsys.readouterr()
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_json_excludes_hashed_password(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="sec@test.com")
+        cmd_list(db, as_json=True)
+        out, _ = capsys.readouterr()
+        assert "hashed_password" not in out
+        data = json.loads(out)
+        for item in data:
+            assert "hashed_password" not in item
+
+    def test_json_schema_fields(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="schema@test.com", role=UserRole.admin)
+        cmd_list(db, as_json=True)
+        out, _ = capsys.readouterr()
+        data = json.loads(out)
+        item = next(d for d in data if d["email"] == "schema@test.com")
+        assert set(item.keys()) == {
+            "id",
+            "email",
+            "full_name",
+            "role",
+            "is_active",
+            "created_at",
+            "updated_at",
+        }
+
+    def test_empty_list(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cmd_list(db)
+        out, _ = capsys.readouterr()
+        assert "0 user(s) found." in out
+
+
+# ---------------------------------------------------------------------------
+# cmd_update
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdate:
+    def test_update_full_name_by_email(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        user = _make_user(db, email="update1@test.com")
+        cmd_update(db, "update1@test.com", full_name="New Name")
+        db.refresh(user)
+        assert user.full_name == "New Name"
+        out, _ = capsys.readouterr()
+        assert "New Name" in out
+
+    def test_update_full_name_by_id(self, db: Session) -> None:
+        user = _make_user(db, email="update2@test.com")
+        cmd_update(db, str(user.id), full_name="Updated By ID")
+        db.refresh(user)
+        assert user.full_name == "Updated By ID"
+
+    def test_update_email(self, db: Session) -> None:
+        user = _make_user(db, email="oldemail@test.com")
+        cmd_update(db, "oldemail@test.com", email="newemail@test.com")
+        db.refresh(user)
+        assert user.email == "newemail@test.com"
+
+    def test_update_role(self, db: Session) -> None:
+        # Need two admins so the lockout guard doesn't block the demotion.
+        _make_user(db, email="admin_keep@test.com", role=UserRole.admin)
+        user = _make_user(db, email="demote@test.com", role=UserRole.admin)
+        cmd_update(db, "demote@test.com", role="viewer")
+        db.refresh(user)
+        assert user.role == UserRole.viewer
+
+    def test_update_password(self, db: Session) -> None:
+        user = _make_user(db, email="pwchange@test.com", password="oldpassword12345")
+        cmd_update(db, "pwchange@test.com", password="newpassword12345")
+        db.refresh(user)
+        assert verify_password("newpassword12345", user.hashed_password)
+        assert not verify_password("oldpassword12345", user.hashed_password)
+
+    def test_deactivate_user(self, db: Session) -> None:
+        # Non-admin user — lockout guard does not apply.
+        user = _make_user(db, email="deactivate@test.com", role=UserRole.viewer)
+        cmd_update(db, "deactivate@test.com", activate=False)
+        db.refresh(user)
+        assert user.is_active is False
+
+    def test_activate_user(self, db: Session) -> None:
+        user = _make_user(db, email="reactivate@test.com", is_active=False)
+        cmd_update(db, "reactivate@test.com", activate=True)
+        db.refresh(user)
+        assert user.is_active is True
+
+    def test_no_fields_exits_1(self, db: Session) -> None:
+        _make_user(db, email="nofields@test.com")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "nofields@test.com")
+        assert exc_info.value.code == 1
+
+    def test_user_not_found_by_email_exits_1(self, db: Session) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "ghost@test.com", full_name="Ghost")
+        assert exc_info.value.code == 1
+
+    def test_user_not_found_by_id_exits_1(self, db: Session) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "99999", full_name="Ghost")
+        assert exc_info.value.code == 1
+
+    def test_short_password_exits_1(self, db: Session) -> None:
+        _make_user(db, email="badpw@test.com")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "badpw@test.com", password="short")
+        assert exc_info.value.code == 1
+
+    def test_invalid_email_update_exits_1(self, db: Session) -> None:
+        _make_user(db, email="bademail@test.com")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "bademail@test.com", email="not-valid")
+        assert exc_info.value.code == 1
+
+    def test_output_excludes_hashed_password(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="sec2@test.com")
+        cmd_update(db, "sec2@test.com", full_name="Secure User")
+        out, _ = capsys.readouterr()
+        assert "hashed_password" not in out
+
+    # --- Lockout guard ---
+
+    def test_lockout_demote_last_admin_exits_1(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="lastadmin@test.com", role=UserRole.admin)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "lastadmin@test.com", role="viewer")
+        assert exc_info.value.code == 1
+        _, err = capsys.readouterr()
+        assert "last active admin" in err
+
+    def test_lockout_deactivate_last_admin_exits_1(
+        self, db: Session, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_user(db, email="lastadmin2@test.com", role=UserRole.admin)
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_update(db, "lastadmin2@test.com", activate=False)
+        assert exc_info.value.code == 1
+        _, err = capsys.readouterr()
+        assert "last active admin" in err
+
+    def test_lockout_allows_demote_when_second_admin_exists(
+        self, db: Session
+    ) -> None:
+        _make_user(db, email="admin_a@test.com", role=UserRole.admin)
+        user_b = _make_user(db, email="admin_b@test.com", role=UserRole.admin)
+        # Demoting admin_b is allowed because admin_a is still active admin.
+        cmd_update(db, "admin_b@test.com", role="viewer")
+        db.refresh(user_b)
+        assert user_b.role == UserRole.viewer
+
+    def test_lockout_allows_deactivate_when_second_admin_exists(
+        self, db: Session
+    ) -> None:
+        _make_user(db, email="admin_c@test.com", role=UserRole.admin)
+        user_d = _make_user(db, email="admin_d@test.com", role=UserRole.admin)
+        cmd_update(db, "admin_d@test.com", activate=False)
+        db.refresh(user_d)
+        assert user_d.is_active is False
+
+    def test_lockout_does_not_block_viewer_deactivation(
+        self, db: Session
+    ) -> None:
+        # Viewers can always be deactivated regardless of admin count.
+        user = _make_user(db, email="viewer_only@test.com", role=UserRole.viewer)
+        cmd_update(db, "viewer_only@test.com", activate=False)
+        db.refresh(user)
+        assert user.is_active is False
+
+    def test_lockout_does_not_block_admin_activation(
+        self, db: Session
+    ) -> None:
+        # Activating the last admin is always fine (it cannot cause lockout).
+        user = _make_user(
+            db, email="inactive_admin@test.com", role=UserRole.admin, is_active=False
+        )
+        cmd_update(db, "inactive_admin@test.com", activate=True)
+        db.refresh(user)
+        assert user.is_active is True
+
+    def test_lockout_does_not_block_role_change_within_viewer(
+        self, db: Session
+    ) -> None:
+        # viewer → admin should always succeed.
+        _make_user(db, email="promote@test.com", role=UserRole.viewer)
+        user = db.query(User).filter(User.email == "promote@test.com").first()
+        assert user is not None
+        cmd_update(db, "promote@test.com", role="admin")
+        db.refresh(user)
+        assert user.role == UserRole.admin


### PR DESCRIPTION
## Summary

Implements #219.

- Adds `scripts/manage_users.py` — a multi-subcommand argparse CLI for operator-level user management (`create`, `list`, `update`), following the same convention as the existing `seed_admin.py`
- Closes #67 with a **CLI-only approach**: user management stays at the operator layer (smaller attack surface, no HTTP endpoint to secure/audit, avoids the bootstrap chicken-and-egg problem)
- Adds 39 integration tests covering all happy paths, error exits, and lockout-guard edge cases
- Adds `make users ARGS="..."` convenience target (mirrors `make seed`)

## What changed

| File | Description |
|------|-------------|
| `src/backend/scripts/manage_users.py` | New CLI — `create`, `list`, `update` subcommands |
| `src/backend/scripts/__init__.py` | Empty init to enable package import from pytest |
| `src/backend/tests/integration/test_manage_users.py` | 39 integration tests (39/39 pass, ruff ✓, mypy strict ✓) |
| `Makefile` | `make users ARGS="list --json"` target for in-container use |

## Design decisions

**Validation** is single-sourced through the existing `UserCreate` / `UserUpdate` Pydantic schemas — email format and 12-char password minimum are not re-implemented.

**Lockout guard** — `update` refuses to demote or deactivate a user who is the last active admin. The guard counts other active admins before committing; if zero remain, the operation is rejected with a clear error.

**Output** uses `UserResponse` — `hashed_password` is never printed to stdout or JSON output.

**No new dependencies** — stdlib `argparse` only, matching the established `seed_admin.py` convention.

## Usage

```bash
# local
uv run python scripts/manage_users.py create \
    --email alice@example.com --password changeme1234 --full-name "Alice" [--role admin]

uv run python scripts/manage_users.py list [--role admin|viewer] [--active|--inactive] [--json]

uv run python scripts/manage_users.py update alice@example.com \
    [--email …] [--full-name …] [--role …] [--password …] [--activate|--deactivate]

# Docker (or via Makefile)
make users ARGS="list --json"
make users ARGS="create --email ops@example.com --password changeme1234 --full-name Ops"
```

## Test plan

- [x] `uv run --extra dev pytest tests/integration/test_manage_users.py -v` → 39/39 pass
- [x] `ruff check scripts/manage_users.py tests/integration/test_manage_users.py` → clean
- [x] `mypy scripts/manage_users.py tests/integration/test_manage_users.py` → no issues (strict mode)
