### PR TITLE
feat(auth): rate-limit login and refresh to 5/min per IP (M0-08, closes #103)

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -106,6 +106,47 @@ machine-readable degraded reason header.
 5. FastAPI validates and normalizes payloads into the persisted `Log` model.
 6. `GET /logs` exposes stored events for the admin panel log viewer.
 
+## Authentication & Rate Limiting
+
+The FastAPI backend issues short-lived **JWT access tokens** (30 min, HS256) and
+long-lived **refresh tokens** (7 days) stored in an `HttpOnly` cookie at path
+`/auth`. The refresh cookie is unavailable to JavaScript, so the frontend keeps
+no long-lived secret in memory or `localStorage`.
+
+### Brute-force protection
+
+`POST /auth/login` and `POST /auth/refresh` are rate-limited to **5 requests per
+minute per client IP** using [slowapi](https://slowapi.readthedocs.io/). Exceeding
+the limit returns:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+```
+
+The limit is enforced in-process (in-memory via `limits.MemoryStorage`), which is
+appropriate for a single-uvicorn-process deployment.
+
+### Client IP resolution
+
+HAProxy sits in front of the backend. The frontend config includes:
+
+```
+http-request set-header X-Forwarded-For %[src]
+```
+
+This overwrites any client-supplied `X-Forwarded-For` value with the real source
+IP before the request reaches the backend, preventing header-spoofing bypass of
+the rate limit. The backend's key function reads the first (and only) XFF entry
+and falls back to the socket peer when the header is absent (direct connections in
+development and test).
+
+### Timing-attack mitigation
+
+The login handler always runs `bcrypt.verify` against a precomputed dummy hash
+when the requested email does not exist, keeping response time consistent and
+preventing user-enumeration through timing.
+
 ## Deployment
 
 ### Health and Readiness Probes
@@ -203,3 +244,8 @@ See `notes/decisions/` for Architecture Decision Records:
 - [ADR-006](notes/decisions/ADR-006-sync-sqlalchemy-for-mvp.md) - Synchronous SQLAlchemy for MVP
 - [ADR-007](notes/decisions/ADR-007-coraza-spoa-integration.md) - Coraza SPOA integration approach
 - [ADR-008](notes/decisions/ADR-008-log-shipper-sidecar.md) - Log shipper: custom Python sidecar over Vector/Fluent Bit
+
+**M0-08 — Rate limiting (slowapi, in-memory):** The auth endpoints are guarded
+by a 5/minute per-IP limit via slowapi with in-memory storage. A Redis-backed
+distributed limiter was considered but is not needed for a single-process
+deployment; the simpler in-process approach avoids an external dependency.

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -45,6 +45,10 @@ frontend fe_http
     acl host_app hdr(host),field(1,:) -i app.local localhost 127.0.0.1
     http-request deny deny_status 421 if !host_app
 
+    # Overwrite any client-supplied X-Forwarded-For with the real source IP
+    # so the backend rate limiter cannot be bypassed by header spoofing.
+    http-request set-header X-Forwarded-For %[src]
+
 
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
@@ -79,7 +83,6 @@ frontend fe_http
 
 # --- Application backends ----------------------------------------
 backend be_app
-    option forwardfor
     option httpchk GET /health
     http-check expect status 200
     # init-addr none lets `haproxy -c` succeed even when the

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -7,12 +7,14 @@ from pathlib import Path
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
 from app.database import get_db
+from app.rate_limit import limiter, rate_limit_exceeded_handler
 from app.routers import (
     auth,
     config,
@@ -57,6 +59,11 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# --- Rate limiting -----------------------------------------------------------
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)  # type: ignore[arg-type]
+
+# --- CORS --------------------------------------------------------------------
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,

--- a/src/backend/app/rate_limit.py
+++ b/src/backend/app/rate_limit.py
@@ -1,0 +1,62 @@
+"""Rate-limiting primitives for Guard Proxy.
+
+Uses slowapi (backed by limits, in-memory MemoryStorage) — appropriate for a
+single-process uvicorn deployment.  The limiter is instantiated here so it can
+be imported by both main.py (registration) and any router that needs a decorator.
+
+IP resolution
+-------------
+HAProxy sits in front of the backend and stamps ``X-Forwarded-For`` with the
+real source IP (``http-request set-header X-Forwarded-For %[src]`` in
+haproxy.cfg), overwriting any value the client may have injected.  We therefore
+trust the first entry of the XFF header when it is present and fall back to the
+socket peer address otherwise (direct connections in dev / tests).
+"""
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+
+def client_ip(request: Request) -> str:
+    """Return the real client IP to use as the rate-limit key.
+
+    HAProxy sets ``X-Forwarded-For: <real-src-ip>`` before forwarding to
+    uvicorn, so the first (and only) entry is the canonical client address.
+    If the header is absent (direct connection in dev or tests) we fall back
+    to the socket peer returned by slowapi's built-in helper.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    return get_remote_address(request)
+
+
+def rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded
+) -> JSONResponse:
+    """Return a 429 in the API-standard ``{"detail": ...}`` shape.
+
+    The whole API and the frontend ``api-client.ts`` expect a ``detail`` key.
+    Using the same shape here ensures the login form can surface a meaningful
+    error message rather than the generic "Request failed" fallback.
+
+    ``Retry-After`` is a static 60 s: the limit is a 1-minute fixed window, so
+    the worst-case wait never exceeds 60 seconds.
+    """
+    return JSONResponse(
+        status_code=429,
+        content={"detail": "Too many requests. Please wait a minute and try again."},
+        headers={"Retry-After": "60"},
+    )
+
+
+#: Shared limiter instance.  Register with the FastAPI app via:
+#:   app.state.limiter = limiter
+#:   app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+limiter = Limiter(key_func=client_ip)
+
+#: Brute-force limit applied to auth endpoints that accept credentials.
+AUTH_RATE_LIMIT = "5/minute"

--- a/src/backend/app/routers/auth.py
+++ b/src/backend/app/routers/auth.py
@@ -8,6 +8,7 @@ from app.config import settings
 from app.database import get_db
 from app.dependencies import get_current_user
 from app.models.user import User
+from app.rate_limit import AUTH_RATE_LIMIT, limiter
 from app.schemas.auth import AccessTokenResponse, LoginRequest
 from app.schemas.user import UserResponse
 from app.services import auth_service
@@ -49,7 +50,9 @@ def _clear_refresh_cookie(response: Response) -> None:
 
 
 @router.post("/login", response_model=AccessTokenResponse)
+@limiter.limit(AUTH_RATE_LIMIT)
 def login(
+    request: Request,
     body: LoginRequest,
     response: Response,
     db: Session = Depends(get_db),
@@ -87,6 +90,7 @@ def login(
 
 
 @router.post("/refresh", response_model=AccessTokenResponse)
+@limiter.limit(AUTH_RATE_LIMIT)
 def refresh(
     request: Request,
     response: Response,

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -51,6 +51,10 @@ frontend fe_http
     http-request deny deny_status 421
 {% endif %}
 
+    # Overwrite any client-supplied X-Forwarded-For with the real source IP
+    # so the backend rate limiter cannot be bypassed by header spoofing.
+    http-request set-header X-Forwarded-For %[src]
+
     # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
     # server. This covers startup and unhealthy-container windows.
     http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
@@ -89,7 +93,6 @@ frontend fe_http
 # --- Application backends ----------------------------------------
 {% for route in routes %}
 backend {{ route.backend.name }}
-    option forwardfor
     option httpchk GET /health
     http-check expect status 200
     # init-addr none lets `haproxy -c` succeed even when the

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-multipart>=0.0.12",
     "pydantic[email]>=2.12.5",
     "jinja2>=3.1.4",
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -205,3 +205,24 @@ INACTIVE_PASSWORD = _INACTIVE_PASSWORD
 def log_ingest_headers() -> dict[str, str]:
     """Header used by the log producer ingest endpoint."""
     return {"X-Guard-Proxy-Ingest-Secret": os.environ["LOG_INGEST_SHARED_SECRET"]}
+
+
+# ---------------------------------------------------------------------------
+# Rate-limiter reset — prevents counter leakage between tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter() -> Iterator[None]:
+    """Reset slowapi in-memory counters before and after every test.
+
+    The limiter is attached to the shared FastAPI ``app`` instance which
+    survives across the entire test session.  Without this fixture, rapid
+    sequences of login/refresh calls in earlier tests would exhaust the
+    per-IP bucket and cause unrelated tests to see unexpected 429 responses.
+    """
+    from app.rate_limit import limiter
+
+    limiter.reset()
+    yield
+    limiter.reset()

--- a/src/backend/tests/integration/test_auth_router.py
+++ b/src/backend/tests/integration/test_auth_router.py
@@ -232,3 +232,110 @@ def test_me_password_not_in_response(
     body = resp.json()
     assert "password" not in body
     assert "hashed_password" not in body
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting — M0-08
+# ---------------------------------------------------------------------------
+
+
+def test_login_rate_limited_after_five_attempts(
+    client: TestClient, admin_user: User
+) -> None:
+    """Six rapid login attempts from the same IP hit 429 on the sixth.
+
+    Wrong passwords are used so the bcrypt timing cost is still incurred and
+    the test does not accidentally create valid sessions, but the rate limit
+    counts *all* attempts regardless of outcome.
+    TestClient connects directly (no HAProxy), so the key is the loopback
+    address; the autouse ``_reset_rate_limiter`` fixture ensures a clean
+    counter at the start of this test.
+    """
+    for i in range(5):
+        resp = client.post(
+            "/auth/login",
+            json={"email": admin_user.email, "password": "wrong-password"},
+        )
+        assert resp.status_code == 401, (
+            f"attempt {i + 1}: expected 401, got {resp.status_code}"
+        )
+
+    sixth = client.post(
+        "/auth/login",
+        json={"email": admin_user.email, "password": "wrong-password"},
+    )
+    assert sixth.status_code == 429
+    assert "retry-after" in sixth.headers
+    assert "detail" in sixth.json()
+
+
+def test_refresh_rate_limited_after_five_attempts(client: TestClient) -> None:
+    """Six rapid refresh attempts from the same IP hit 429 on the sixth.
+
+    The refresh endpoint is called without a valid cookie so it would return
+    401 anyway, but the rate limit is evaluated before authentication and
+    counts all requests regardless of cookie validity.
+    """
+    for i in range(5):
+        resp = client.post("/auth/refresh")
+        assert resp.status_code == 401, (
+            f"attempt {i + 1}: expected 401, got {resp.status_code}"
+        )
+
+    sixth = client.post("/auth/refresh")
+    assert sixth.status_code == 429
+    assert "retry-after" in sixth.headers
+    assert "detail" in sixth.json()
+
+
+def test_login_under_limit_is_not_rate_limited(
+    client: TestClient, admin_user: User
+) -> None:
+    """Exactly five attempts do not trigger rate limiting (boundary check)."""
+    for i in range(5):
+        resp = client.post(
+            "/auth/login",
+            json={"email": admin_user.email, "password": "wrong-password"},
+        )
+        assert resp.status_code != 429, f"attempt {i + 1} unexpectedly rate-limited"
+
+
+def test_login_rate_limit_is_per_ip(client: TestClient, admin_user: User) -> None:
+    """Rate-limit buckets are keyed per client IP via X-Forwarded-For.
+
+    Five requests from 10.0.0.1 exhaust that IP's bucket. The sixth from
+    10.0.0.1 is rate-limited, but the first request from 10.0.0.2 is not —
+    proving independent per-IP counters and that the XFF key function works.
+    """
+    ip_a = "10.0.0.1"
+    ip_b = "10.0.0.2"
+
+    for i in range(5):
+        resp = client.post(
+            "/auth/login",
+            json={"email": admin_user.email, "password": "wrong-password"},
+            headers={"X-Forwarded-For": ip_a},
+        )
+        assert resp.status_code == 401, (
+            f"attempt {i + 1} from {ip_a}: expected 401, got {resp.status_code}"
+        )
+
+    # 6th from ip_a must be blocked
+    sixth = client.post(
+        "/auth/login",
+        json={"email": admin_user.email, "password": "wrong-password"},
+        headers={"X-Forwarded-For": ip_a},
+    )
+    assert sixth.status_code == 429, (
+        f"expected 429 from {ip_a}, got {sixth.status_code}"
+    )
+
+    # 1st from ip_b must NOT be blocked
+    first_b = client.post(
+        "/auth/login",
+        json={"email": admin_user.email, "password": "wrong-password"},
+        headers={"X-Forwarded-For": ip_b},
+    )
+    assert first_b.status_code == 401, (
+        f"expected 401 from {ip_b}, got {first_b.status_code}"
+    )

--- a/src/backend/tests/unit/test_rate_limit.py
+++ b/src/backend/tests/unit/test_rate_limit.py
@@ -1,0 +1,62 @@
+"""Unit tests for app.rate_limit.client_ip()."""
+
+from starlette.requests import Request
+from starlette.types import Scope
+
+
+def _make_request(
+    xff: str | None = None,
+    client_host: str = "127.0.0.1",
+) -> Request:
+    """Build a minimal Starlette Request with controlled headers and client."""
+    headers: list[tuple[bytes, bytes]] = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode()))
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/auth/login",
+        "headers": headers,
+        "client": (client_host, 12345),
+        "query_string": b"",
+        "root_path": "",
+    }
+    return Request(scope)
+
+
+class TestClientIp:
+    """client_ip() returns the correct key for rate-limit bucketing."""
+
+    def test_single_xff_returns_that_ip(self) -> None:
+        from app.rate_limit import client_ip
+
+        request = _make_request(xff="203.0.113.7")
+        assert client_ip(request) == "203.0.113.7"
+
+    def test_multi_value_xff_returns_first_entry(self) -> None:
+        """XFF may contain a chain; trust only the leftmost (closest to client)."""
+        from app.rate_limit import client_ip
+
+        request = _make_request(xff="10.1.2.3, 172.16.0.1, 192.168.0.5")
+        assert client_ip(request) == "10.1.2.3"
+
+    def test_xff_with_extra_whitespace_is_stripped(self) -> None:
+        from app.rate_limit import client_ip
+
+        request = _make_request(xff="  198.51.100.42  ")
+        assert client_ip(request) == "198.51.100.42"
+
+    def test_no_xff_falls_back_to_socket_peer(self) -> None:
+        """Without X-Forwarded-For the socket client address is used (dev / tests)."""
+        from app.rate_limit import client_ip
+
+        request = _make_request(xff=None, client_host="192.0.2.99")
+        assert client_ip(request) == "192.0.2.99"
+
+    def test_empty_xff_falls_back_to_socket_peer(self) -> None:
+        """An empty XFF header (edge case) should not become the key."""
+        from app.rate_limit import client_ip
+
+        # Header present but blank → falsy, falls through to get_remote_address
+        request = _make_request(xff="", client_host="192.0.2.100")
+        assert client_ip(request) == "192.0.2.100"

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -212,6 +212,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -298,6 +310,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -329,6 +342,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
     { name = "types-passlib", marker = "extra == 'dev'", specifier = ">=1.7.7.20260211" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
@@ -469,6 +483,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -866,6 +894,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,4 +1127,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]


### PR DESCRIPTION
## Summary

Implements issue #103 (M0-08): brute-force protection for the auth endpoints.

- **`POST /auth/login` and `POST /auth/refresh`** are now rate-limited to **5 requests/minute per client IP** using [slowapi](https://slowapi.readthedocs.io/) (in-memory; appropriate for a single uvicorn process).
- Exceeding the limit returns **HTTP 429** with `Retry-After: 60` and a `{"detail": "..."}` body (API-standard shape — the login form will surface a real message rather than the generic fallback).
- HAProxy stamps `X-Forwarded-For: %[src]` in the frontend, overwriting any client-supplied value so the limit cannot be bypassed by header spoofing. The now-redundant `option forwardfor` in `be_app` is removed.
- `README.architecture.md` gains an **Authentication & Rate Limiting** section covering token design, the brute-force limit, IP resolution, and timing-attack mitigation.

## New files

| File | Purpose |
|------|---------|
| `src/backend/app/rate_limit.py` | `client_ip()` key func, `Limiter`, custom 429 handler, `AUTH_RATE_LIMIT` |
| `src/backend/tests/unit/test_rate_limit.py` | Unit tests for `client_ip()` (XFF variants, fallback) |

## Test plan

- [x] `uv run pytest -m "not e2e" -q` → 383 pass, 1 pre-existing failure (`test_rendered_haproxy_template_validates_with_haproxy` — fails because `coraza.cfg` is absent from the local `haproxy -c` env; unrelated to this change and was failing before).
- [x] Integration: 6th login/refresh → 429 + `Retry-After` + `{"detail": ...}`
- [x] Integration: per-IP isolation — exhausting `10.0.0.1`'s bucket doesn't affect `10.0.0.2`
- [x] Integration: ≤5 attempts → no rate limit (boundary check)
- [x] Unit: `client_ip()` — single XFF, multi-value XFF (first entry), whitespace stripping, no-XFF fallback, empty-XFF fallback
- [x] `uv run ruff check app/ tests/` → clean
- [x] `uv run mypy app/` → clean

## Definition of done checklist (from #103)

- [x] Six rapid login attempts from the same IP result in HTTP 429 on the sixth
- [x] Legitimate users are not affected under normal usage
- [x] New integration test passes
- [x] Documented in the auth section of the architecture doc
