### PR TITLE
feat(compose): M5-04 — wire log-shipper→coraza service_healthy

### DIFF
--- a/deploy/docker/coraza.Dockerfile
+++ b/deploy/docker/coraza.Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/corazawaf/coraza-spoa:0.6.1 AS upstream
 
 FROM alpine:3.19
 
-RUN apk add --no-cache su-exec tini
+RUN apk add --no-cache su-exec tini netcat-openbsd
 
 COPY --from=upstream /coraza-spoa /usr/local/bin/coraza-spoa
 COPY configs/coraza/coraza-spoa.yaml /etc/coraza-spoa/coraza-spoa.yaml

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       backend:
         condition: service_healthy
       coraza:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - coraza_audit:/var/log/coraza:ro
       - shipper_state:/var/lib/log-shipper

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -37,8 +37,13 @@ def test_default_docker_compose_does_not_use_debug_flag() -> None:
 def test_default_docker_compose_starts_haproxy_before_coraza_is_healthy() -> None:
     compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
 
-    assert "coraza:\n        condition: service_started" in compose
-    assert "coraza:\n        condition: service_healthy" not in compose
+    # Scope the coraza-condition check to the haproxy service block only.
+    # log-shipper intentionally uses service_healthy for coraza (also present in the
+    # file), so the assertions must not operate on the whole document.
+    haproxy_block = compose.split("\n  haproxy:")[1].split("\nnetworks:")[0]
+
+    assert "coraza:\n        condition: service_started" in haproxy_block
+    assert "coraza:\n        condition: service_healthy" not in haproxy_block
     assert '"${HAPROXY_HTTP_PORT:-8080}:80"' in compose
 
 

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -47,6 +47,13 @@ def test_default_docker_compose_starts_haproxy_before_coraza_is_healthy() -> Non
     assert '"${HAPROXY_HTTP_PORT:-8080}:80"' in compose
 
 
+def test_default_docker_compose_starts_log_shipper_after_coraza_is_healthy() -> None:
+    compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
+
+    log_shipper_block = compose.split("\n  log-shipper:")[1].split("\n  haproxy:")[0]
+    assert "coraza:\n        condition: service_healthy" in log_shipper_block
+
+
 def test_debug_coraza_spoa_config_enables_debug_logging() -> None:
     config = (REPO_ROOT / "configs/coraza/coraza-spoa.debug.yaml").read_text()
 


### PR DESCRIPTION
Closes #129

## Summary

- Flips `log-shipper` → `coraza` dependency from `service_started` to `service_healthy`, so the log-shipper only starts once coraza's SPOA port is actually listening
- `haproxy` → `coraza` intentionally stays `service_started` — haproxy must start in degraded mode and serve 503 when coraza is down (#69)
- Scopes the haproxy regression test to the haproxy service block (the previous global substring check would break because log-shipper now introduces a second `coraza: service_healthy` line in the file)

Everything else in #129 was already shipped by M5-03 in [PR #220](https://github.com/bihius/guard-proxy/pull/220) (backend `/ready` probe, compose healthcheck switch, all five service healthcheck blocks, `service_healthy` wiring for all other deps).

## Test plan

- [x] `pytest tests/unit/` — 195 passed, 1 skipped
- [x] `docker compose config` — validates cleanly
- [x] `docker compose up -d && docker compose ps` — all services healthy; log-shipper starts after coraza healthy
