### PR TITLE
Fix runtime seeding and HAProxy reload access for smoke e2e

### DIFF
--- a/deploy/docker/docker-compose.debug.yml
+++ b/deploy/docker/docker-compose.debug.yml
@@ -9,7 +9,7 @@ services:
       [
         "sh",
         "-c",
-        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -d -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -d -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
       ]
 
   coraza:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       [
         "sh",
         "-c",
-        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,660,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
       ]
     restart: unless-stopped
     depends_on:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       backend:
         condition: service_healthy
       coraza:
-        condition: service_started
+        condition: service_healthy
     volumes:
       - coraza_audit:/var/log/coraza:ro
       - shipper_state:/var/lib/log-shipper

--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
-runtime_dir="${GUARD_PROXY_RUNTIME_DIR:-/runtime}"
+# Must match RUNTIME_GENERATED_CONFIG_ROOT so the shared volume Coraza mounts at
+# /runtime is seeded before Coraza starts.
+runtime_dir="${GUARD_PROXY_RUNTIME_DIR:-${RUNTIME_GENERATED_CONFIG_ROOT:-/runtime}}"
 
 seed_runtime_config() {
     if [ ! -f "${runtime_dir}/current/rule-overrides.conf" ]; then

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -42,6 +42,28 @@ def test_default_docker_compose_starts_haproxy_before_coraza_is_healthy() -> Non
     assert '"${HAPROXY_HTTP_PORT:-8080}:80"' in compose
 
 
+def test_backend_runtime_config_env_matches_readiness_probe() -> None:
+    compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
+
+    assert "RUNTIME_GENERATED_CONFIG_ROOT: /var/lib/guard-proxy/generated" in compose
+
+
+def test_backend_entrypoint_seeds_runtime_generated_config_root() -> None:
+    entrypoint = (REPO_ROOT / "src/backend/docker-entrypoint.sh").read_text()
+
+    assert (
+        'runtime_dir="${GUARD_PROXY_RUNTIME_DIR:-'
+        '${RUNTIME_GENERATED_CONFIG_ROOT:-/runtime}}"'
+    ) in entrypoint
+
+
+def test_haproxy_master_socket_is_accessible_to_backend_container() -> None:
+    compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
+
+    assert "/var/run/haproxy/master.sock,mode,666,level,operator" in compose
+    assert "/var/run/haproxy/master.sock,mode,660" not in compose
+
+
 def test_debug_coraza_spoa_config_enables_debug_logging() -> None:
     config = (REPO_ROOT / "configs/coraza/coraza-spoa.debug.yaml").read_text()
 
@@ -52,7 +74,10 @@ def test_debug_coraza_spoa_config_enables_debug_logging() -> None:
 def test_debug_compose_override_enables_haproxy_debug_flag() -> None:
     compose = (REPO_ROOT / "deploy/docker/docker-compose.debug.yml").read_text()
 
-    assert "exec haproxy -d -W -S /var/run/haproxy/master.sock" in compose
+    assert (
+        "exec haproxy -d -W -S "
+        "/var/run/haproxy/master.sock,mode,666,level,operator"
+    ) in compose
     assert "-f /etc/haproxy/generated/current/haproxy.cfg" in compose
 
 

--- a/src/backend/tests/unit/test_waf_debug_reference_config.py
+++ b/src/backend/tests/unit/test_waf_debug_reference_config.py
@@ -37,8 +37,9 @@ def test_default_docker_compose_does_not_use_debug_flag() -> None:
 def test_default_docker_compose_starts_haproxy_before_coraza_is_healthy() -> None:
     compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
 
-    assert "coraza:\n        condition: service_started" in compose
-    assert "coraza:\n        condition: service_healthy" not in compose
+    haproxy_block = compose.split("\n  haproxy:")[1].split("\nnetworks:")[0]
+    assert "coraza:\n        condition: service_started" in haproxy_block
+    assert "coraza:\n        condition: service_healthy" not in haproxy_block
     assert '"${HAPROXY_HTTP_PORT:-8080}:80"' in compose
 
 
@@ -62,6 +63,13 @@ def test_haproxy_master_socket_is_accessible_to_backend_container() -> None:
 
     assert "/var/run/haproxy/master.sock,mode,666,level,operator" in compose
     assert "/var/run/haproxy/master.sock,mode,660" not in compose
+
+
+def test_default_docker_compose_starts_log_shipper_after_coraza_is_healthy() -> None:
+    compose = (REPO_ROOT / "deploy/docker/docker-compose.yml").read_text()
+
+    log_shipper_block = compose.split("\n  log-shipper:")[1].split("\n  haproxy:")[0]
+    assert "coraza:\n        condition: service_healthy" in log_shipper_block
 
 
 def test_debug_coraza_spoa_config_enables_debug_logging() -> None:


### PR DESCRIPTION
## Summary
- Seed the backend runtime config from `RUNTIME_GENERATED_CONFIG_ROOT` as well as `GUARD_PROXY_RUNTIME_DIR` so Coraza gets `/runtime/current/rule-overrides.conf` from the shared volume.
- Allow the backend container to reload HAProxy by making the master socket accessible from the non-root service user.
- Add regression coverage for the runtime env fallback and HAProxy socket mode in the reference config tests.

## Testing
- `uv run pytest tests/unit/test_waf_debug_reference_config.py tests/integration/test_health_router.py`
- `uv run pytest -m e2e tests/e2e/test_policy_apply.py`
- `HAPROXY_HTTP_PORT=51808 bash benchmarks/smoke/e2e.sh`