### PR TITLE
docs: reframe WAF effectiveness as reported observations, not pass/fail gates

### DIFF
--- a/README.testing.md
+++ b/README.testing.md
@@ -11,11 +11,36 @@
 
 ## WAF Testing
 
-### Detection Targets (draft)
-- SQL Injection: >95% detection rate
-- XSS: >95% detection rate
-- Path Traversal: >95% detection rate
-- False positive rate: <10%
+### WAF effectiveness — reported, not gated
+
+Detection and false-positive rates are properties of the **CRS ruleset, paranoia
+level, and per-application tuning** — not of Guard Proxy itself. Guard Proxy's job
+is to wire HAProxy to Coraza correctly and make that policy *manageable*. So these
+numbers are **measured and reported against a pinned baseline**, never enforced as
+pass/fail gates and never used as a project SLO.
+
+Every effectiveness measurement records its baseline so it is reproducible:
+- CRS version: the pinned `configs/coraza/crs` submodule commit (record tag/SHA)
+- Paranoia level + thresholds: PL1, default anomaly thresholds (inbound 5 / outbound 4)
+- Corpus: `benchmarks/payloads/` (sqli.txt, xss.txt, legitimate.txt)
+
+Reported per run, alongside the baseline above:
+- True-positive (detection) rate per attack class — SQLi, XSS, path traversal
+- False-positive rate on the benign corpus
+- **Tuning effect**: FP rate *before vs after* applying a rule override (and, post-MVP,
+  an app exclusion profile) on the same corpus — the delta is the result, not the absolute
+
+These are observations about a given CRS configuration, reported for transparency and
+to demonstrate the tuning workflow. Guard Proxy does not claim to improve detection
+beyond what the configured ruleset provides.
+
+### What CI actually enforces (functional, not statistical)
+
+CI gates assert behavior the project *owns*, so they stay stable as the ruleset evolves:
+- A known attack request is blocked (403) — smoke test
+- A known benign request is allowed (200) — smoke test
+- Toggling a CRS rule via the panel changes live request behavior — policy apply e2e (rule `913100`)
+- WAF overhead stays under 20% — performance benchmarks
 
 ### End-to-End Smoke
 

--- a/docs/course-project-report.md
+++ b/docs/course-project-report.md
@@ -16,6 +16,21 @@ Glownym celem projektu jest zarzadzanie konfiguracja WAF z poziomu panelu:
 - odbieranie i przegladanie logow zdarzen WAF,
 - zabezpieczenie panelu przez logowanie i role uzytkownikow.
 
+Cele dodatkowe (mierzalne i raportowane, nie gwarantowane):
+
+- wykazanie, ze integracja HAProxy–Coraza przez SPOE nie degraduje skutecznosci
+  regul CRS w stosunku do ich referencyjnego dzialania (fidelity),
+- zmierzenie narzutu czasowego warstwy WAF wzgledem ruchu bez inspekcji i wykazanie,
+  ze pozostaje on ponizej akceptowalnego progu,
+- zademonstrowanie, ze wylaczenie lub modyfikacja reguly przez panel zmienia
+  obserwowalne zachowanie WAF na ustalonym korpusie testowym.
+
+Poziom wykrywalnosci atakow oraz wspolczynnik false positive nie sa celami
+projektowymi — sa wlasciwoscia zestawu reguł CRS i wybranego poziomu paranoi,
+nie systemu Guard Proxy. Odpowiednie wartosci sa mierzone i raportowane
+wzgledem okreslonego punktu odniesienia (wersja CRS, poziom paranoi, korpus
+testowy), nie egzekwowane jako proby zaliczenia.
+
 ## 2. Zastosowane technologie
 
 | Warstwa | Technologie |
@@ -285,14 +300,32 @@ razem z dwiema prostymi aplikacjami HTTP echo za WAF-em. Pozwala to pokazac:
 ## 12. Testy
 
 Backend ma testy jednostkowe i integracyjne w `src/backend/tests`. Frontend ma
-testy komponentow i klienta API w `src/frontend/src`. Dodatkowo istnieje smoke
-test end-to-end dla stacka Docker Compose.
+testy komponentow i klienta API w `src/frontend/src`. Dodatkowo istnieja testy
+end-to-end dla stacka Docker Compose.
+
+Testy dziel sie na dwie kategorie:
+
+**Bramy zaliczenia (pass/fail, egzekwowane w CI):**
+- Znany payload ataku jest blokowany (403) — smoke test,
+- Znany benign request przechodzi (200) — smoke test,
+- Wylaczenie i ponowne wlaczenie reguly przez panel zmienia zachowanie WAF na
+  zywo (e2e test `test_policy_apply.py`, regula `913100`),
+- Narzut WAF ponizej 20% — testy wydajnosciowe.
+
+**Pomiary raportowane (nie egzekwowane):**
+- Wspolczynnik wykrycia (TP) per klasa ataku (SQLi, XSS, path traversal),
+- Wspolczynnik false positive na korpusie benign,
+- Delta FP przed i po zastosowaniu override reguly na ustalonym korpusie.
+
+Kazdy pomiar raportowany jest zapisywany razem z punktem odniesienia: commit
+submodulu CRS, poziom paranoi, progi anomalii.
 
 Przykladowe komendy:
 
 ```bash
 cd src/backend
 uv run pytest
+uv run pytest -m e2e tests/e2e/test_policy_apply.py
 ```
 
 ```bash
@@ -302,7 +335,35 @@ pnpm run type-check
 pnpm run lint
 ```
 
