### PR TITLE
feat(health): M5-03 — /ready readiness probe, compose healthcheck gate

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -58,7 +58,7 @@ machine-readable degraded reason header.
 | **HAProxy** | Reference reverse proxy, host routing, SPOE filter, WAF enforcement, degraded-mode handling | `configs/haproxy/` |
 | **Coraza SPOA + OWASP CRS** | Request-phase WAF inspection, CRS anomaly scoring, JSON audit log | `configs/coraza/`, `deploy/docker/coraza.Dockerfile` |
 | **Log Shipper sidecar** | Tails Coraza's JSON audit file and ships each event to `POST /logs/ingest` with exponential backoff | `src/log-shipper/` |
-| **FastAPI Backend** | Control-plane API for auth, vhosts, policies, rule overrides, logs, and health checks | `src/backend/` |
+| **FastAPI Backend** | Control-plane API for auth, vhosts, policies, rule overrides, logs, and health/readiness probes | `src/backend/` |
 | **React Frontend** | Admin panel SPA built with React, TypeScript, Vite, Tailwind CSS, and pnpm | `src/frontend/` |
 | **PostgreSQL** | Docker Compose database for backend state | `deploy/docker/docker-compose.yml` |
 | **Docker Compose Stack** | Local full-stack orchestration, health checks, networks, logs, and persistent volumes | `deploy/docker/` |
@@ -107,6 +107,29 @@ machine-readable degraded reason header.
 6. `GET /logs` exposes stored events for the admin panel log viewer.
 
 ## Deployment
+
+### Health and Readiness Probes
+
+The backend exposes two probe endpoints, both unauthenticated:
+
+| Endpoint | Type | Returns | Checks |
+|----------|------|---------|--------|
+| `GET /health` | Liveness | 200 always | None — proves the process is alive |
+| `GET /ready` | Readiness | 200 / 503 | DB connectivity (`SELECT 1`), runtime config volume writable |
+
+`/ready` returns a JSON body with per-check status so operators can tell which dependency is down:
+
+```json
+// 200 — all clear
+{"status": "ready", "checks": {"database": {"status": "ok"}, "runtime_config": {"status": "ok"}}}
+
+// 503 — one or more dependencies unavailable
+{"status": "not ready", "checks": {"database": {"status": "ok"}, "runtime_config": {"status": "error", "detail": "/var/lib/guard-proxy/generated is not a writable directory"}}}
+```
+
+The Docker Compose `healthcheck` for the `backend` service targets `/ready`. Almost every other service in the stack (`frontend`, `haproxy`, `coraza`, `log-shipper`) depends on `backend` with `condition: service_healthy`, so `/ready` must pass before dependents start. This prevents dependents from launching while the database is still initialising or the config volume is unavailable.
+
+`/health` is retained as a lightweight liveness probe for orchestrators that separately track process aliveness (e.g. a future Kubernetes `livenessProbe`).
 
 ### Development (Docker Compose)
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ make seed      # add the initial admin user
 |---|---|
 | Admin panel | http://localhost:3000 |
 | API (via HAProxy) | http://localhost:8080 |
-| Health check | `curl http://localhost:8080/health` |
+| Liveness probe | `curl http://localhost:8080/health` |
+| Readiness probe | `curl http://localhost:8080/ready` |
 
 ### WAF smoke test
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .env
     environment:
       DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
-      GUARD_PROXY_RUNTIME_DIR: /var/lib/guard-proxy/generated
+      RUNTIME_GENERATED_CONFIG_ROOT: /var/lib/guard-proxy/generated
     depends_on:
       postgres:
         condition: service_healthy
@@ -35,7 +35,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)\"",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/ready', timeout=2)\"",
         ]
       interval: 10s
       timeout: 5s

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -13,8 +13,6 @@ from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
 from app.database import get_db
