### PR TITLE
[codex] Implement vhost detail page

### DIFF
--- a/src/frontend/src/features/policies/api.ts
+++ b/src/frontend/src/features/policies/api.ts
@@ -1,6 +1,14 @@
 import { apiRequest } from "@/lib/api-client";
 
-import type { Policy, PolicyCreate, PolicyDetail, PolicyUpdate } from "./types";
+import type {
+  Policy,
+  PolicyCreate,
+  PolicyDetail,
+  PolicyUpdate,
+  RuleOverride,
+  RuleOverrideCreate,
+  RuleOverrideUpdate,
+} from "./types";
 
 export function listPolicies(token: string, signal?: AbortSignal) {
   return apiRequest<Policy[]>("/policies", { token, signal });
@@ -20,6 +28,57 @@ export function updatePolicy(token: string, id: number, body: PolicyUpdate) {
 
 export function deletePolicy(token: string, id: number) {
   return apiRequest<void>(`/policies/${id}`, {
+    method: "DELETE",
+    token,
+    responseType: "empty",
+  });
+}
+
+export function listRuleOverrides(
+  token: string,
+  policyId: number,
+  signal?: AbortSignal,
+) {
+  return apiRequest<RuleOverride[]>(`/policies/${policyId}/rules`, {
+    token,
+    signal,
+  });
+}
+
+export function createRuleOverride(
+  token: string,
+  policyId: number,
+  body: RuleOverrideCreate,
+) {
+  return apiRequest<RuleOverride>(`/policies/${policyId}/rules`, {
+    method: "POST",
+    token,
+    body,
+  });
+}
+
+export function updateRuleOverride(
+  token: string,
+  policyId: number,
+  ruleOverrideId: number,
+  body: RuleOverrideUpdate,
+) {
+  return apiRequest<RuleOverride>(
+    `/policies/${policyId}/rules/${ruleOverrideId}`,
+    {
+      method: "PATCH",
+      token,
+      body,
+    },
+  );
+}
+
+export function deleteRuleOverride(
+  token: string,
+  policyId: number,
+  ruleOverrideId: number,
+) {
+  return apiRequest<void>(`/policies/${policyId}/rules/${ruleOverrideId}`, {
     method: "DELETE",
     token,
     responseType: "empty",

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -21,6 +21,18 @@ export type RuleOverride = {
   created_at: string;
 };
 
+export type RuleOverrideCreate = {
+  rule_id: number;
+  action: "enable" | "disable";
+  comment?: string | null;
+};
+
+export type RuleOverrideUpdate = {
+  rule_id?: number;
+  action?: "enable" | "disable";
+  comment?: string | null;
+};
+
 export type PolicyDetail = Policy & {
   rule_overrides: RuleOverride[];
 };

--- a/src/frontend/src/features/vhosts/api.ts
+++ b/src/frontend/src/features/vhosts/api.ts
@@ -1,9 +1,13 @@
 import { apiRequest } from "@/lib/api-client";
 
-import type { Policy, VHost, VHostCreate, VHostUpdate } from "./types";
+import type { Policy, VHost, VHostCreate, VHostDetail, VHostUpdate } from "./types";
 
 export function listVHosts(token: string, signal?: AbortSignal) {
   return apiRequest<VHost[]>("/vhosts", { token, signal });
+}
+
+export function getVHost(token: string, id: number, signal?: AbortSignal) {
+  return apiRequest<VHostDetail>(`/vhosts/${id}`, { token, signal });
 }
 
 export function createVHost(token: string, body: VHostCreate) {

--- a/src/frontend/src/features/vhosts/types.ts
+++ b/src/frontend/src/features/vhosts/types.ts
@@ -11,6 +11,24 @@ export type VHost = {
   updated_at: string;
 };
 
+export type VHostAssignedPolicy = {
+  id: number;
+  name: string;
+  description: string | null;
+  paranoia_level: 1 | 2 | 3 | 4;
+  inbound_anomaly_threshold: number;
+  outbound_anomaly_threshold: number;
+  enforcement_mode: "block" | "detect_only";
+  is_active: boolean;
+  created_by: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type VHostDetail = VHost & {
+  policy: VHostAssignedPolicy | null;
+};
+
 export type VHostCreate = {
   domain: string;
   backend_url: string;

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as policiesApi from "@/features/policies/api";
+import type { RuleOverride } from "@/features/policies/types";
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as vhostsApi from "@/features/vhosts/api";
+import type { Policy, VHostDetail } from "@/features/vhosts/types";
+
+import { VHostDetailPage } from "./VHostDetailPage";
+
+vi.mock("@/features/vhosts/api");
+vi.mock("@/features/policies/api");
+
+function makeAuthContext(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockPolicies: Policy[] = [
+  { id: 1, name: "Default WAF" },
+  { id: 2, name: "Strict WAF" },
+];
+
+const mockVHost: VHostDetail = {
+  id: 1,
+  domain: "app.example.com",
+  backend_url: "https://backend.internal",
+  description: "Primary app",
+  ssl_enabled: true,
+  is_active: true,
+  policy_id: 1,
+  created_by: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  policy: {
+    id: 1,
+    name: "Default WAF",
+    description: "Default policy",
+    paranoia_level: 2,
+    inbound_anomaly_threshold: 5,
+    outbound_anomaly_threshold: 4,
+    enforcement_mode: "block",
+    is_active: true,
+    created_by: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+  },
+};
+
+const mockOverride: RuleOverride = {
+  id: 10,
+  policy_id: 1,
+  rule_id: 942100,
+  action: "disable",
+  comment: "False positive on search",
+  created_at: "2026-01-03T00:00:00Z",
+};
+
+const mockOverrides: RuleOverride[] = [mockOverride];
+
+function mockSuccessfulLoad(
+  vhost: VHostDetail = mockVHost,
+  overrides: RuleOverride[] = mockOverrides,
+) {
+  vi.mocked(vhostsApi.getVHost).mockResolvedValue(vhost);
+  vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+  vi.mocked(policiesApi.listRuleOverrides).mockResolvedValue(overrides);
+}
+
+function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext(authOverrides)}>
+      <MemoryRouter initialEntries={["/vhosts/1"]}>
+        <Routes>
+          <Route path="/vhosts/:vhostId" element={<VHostDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+}
+
+describe("VHostDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(vhostsApi.updateVHost).mockResolvedValue(mockVHost);
+    vi.mocked(policiesApi.createRuleOverride).mockResolvedValue(mockOverride);
+    vi.mocked(policiesApi.updateRuleOverride).mockResolvedValue(mockOverride);
+    vi.mocked(policiesApi.deleteRuleOverride).mockResolvedValue(undefined);
+  });
+
+  it("shows loading state initially", () => {
+    vi.mocked(vhostsApi.getVHost).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    expect(screen.getByText(/loading virtual host/i)).toBeInTheDocument();
+  });
+
+  it("renders virtual host metadata, assigned policy, and rule overrides", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "app.example.com" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("https://backend.internal")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Default WAF")).toBeInTheDocument();
+    expect(screen.getByText("942100")).toBeInTheDocument();
+    expect(screen.getByText("False positive on search")).toBeInTheDocument();
+  });
+
+  it("shows error state and retries loading", async () => {
+    vi.mocked(vhostsApi.getVHost)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValue(mockVHost);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(policiesApi.listRuleOverrides).mockResolvedValue(mockOverrides);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load virtual host/i)).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "app.example.com" }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows no-policy and no-overrides states", async () => {
+    mockSuccessfulLoad(
+      {
+        ...mockVHost,
+        policy_id: null,
+        policy: null,
+      },
+      [],
+    );
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "app.example.com" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getAllByText(/no policy assigned/i).length).toBeGreaterThan(0);
+    expect(policiesApi.listRuleOverrides).not.toHaveBeenCalled();
+  });
+
+  it("lets admins reassign the policy", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    const policySelect = await screen.findByLabelText("Policy");
+    await userEvent.selectOptions(policySelect, "2");
+    await userEvent.click(screen.getByRole("button", { name: /save policy/i }));
+
+    await waitFor(() =>
+      expect(vhostsApi.updateVHost).toHaveBeenCalledWith("test-token", 1, {
+        policy_id: 2,
+      }),
+    );
+  });
+
+  it("lets admins add and edit rule overrides", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /add override/i }));
+    await userEvent.clear(screen.getByLabelText("Rule ID"));
+    await userEvent.type(screen.getByLabelText("Rule ID"), "941100");
+    await userEvent.selectOptions(screen.getByLabelText("Action"), "enable");
+    await userEvent.type(screen.getByLabelText("Comment"), "Enable legacy rule");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.createRuleOverride).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        {
+          rule_id: 941100,
+          action: "enable",
+          comment: "Enable legacy rule",
+        },
+      ),
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByLabelText("Action"), "enable");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.updateRuleOverride).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        10,
+        {
+          rule_id: 942100,
+          action: "enable",
+          comment: "False positive on search",
+        },
+      ),
+    );
+  });
+
+  it("lets admins delete rule overrides", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Delete" }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(policiesApi.deleteRuleOverride).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        10,
+      ),
+    );
+  });
+
+  it("keeps viewer role read-only", async () => {
+    mockSuccessfulLoad();
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(false), role: "viewer" });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "app.example.com" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /save policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add override/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -1,14 +1,659 @@
+import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
-import { PagePlaceholder } from "@/components/shared/PagePlaceholder";
+import type { DataTableColumn } from "@/components/shared/DataTable";
+import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { Modal } from "@/components/shared/Modal";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { StatusBadge } from "@/components/shared/StatusBadge";
+import {
+  createRuleOverride,
+  deleteRuleOverride,
+  listRuleOverrides,
+  updateRuleOverride,
+} from "@/features/policies/api";
+import type {
+  RuleOverride,
+  RuleOverrideCreate,
+  RuleOverrideUpdate,
+} from "@/features/policies/types";
+import { getVHost, listPolicies, updateVHost } from "@/features/vhosts/api";
+import type { Policy, VHostDetail } from "@/features/vhosts/types";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+type OverrideModalState =
+  | null
+  | { type: "create"; policyId: number }
+  | { type: "edit"; policyId: number; override: RuleOverride }
+  | { type: "delete"; policyId: number; override: RuleOverride };
+
+type RuleOverrideFormModalProps = {
+  mode: "create" | "edit";
+  policyId: number;
+  override?: RuleOverride;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function RuleOverrideFormModal({
+  mode,
+  policyId,
+  override,
+  onSuccess,
+  onClose,
+}: RuleOverrideFormModalProps) {
+  const { accessToken } = useAuth();
+  const [ruleId, setRuleId] = useState(String(override?.rule_id ?? ""));
+  const [action, setAction] = useState<"enable" | "disable">(
+    override?.action ?? "disable",
+  );
+  const [comment, setComment] = useState(override?.comment ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    const parsedRuleId = Number(ruleId);
+    if (!Number.isInteger(parsedRuleId) || parsedRuleId <= 0) {
+      setServerError("Rule ID must be greater than 0");
+      return;
+    }
+
+    setSubmitting(true);
+    setServerError(null);
+
+    const body: RuleOverrideCreate | RuleOverrideUpdate = {
+      rule_id: parsedRuleId,
+      action,
+      comment: comment || null,
+    };
+
+    try {
+      if (mode === "edit" && override) {
+        await updateRuleOverride(accessToken, policyId, override.id, body);
+      } else {
+        await createRuleOverride(accessToken, policyId, body as RuleOverrideCreate);
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={mode === "create" ? "Add rule override" : "Edit rule override"}
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="rule-override-form"
+            disabled={submitting}
+            className="btn-primary px-4 py-2 text-sm"
+          >
+            {submitting ? "Saving..." : "Save"}
+          </button>
+        </>
+      }
+    >
+      <form
+        id="rule-override-form"
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-4"
+      >
+        {serverError && (
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+          >
+            {serverError}
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <label htmlFor="rule-override-rule-id" className="block text-sm font-medium text-fg-muted">
+            Rule ID
+          </label>
+          <input
+            id="rule-override-rule-id"
+            type="number"
+            required
+            min={1}
+            value={ruleId}
+            onChange={(e) => setRuleId(e.target.value)}
+            className="input-field"
+            placeholder="942100"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="rule-override-action" className="block text-sm font-medium text-fg-muted">
+            Action
+          </label>
+          <select
+            id="rule-override-action"
+            value={action}
+            onChange={(e) => setAction(e.target.value as "enable" | "disable")}
+            className="input-field"
+          >
+            <option value="enable">Enable</option>
+            <option value="disable">Disable</option>
+          </select>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="rule-override-comment" className="block text-sm font-medium text-fg-muted">
+            Comment
+          </label>
+          <input
+            id="rule-override-comment"
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            className="input-field"
+            placeholder="Optional"
+          />
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+type DeleteRuleOverrideDialogProps = {
+  policyId: number;
+  override: RuleOverride;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+function DeleteRuleOverrideDialog({
+  policyId,
+  override,
+  onSuccess,
+  onClose,
+}: DeleteRuleOverrideDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    try {
+      await deleteRuleOverride(accessToken, policyId, override.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete rule override"
+      onClose={onClose}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            className="rounded-[var(--radius-md)] bg-error px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? "Deleting..." : "Delete"}
+          </button>
+        </>
+      }
+    >
+      {serverError && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+        >
+          {serverError}
+        </div>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete the override for rule{" "}
+        <span className="font-semibold text-fg">{override.rule_id}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}
 
 export function VHostDetailPage() {
   const { vhostId } = useParams();
+  const { accessToken, hasRole } = useAuth();
+  const [vhost, setVHost] = useState<VHostDetail | null>(null);
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [ruleOverrides, setRuleOverrides] = useState<RuleOverride[]>([]);
+  const [selectedPolicyId, setSelectedPolicyId] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [policyError, setPolicyError] = useState<string | null>(null);
+  const [savingPolicy, setSavingPolicy] = useState(false);
+  const [overrideModal, setOverrideModal] = useState<OverrideModalState>(null);
+  const refreshCountRef = useRef(0);
+  const isAdmin = hasRole("admin");
+
+  const load = useCallback(() => {
+    if (!accessToken) return;
+
+    const parsedVHostId = Number(vhostId);
+    if (!Number.isInteger(parsedVHostId) || parsedVHostId <= 0) {
+      setError("Invalid virtual host ID");
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+    setPolicyError(null);
+
+    Promise.all([
+      getVHost(accessToken, parsedVHostId, controller.signal),
+      listPolicies(accessToken, controller.signal),
+    ])
+      .then(async ([vhostDetail, policyList]) => {
+        let overrides: RuleOverride[] = [];
+
+        if (vhostDetail.policy_id != null) {
+          overrides = await listRuleOverrides(
+            accessToken,
+            vhostDetail.policy_id,
+            controller.signal,
+          );
+        }
+
+        if (generation !== refreshCountRef.current) return;
+        setVHost(vhostDetail);
+        setPolicies(policyList);
+        setRuleOverrides(overrides);
+        setSelectedPolicyId(
+          vhostDetail.policy_id != null ? String(vhostDetail.policy_id) : "",
+        );
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load virtual host");
+        setIsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [accessToken, vhostId]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  async function handlePolicySave() {
+    if (!accessToken || !vhost) return;
+
+    setSavingPolicy(true);
+    setPolicyError(null);
+
+    try {
+      await updateVHost(accessToken, vhost.id, {
+        policy_id: selectedPolicyId ? Number(selectedPolicyId) : null,
+      });
+      load();
+    } catch (err) {
+      setPolicyError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSavingPolicy(false);
+    }
+  }
+
+  function closeOverrideModalAndRefresh() {
+    setOverrideModal(null);
+    load();
+  }
+
+  const overrideColumns: DataTableColumn<RuleOverride>[] = [
+    { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
+    {
+      key: "action",
+      header: "Action",
+      cell: (row) => (
+        <StatusBadge
+          label={row.action === "enable" ? "Enabled" : "Disabled"}
+          tone={row.action === "enable" ? "success" : "warning"}
+        />
+      ),
+    },
+    {
+      key: "comment",
+      header: "Comment",
+      cell: (row) =>
+        row.comment ? (
+          <span>{row.comment}</span>
+        ) : (
+          <span className="text-fg-subtle">None</span>
+        ),
+    },
+    {
+      key: "created_at",
+      header: "Created",
+      cell: (row) => (
+        <span className="text-fg-muted">{formatDate(row.created_at)}</span>
+      ),
+    },
+    ...(isAdmin && vhost?.policy_id != null
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: RuleOverride) => (
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setOverrideModal({
+                      type: "edit",
+                      policyId: vhost.policy_id as number,
+                      override: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setOverrideModal({
+                      type: "delete",
+                      policyId: vhost.policy_id as number,
+                      override: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft"
+                >
+                  Delete
+                </button>
+              </div>
+            ),
+          } satisfies DataTableColumn<RuleOverride>,
+        ]
+      : []),
+  ];
+
+  const selectedPolicyChanged =
+    selectedPolicyId !== (vhost?.policy_id != null ? String(vhost.policy_id) : "");
+  const assignedPolicyName =
+    vhost?.policy?.name ??
+    policies.find((policy) => String(policy.id) === selectedPolicyId)?.name ??
+    null;
 
   return (
-    <PagePlaceholder
-      title={`VHost detail placeholder${vhostId ? ` #${vhostId}` : ""}`}
-      description="This route proves we already support a dedicated detail view. Later it can become a read-only page or a drawer entry point for the assigned team task."
-    />
+    <section className="space-y-8">
+      <PageHeader
+        title={vhost ? vhost.domain : "Virtual host detail"}
+        description={vhost?.description ?? undefined}
+      />
+
+      {isLoading ? (
+        <LoadingState label="Loading virtual host..." />
+      ) : error ? (
+        <ErrorState
+          title="Failed to load virtual host"
+          description={error}
+          action={
+            <button
+              type="button"
+              onClick={load}
+              className="btn-ghost px-4 py-2 text-sm"
+            >
+              Retry
+            </button>
+          }
+        />
+      ) : vhost ? (
+        <>
+          <SectionCard
+            title="Virtual host"
+            description="Domain, backend target, and routing status."
+          >
+            <dl className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm sm:grid-cols-2 lg:grid-cols-3">
+              <div>
+                <dt className="font-medium text-fg-muted">Domain</dt>
+                <dd className="mt-1 font-medium text-fg">{vhost.domain}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Backend URL</dt>
+                <dd className="mt-1 break-all font-mono text-xs text-fg">
+                  {vhost.backend_url}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Status</dt>
+                <dd className="mt-1">
+                  <StatusBadge
+                    label={vhost.is_active ? "Active" : "Inactive"}
+                    tone={vhost.is_active ? "success" : "warning"}
+                  />
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">SSL</dt>
+                <dd className="mt-1">
+                  <StatusBadge
+                    label={vhost.ssl_enabled ? "Enabled" : "Disabled"}
+                    tone={vhost.ssl_enabled ? "success" : "warning"}
+                  />
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Created</dt>
+                <dd className="mt-1 text-fg">{formatDate(vhost.created_at)}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-fg-muted">Updated</dt>
+                <dd className="mt-1 text-fg">{formatDate(vhost.updated_at)}</dd>
+              </div>
+            </dl>
+          </SectionCard>
+
+          <SectionCard
+            title="Assigned policy"
+            description="WAF policy currently attached to this virtual host."
+          >
+            {policyError && (
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="mb-4 rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
+              >
+                {policyError}
+              </div>
+            )}
+
+            {isAdmin ? (
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <label htmlFor="vhost-policy-assignment" className="block text-sm font-medium text-fg-muted">
+                    Policy
+                  </label>
+                  <select
+                    id="vhost-policy-assignment"
+                    value={selectedPolicyId}
+                    onChange={(e) => setSelectedPolicyId(e.target.value)}
+                    className="input-field"
+                  >
+                    <option value="">None</option>
+                    {policies.map((policy) => (
+                      <option key={policy.id} value={String(policy.id)}>
+                        {policy.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <button
+                  type="button"
+                  disabled={!selectedPolicyChanged || savingPolicy}
+                  onClick={() => void handlePolicySave()}
+                  className="btn-primary px-4 py-2 text-sm disabled:opacity-50"
+                >
+                  {savingPolicy ? "Saving..." : "Save policy"}
+                </button>
+              </div>
+            ) : (
+              <p className="text-sm text-fg">
+                {assignedPolicyName ?? (
+                  <span className="text-fg-subtle">No policy assigned</span>
+                )}
+              </p>
+            )}
+
+            {vhost.policy ? (
+              <dl className="mt-5 grid grid-cols-2 gap-x-8 gap-y-4 text-sm sm:grid-cols-4">
+                <div>
+                  <dt className="font-medium text-fg-muted">Enforcement</dt>
+                  <dd className="mt-1">
+                    <StatusBadge
+                      label={
+                        vhost.policy.enforcement_mode === "block"
+                          ? "Block"
+                          : "Detect only"
+                      }
+                      tone={
+                        vhost.policy.enforcement_mode === "block"
+                          ? "info"
+                          : "warning"
+                      }
+                    />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-fg-muted">Policy status</dt>
+                  <dd className="mt-1">
+                    <StatusBadge
+                      label={vhost.policy.is_active ? "Active" : "Inactive"}
+                      tone={vhost.policy.is_active ? "success" : "warning"}
+                    />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-fg-muted">Paranoia level</dt>
+                  <dd className="mt-1 text-fg">{vhost.policy.paranoia_level}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-fg-muted">Inbound threshold</dt>
+                  <dd className="mt-1 text-fg">
+                    {vhost.policy.inbound_anomaly_threshold}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="mt-5 text-sm text-fg-muted">No policy assigned</p>
+            )}
+          </SectionCard>
+
+          <SectionCard
+            title="Rule overrides"
+            description="Individual CRS rules enabled or disabled for the assigned policy."
+            actions={
+              isAdmin && vhost.policy_id != null ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setOverrideModal({
+                      type: "create",
+                      policyId: vhost.policy_id as number,
+                    })
+                  }
+                  className="btn-primary px-4 py-2 text-sm"
+                >
+                  Add override
+                </button>
+              ) : undefined
+            }
+          >
+            {vhost.policy_id == null ? (
+              <div className="rounded-[var(--radius-lg)] border border-border bg-surface px-4 py-6 text-sm text-fg-muted">
+                No policy assigned
+              </div>
+            ) : (
+              <DataTable
+                columns={overrideColumns}
+                rows={ruleOverrides}
+                getRowKey={(row) => String(row.id)}
+                emptyTitle="No rule overrides"
+                emptyDescription="All CRS rules follow the assigned policy settings."
+              />
+            )}
+          </SectionCard>
+
+          {overrideModal?.type === "create" && (
+            <RuleOverrideFormModal
+              mode="create"
+              policyId={overrideModal.policyId}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+
+          {overrideModal?.type === "edit" && (
+            <RuleOverrideFormModal
+              mode="edit"
+              policyId={overrideModal.policyId}
+              override={overrideModal.override}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+
+          {overrideModal?.type === "delete" && (
+            <DeleteRuleOverrideDialog
+              policyId={overrideModal.policyId}
+              override={overrideModal.override}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+        </>
+      ) : null}
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the VHost detail placeholder with a real metadata, policy assignment, and rule override view.
- Add frontend API and type contracts for VHost detail and rule override CRUD.
- Add focused tests for loading, permissions, policy reassignment, and override management.

Closes #198

## Validation
- pnpm run type-check
- pnpm run lint
- pnpm test