-## 13. Screenshoty
+```bash
+bash benchmarks/smoke/e2e.sh
+```
+
+## 13. Plan ewaluacji
+
+Ewaluacja projektu obejmuje dwie klasy pomiarow: bramy zaliczenia (egzekwowane w CI)
+oraz obserwacje raportowane (mierzone na ustalonym korpusie i zapisywane z punktem
+odniesienia, nie uzywane jako kryterium zdania).
+
+| ID | Co mierzymy | Jak | Typ |
+|----|-------------|-----|-----|
+| E1 | Poprawnosc funkcjonalna zarzadzania | e2e: utworzenie vhosta → polityki → zastosowanie → rollback; toggle reguly widoczny w zachowaniu live | **Brama (pass/fail)** |
+| E2 | Fidelity integracji | Replay korpusu atakow i benign przez proxy; raport TP per klasa + FP z zapisanym SHA submodulu CRS, PL i progami | **Raportowane** |
+| E3 | Narzut wydajnosciowy | wrk/k6: latencja p50/p95/p99 + przepustowosc, WAF-on vs WAF-bypass | **Brama (<20% narzutu)** |
+| E4 | Skutecznosc tuningu | FP na korpusie WordPress przed i po overridzie reguly; wynik to delta, nie wartosc bezwzgledna | **Raportowane (delta)** |
+| E5 | Porownanie referencyjne (M6, opcjonalne) | Ten sam korpus przez Guard Proxy vs raw Coraza/standalone — brak degradacji fidelity | **Raportowane** |
+
+### Punkt odniesienia dla E2, E4, E5
+
+Kazdy raport zapisuje:
+
+- SHA commitu submodulu `configs/coraza/crs` (wersja CRS),
+- poziom paranoi i progi anomalii (domyslnie PL1, inbound 5, outbound 4),
+- korpus testowy (`benchmarks/payloads/`: sqli.txt, xss.txt, legitimate.txt).
+
+Bez tych danych wyniki nie sa porownywalne miedzyokresowo.
+
+## 15. Screenshoty
 
 Do uzupelnienia przed oddaniem projektu:
 


### PR DESCRIPTION
## Summary

- **Remove** the `Detection Targets (draft)` block from `README.testing.md` — the `TPR >95%` and `FPR <10%` thresholds were framed as CI gates but those numbers are properties of the CRS ruleset and paranoia level, not of Guard Proxy itself.
- **Replace** with a two-section block: what is *reported* (measured against a pinned baseline with CRS SHA, PL, and corpus recorded) vs what CI *actually enforces* (functional block/allow assertions + RPS overhead gate).
- **Update** `docs/course-project-report.md` to match: new "Cele dodatkowe" block in §1, split test taxonomy in §12, and a new §13 "Plan ewaluacji" table (E1–E5, gate vs reported).

## Why

Enforcing absolute TPR/FPR thresholds as pass/fail gates would couple CI to CRS rule quality — something Guard Proxy doesn't control. The right framing is: Guard Proxy owns the *wiring* and *management* correctness; CRS owns detection quality. The thesis evaluation should *report* effectiveness measurements against a pinned baseline, not gate builds on them.

The key thesis finding is now framed as the **before/after FP delta** from applying a rule override on a fixed corpus — a reproducible, owned result that demonstrates the tuning workflow works.

## What CI still enforces (unchanged behaviour)

- Known attack → blocked (403) — smoke test
- Known benign → passes (200) — smoke test
- Rule toggle via panel changes live WAF behaviour — policy apply e2e
- WAF overhead < 20% RPS degradation — performance benchmarks

## Related

- GitHub issue [#227](https://github.com/bihius/guard-proxy/issues/227) — post-MVP policy profiles feature (app-specific CRS exclusion profiles) created in this session; not part of this PR.
- `thesis/evaluation-plan.md` §7 also updated (file is gitignored — lives outside the repo).

## Test plan

- [x] README.testing.md renders correctly — no broken markdown, section headers make sense
- [x] course-project-report.md new §13 table displays correctly
- [x] No other files reference the removed `<10%` / `>95%` thresholds (confirmed by grep — none found)