-
-logger = logging.getLogger(__name__)
 from app.routers import (
     auth,
     config,
@@ -24,6 +22,8 @@ from app.routers import (
     runtime_status,
     vhosts,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class _HealthcheckAccessFilter(logging.Filter):

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,11 +1,18 @@
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
+from app.database import get_db
 from app.routers import (
     auth,
     config,
@@ -24,7 +31,7 @@ class _HealthcheckAccessFilter(logging.Filter):
             isinstance(args, tuple)
             and len(args) >= 3
             and args[1] == "GET"
-            and args[2] == "/health"
+            and args[2] in ("/health", "/ready")
         ):
             return False
         return True
@@ -67,8 +74,48 @@ app.include_router(vhosts.router)
 
 @app.get("/health")
 def health_check() -> dict[str, str]:
-    """Health check endpoint."""
+    """Liveness probe — always returns 200 if the process is running."""
     return {
         "status": "healthy",
         "version": "0.1.0",
     }
+
+
+@app.get("/ready")
+def readiness_check(db: Session = Depends(get_db)) -> JSONResponse:
+    """Readiness probe — checks DB connectivity and runtime config volume.
+
+    Returns 200 when all checks pass, 503 with a per-check breakdown when any
+    dependency is unavailable. Used as the Docker Compose healthcheck gate so
+    dependent services (frontend, HAProxy, Coraza) only start once the backend
+    can actually serve traffic.
+    """
+    checks: dict[str, dict[str, str]] = {}
+    all_ok = True
+
+    # Check 1: database connectivity
+    try:
+        db.execute(text("SELECT 1"))
+        checks["database"] = {"status": "ok"}
+    except SQLAlchemyError as exc:
+        checks["database"] = {"status": "error", "detail": str(exc)}
+        all_ok = False
+
+    # Check 2: runtime config volume present and writable
+    config_root = Path(settings.runtime_generated_config_root)
+    if config_root.is_dir() and os.access(config_root, os.W_OK):
+        checks["runtime_config"] = {"status": "ok"}
+    else:
+        checks["runtime_config"] = {
+            "status": "error",
+            "detail": f"{config_root} is not a writable directory",
+        }
+        all_ok = False
+
+    return JSONResponse(
+        content={
+            "status": "ready" if all_ok else "not ready",
+            "checks": checks,
+        },
+        status_code=200 if all_ok else 503,
+    )

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -13,6 +13,8 @@ from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
 from app.database import get_db
+
+logger = logging.getLogger(__name__)
 from app.routers import (
     auth,
     config,
@@ -98,12 +100,14 @@ def readiness_check(db: Session = Depends(get_db)) -> JSONResponse:
         db.execute(text("SELECT 1"))
         checks["database"] = {"status": "ok"}
     except SQLAlchemyError as exc:
-        checks["database"] = {"status": "error", "detail": str(exc)}
+        logger.error("Readiness DB check failed: %s", exc)
+        checks["database"] = {"status": "error", "detail": "database unavailable"}
         all_ok = False
 
-    # Check 2: runtime config volume present and writable
+    # Check 2: runtime config volume present and writable (W_OK + X_OK required
+    # to create files inside a directory)
     config_root = Path(settings.runtime_generated_config_root)
-    if config_root.is_dir() and os.access(config_root, os.W_OK):
+    if config_root.is_dir() and os.access(config_root, os.W_OK | os.X_OK):
         checks["runtime_config"] = {"status": "ok"}
     else:
         checks["runtime_config"] = {

--- a/src/backend/tests/integration/test_health_router.py
+++ b/src/backend/tests/integration/test_health_router.py
@@ -101,7 +101,7 @@ def test_ready_returns_503_when_db_fails(
     data = response.json()
     assert data["status"] == "not ready"
     assert data["checks"]["database"]["status"] == "error"
-    assert "detail" in data["checks"]["database"]
+    assert data["checks"]["database"]["detail"] == "database unavailable"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/integration/test_health_router.py
+++ b/src/backend/tests/integration/test_health_router.py
@@ -1,0 +1,160 @@
+"""Integration tests for the /health liveness and /ready readiness probes."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+import app.main as main_module
+from app.database import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# /health — liveness probe
+# ---------------------------------------------------------------------------
+
+
+def test_health_returns_200(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert "version" in data
+
+
+def test_health_does_not_require_auth(client: TestClient) -> None:
+    """Liveness probe must be accessible without authentication."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /ready — readiness probe (happy path)
+# ---------------------------------------------------------------------------
+
+
+def test_ready_returns_200_when_all_checks_pass(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both DB and config-dir checks pass → 200 with all checks ok."""
+    monkeypatch.setattr(
+        main_module.settings, "runtime_generated_config_root", str(tmp_path)
+    )
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+    assert data["checks"]["database"]["status"] == "ok"
+    assert data["checks"]["runtime_config"]["status"] == "ok"
+
+
+def test_ready_does_not_require_auth(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readiness probe must be accessible without authentication."""
+    monkeypatch.setattr(
+        main_module.settings, "runtime_generated_config_root", str(tmp_path)
+    )
+    response = client.get("/ready")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /ready — readiness probe (DB failure)
+# ---------------------------------------------------------------------------
+
+
+def test_ready_returns_503_when_db_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB connectivity failure → 503 with database check reporting error."""
+    monkeypatch.setattr(
+        main_module.settings, "runtime_generated_config_root", str(tmp_path)
+    )
+
+    mock_session = MagicMock(spec=Session)
+    mock_session.execute.side_effect = SQLAlchemyError("connection refused")
+
+    def broken_db() -> Iterator[Session]:
+        yield mock_session
+
+    app.dependency_overrides[get_db] = broken_db
+    try:
+        with TestClient(app) as c:
+            response = c.get("/ready")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "not ready"
+    assert data["checks"]["database"]["status"] == "error"
+    assert "detail" in data["checks"]["database"]
+
+
+# ---------------------------------------------------------------------------
+# /ready — readiness probe (config dir failure)
+# ---------------------------------------------------------------------------
+
+
+def test_ready_returns_503_when_config_dir_missing(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing config dir → 503 with runtime_config check reporting error."""
+    monkeypatch.setattr(
+        main_module.settings,
+        "runtime_generated_config_root",
+        "/nonexistent/guard-proxy-test-path",
+    )
+
+    response = client.get("/ready")
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["status"] == "not ready"
+    assert data["checks"]["runtime_config"]["status"] == "error"
+    assert "detail" in data["checks"]["runtime_config"]
+    # DB check should still have passed
+    assert data["checks"]["database"]["status"] == "ok"
+
+
+def test_ready_body_includes_both_checks_on_full_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both checks fail the body contains entries for both."""
+    monkeypatch.setattr(
+        main_module.settings,
+        "runtime_generated_config_root",
+        "/nonexistent/guard-proxy-test-path",
+    )
+
+    mock_session = MagicMock(spec=Session)
+    mock_session.execute.side_effect = SQLAlchemyError("unreachable")
+
+    def broken_db() -> Iterator[Session]:
+        yield mock_session
+
+    app.dependency_overrides[get_db] = broken_db
+    try:
+        with TestClient(app) as c:
+            response = c.get("/ready")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 503
+    data = response.json()
+    assert data["checks"]["database"]["status"] == "error"
+    assert data["checks"]["runtime_config"]["status"] == "error"

--- a/src/backend/tests/unit/test_access_logging.py
+++ b/src/backend/tests/unit/test_access_logging.py
@@ -25,3 +25,11 @@ def test_healthcheck_access_filter_keeps_non_get_health() -> None:
 
 def test_healthcheck_access_filter_keeps_non_health_requests() -> None:
     assert _HealthcheckAccessFilter().filter(_access_record("GET", "/api/v1/policies"))
+
+
+def test_healthcheck_access_filter_drops_get_ready() -> None:
+    assert not _HealthcheckAccessFilter().filter(_access_record("GET", "/ready"))
+
+
+def test_healthcheck_access_filter_keeps_non_get_ready() -> None:
+    assert _HealthcheckAccessFilter().filter(_access_record("POST", "/ready", 405))


### PR DESCRIPTION
## Summary

- Adds `GET /ready` — a real readiness probe that checks DB connectivity (`SELECT 1`) and whether the runtime config volume is a writable directory. Returns `200` with per-check status when healthy, `503` with a detailed breakdown when any dependency is unavailable.
- Keeps `GET /health` as a pure liveness probe (static 200, no dependencies checked).
- Switches the Docker Compose backend `healthcheck` from `/health` → `/ready` so the five dependent services (`frontend`, `haproxy`, `coraza`, `log-shipper`) only start once the backend can actually serve traffic.
- Fixes a silent bug: `GUARD_PROXY_RUNTIME_DIR` in compose was never read by the Python settings layer (field is `RUNTIME_GENERATED_CONFIG_ROOT`). Renamed to match; value is unchanged.

## What changed and why

| File | Change |
|------|--------|
| `src/backend/app/main.py` | New `readiness_check` endpoint; extends `_HealthcheckAccessFilter` to also suppress `GET /ready` poll noise; updated imports |
| `deploy/docker/docker-compose.yml` | Healthcheck URL `/health` → `/ready`; env var rename fix |
| `tests/integration/test_health_router.py` | 7 new tests: liveness 200, readiness 200 (happy path), 503 on DB failure, 503 on missing config dir, 503 when both fail, auth-not-required for both |
| `tests/unit/test_access_logging.py` | 2 new tests for the updated filter |
| `README.architecture.md` | New "Health and Readiness Probes" section with endpoint table and response shape examples |
| `README.md` | Access table updated with separate liveness/readiness rows |

## Response shape

```json
// GET /ready → 200
{"status": "ready", "checks": {"database": {"status": "ok"}, "runtime_config": {"status": "ok"}}}

// GET /ready → 503 (one check failed)
{"status": "not ready", "checks": {"database": {"status": "ok"}, "runtime_config": {"status": "error", "detail": "/var/lib/guard-proxy/generated is not a writable directory"}}}
```

## Test plan

- [x] `uv run python -m pytest tests/unit/test_access_logging.py tests/integration/test_health_router.py -v` — 12/12 passed
- [x] Full compose stack: `make run` → confirm backend reaches `healthy` state and all dependents start
- [x] Manual: `curl -i localhost:8080/health` (200), `curl -i localhost:8080/ready` (200)

Closes #128
