### PR TITLE
Add Paranoia Level 2 sweep across all benchmark tools and targets

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -103,16 +103,19 @@ eval-sweep:
 
 # ── Results summary ────────────────────────────────────────────────────────
 
-## Print a summary of the most recent run (or RUN_ID= a specific run).
+## Print a summary of the most recent run (or RUN_ID=<id> [POLICY=pl1|pl2] for a specific run).
 results:
-	@latest=$$(ls -1t $(REPO_ROOT)/benchmarks/results/ 2>/dev/null \
-	            | grep '^run-' | head -1 | sed 's/^run-//'); \
-	run=$${RUN_ID:-$$latest}; \
+	@if [[ "$(origin RUN_ID)" == "command line" ]]; then \
+	  run="$(EFFECTIVE_RUN_ID)"; \
+	else \
+	  run=$$(ls -1t $(REPO_ROOT)/benchmarks/results/ 2>/dev/null \
+	          | grep '^run-' | head -1 | sed 's/^run-//'); \
+	fi; \
 	csv="$(REPO_ROOT)/benchmarks/results/run-$${run}/results.csv"; \
 	if [[ -f "$$csv" ]]; then \
 	  echo "Run: $${run}"; column -t -s, "$$csv"; \
 	else \
-	  echo "No results found. Run 'make eval-all RUN_ID=<id>' first."; \
+	  echo "No results found for run-$${run}. Run 'make eval-all RUN_ID=<id> [POLICY=pl1|pl2]' first."; \
 	fi
 
 # ── Help ───────────────────────────────────────────────────────────────────

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -11,8 +11,15 @@ TARGET_VHOST ?=
 DIRECT_HOST  ?= juiceshop
 DIRECT_PORT  ?= 3000
 
+# POLICY selects which WAF policy is active for the run: pl1 (baseline, default)
+# or pl2 (high-paranoia sweep, see benchmarks/lab/.env.example LAB_PL2_POLICY_*).
+POLICY       ?= pl1
+# Each policy pass gets its own results directory: run-<RUN_ID>-pl1 / run-<RUN_ID>-pl2.
+EFFECTIVE_RUN_ID := $(RUN_ID)-$(POLICY)
+
 .PHONY: lab-up lab-down lab-clean \
         eval-ftw eval-corpus eval-zap eval-nuclei eval-load eval-metrics eval-all \
+        set-policy eval-sweep \
         results help
 
 # ── Lab lifecycle ──────────────────────────────────────────────────────────
@@ -38,41 +45,61 @@ lab-clean:
 
 ## CRS regression suite. Reports go-ftw CRS conformance, not TPR/FPR.
 eval-ftw:
-	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(RUN_ID)/ftw
-	RUN_ID=$(RUN_ID) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),ftw.local) \
+	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(EFFECTIVE_RUN_ID)/ftw
+	RUN_ID=$(EFFECTIVE_RUN_ID) POLICY=$(POLICY) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),ftw.local) \
 	  bash $(RUNNERS)/run-ftw.sh
 
 ## Tagged labeled benign/attack corpus (the only clean TP/FN/TN/FP source).
 eval-corpus:
-	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(RUN_ID)/corpus-$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local)
-	RUN_ID=$(RUN_ID) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local) \
+	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(EFFECTIVE_RUN_ID)/corpus-$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local)
+	RUN_ID=$(EFFECTIVE_RUN_ID) POLICY=$(POLICY) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local) \
 	  bash $(RUNNERS)/run-corpus.sh
 
 ## ZAP baseline scan (supplemental scanner-assisted WordPress coverage).
 eval-zap:
-	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(RUN_ID)/zap-$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local)
-	RUN_ID=$(RUN_ID) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local) \
+	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(EFFECTIVE_RUN_ID)/zap-$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local)
+	RUN_ID=$(EFFECTIVE_RUN_ID) POLICY=$(POLICY) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),wp.local) \
 	  bash $(RUNNERS)/run-zap.sh
 
 ## Nuclei CVE templates (supplemental reached-app/bypass evidence).
 eval-nuclei:
-	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(RUN_ID)/nuclei-$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local)
-	RUN_ID=$(RUN_ID) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local) \
+	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(EFFECTIVE_RUN_ID)/nuclei-$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local)
+	RUN_ID=$(EFFECTIVE_RUN_ID) POLICY=$(POLICY) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local) \
 	  bash $(RUNNERS)/run-nuclei.sh
 
 ## Latency + RPS load test (WAF vs direct). Measures overhead.
 eval-load:
-	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(RUN_ID)/load-$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local)
-	RUN_ID=$(RUN_ID) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local) \
+	@mkdir -p $(REPO_ROOT)/benchmarks/results/run-$(EFFECTIVE_RUN_ID)/load-$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local)
+	RUN_ID=$(EFFECTIVE_RUN_ID) POLICY=$(POLICY) TARGET_VHOST=$(if $(TARGET_VHOST),$(TARGET_VHOST),juice.local) \
 	  DIRECT_HOST=$(DIRECT_HOST) DIRECT_PORT=$(DIRECT_PORT) \
 	  bash $(RUNNERS)/run-load.sh
 
 ## Aggregate all scenario outputs into results.csv + report.json.
 eval-metrics:
-	RUN_ID=$(RUN_ID) bash $(RUNNERS)/collect-metrics.sh
+	RUN_ID=$(EFFECTIVE_RUN_ID) bash $(RUNNERS)/collect-metrics.sh
 
 ## Run all scenarios (ftw → corpus → zap → nuclei → load → metrics) in one pass.
+## POLICY=pl1 (default) or POLICY=pl2 selects the active WAF policy; results land
+## in benchmarks/results/run-<RUN_ID>-<POLICY>/.
 eval-all: eval-ftw eval-corpus eval-zap eval-nuclei eval-load eval-metrics
+
+# ── Paranoia level sweep ────────────────────────────────────────────────────
+
+## Switch all lab vhosts to the given POLICY (pl1|pl2) and reload HAProxy/Coraza config.
+set-policy:
+	POLICY=$(POLICY) bash $(REPO_ROOT)/benchmarks/lab/set-policy.sh
+
+## Run the full eval suite at PL1, then switch to PL2 and run it again, sharing
+## one base RUN_ID. Produces run-<id>-pl1/ and run-<id>-pl2/ for side-by-side comparison.
+eval-sweep:
+	@base_run_id=$(RUN_ID); \
+	echo "==> PL1 pass (run-$${base_run_id}-pl1)"; \
+	$(MAKE) set-policy POLICY=pl1; \
+	$(MAKE) eval-all RUN_ID=$${base_run_id} POLICY=pl1; \
+	echo "==> PL2 pass (run-$${base_run_id}-pl2)"; \
+	$(MAKE) set-policy POLICY=pl2; \
+	$(MAKE) eval-all RUN_ID=$${base_run_id} POLICY=pl2; \
+	echo "==> Done. Compare benchmarks/results/run-$${base_run_id}-pl1/results.csv and run-$${base_run_id}-pl2/results.csv"
 
 # ── Results summary ────────────────────────────────────────────────────────
 
@@ -103,9 +130,14 @@ help:
 	@echo ""
 	@echo "Variables:"
 	@echo "  RUN_ID=<id>         Override run ID (default: timestamp)"
+	@echo "  POLICY=pl1|pl2      Active WAF policy (default: pl1). Results go to"
+	@echo "                      benchmarks/results/run-<RUN_ID>-<POLICY>/."
 	@echo "  TARGET_VHOST=<host> Override scenario vhost (defaults: ftw.local/wp.local/juice.local)"
 	@echo "  DIRECT_HOST=<name>  Direct-access Docker service name"
 	@echo "  DIRECT_PORT=<port>  Direct-access port (bypasses HAProxy)"
 	@echo ""
 	@echo "Example (3 runs for thesis median):"
 	@echo "  for i in 1 2 3; do make eval-all; done"
+	@echo ""
+	@echo "Example (PL1 vs PL2 sweep across all tools/targets):"
+	@echo "  make eval-sweep"

--- a/benchmarks/lab/runners/collect-metrics.sh
+++ b/benchmarks/lab/runners/collect-metrics.sh
@@ -105,6 +105,7 @@ for s in summaries:
         "scenario":           scenario,
         "target_vhost":       vhost,
         "policy":             s.get("policy", {}).get("name", ""),
+        "paranoia_level":     s.get("policy", {}).get("paranoia", ""),
         "tpr":                det.get("tpr", ""),
         "fpr":                det.get("fpr", ""),
         "crs_conformance_rate": det.get("crs_conformance_rate", ""),

--- a/benchmarks/lab/runners/lib.sh
+++ b/benchmarks/lab/runners/lib.sh
@@ -42,13 +42,17 @@ LAB_FTW_DOMAIN="$(env_value LAB_FTW_DOMAIN ftw.local)"
 resolve_policy() {
   local policy="${POLICY:-pl1}"
   case "${policy}" in
+    pl1)
+      POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+      POLICY_PARANOIA="$(env_value LAB_POLICY_PARANOIA 1)"
+      ;;
     pl2)
       POLICY_NAME="$(env_value LAB_PL2_POLICY_NAME 'Lab PL2')"
       POLICY_PARANOIA="$(env_value LAB_PL2_POLICY_PARANOIA 2)"
       ;;
-    pl1|*)
-      POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
-      POLICY_PARANOIA="$(env_value LAB_POLICY_PARANOIA 1)"
+    *)
+      echo "Unknown POLICY '${policy}' (expected pl1 or pl2)." >&2
+      exit 1
       ;;
   esac
 }

--- a/benchmarks/lab/runners/lib.sh
+++ b/benchmarks/lab/runners/lib.sh
@@ -34,6 +34,25 @@ LAB_DVWA_DOMAIN="$(env_value LAB_DVWA_DOMAIN dvwa.local)"
 LAB_WP_DOMAIN="$(env_value LAB_WP_DOMAIN wp.local)"
 LAB_FTW_DOMAIN="$(env_value LAB_FTW_DOMAIN ftw.local)"
 
+# ── Policy selection ───────────────────────────────────────────────────────
+
+# Resolve the active policy for this run based on POLICY (pl1|pl2, default pl1).
+# Exports POLICY_NAME and POLICY_PARANOIA from the matching LAB_POLICY_* /
+# LAB_PL2_POLICY_* env vars.
+resolve_policy() {
+  local policy="${POLICY:-pl1}"
+  case "${policy}" in
+    pl2)
+      POLICY_NAME="$(env_value LAB_PL2_POLICY_NAME 'Lab PL2')"
+      POLICY_PARANOIA="$(env_value LAB_PL2_POLICY_PARANOIA 2)"
+      ;;
+    pl1|*)
+      POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+      POLICY_PARANOIA="$(env_value LAB_POLICY_PARANOIA 1)"
+      ;;
+  esac
+}
+
 # ── Directory setup ────────────────────────────────────────────────────────
 
 setup_run_dir() {
@@ -160,6 +179,7 @@ write_summary() {
   local detection_json="$4"      # {"true_positive":...,"false_negative":...,"tpr":...,"fpr":...}
   local performance_json="$5"    # {"rps":...,"latency_ms":...} or {}
   local resources_json="${6:-{}}"
+  local policy_paranoia="${7:-}"
 
   python3 - <<PY
 import json, os
@@ -168,11 +188,19 @@ detection = json.loads('''${detection_json}''')
 performance = json.loads('''${performance_json}''')
 resources = json.loads('''${resources_json}''')
 
+policy = {"name": "${policy_name}"}
+paranoia_raw = "${policy_paranoia}"
+if paranoia_raw != "":
+    try:
+        policy["paranoia"] = int(paranoia_raw)
+    except ValueError:
+        policy["paranoia"] = paranoia_raw
+
 summary = {
     "run_id": "${RUN_ID}",
     "scenario": "${scenario}",
     "target_vhost": "${target_vhost}",
-    "policy": {"name": "${policy_name}"},
+    "policy": policy,
     "detection": detection,
     "performance": performance,
     "resources": resources

--- a/benchmarks/lab/runners/run-corpus.sh
+++ b/benchmarks/lab/runners/run-corpus.sh
@@ -119,8 +119,8 @@ with open(os.path.join(os.path.dirname(os.environ["CASES_JSONL"]), "detection.js
 PY
 
 DETECTION="$(cat "${OUT_DIR}/detection.json")"
-POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
-write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}"
+resolve_policy
+write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}" "${POLICY_PARANOIA}"
 
 echo ""
 python3 - <<PY

--- a/benchmarks/lab/runners/run-ftw.sh
+++ b/benchmarks/lab/runners/run-ftw.sh
@@ -74,9 +74,9 @@ PY
 
 # Write final summary.json.
 DETECTION="$(cat "${OUT_DIR}/detection.json")"
-POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+resolve_policy
 
-write_summary "ftw" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}"
+write_summary "ftw" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}" "${POLICY_PARANOIA}"
 
 echo ""
 echo "FTW conformance: $(python3 -c "import json; d=json.load(open('${OUT_DIR}/detection.json')); print(f\"{(d.get('crs_conformance_rate') or 0)*100:.1f}%\")")"

--- a/benchmarks/lab/runners/run-load.sh
+++ b/benchmarks/lab/runners/run-load.sh
@@ -199,9 +199,9 @@ c = json.loads('''${RESOURCES_CORAZA}''')
 h = json.loads('''${RESOURCES_HAPROXY}''')
 print(json.dumps({'coraza': c, 'haproxy': h}))
 ")"
-POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+resolve_policy
 
-write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "{}" "${PERFORMANCE}" "${RESOURCES_JSON}"
+write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "{}" "${PERFORMANCE}" "${RESOURCES_JSON}" "${POLICY_PARANOIA}"
 
 echo ""
 python3 - <<PY

--- a/benchmarks/lab/runners/run-nuclei.sh
+++ b/benchmarks/lab/runners/run-nuclei.sh
@@ -104,9 +104,9 @@ with open(os.path.join(out_dir, "detection.json"), "w") as f:
 PY
 
 DETECTION="$(cat "${OUT_DIR}/detection.json")"
-POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+resolve_policy
 
-write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}"
+write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}" "${POLICY_PARANOIA}"
 
 echo ""
 echo "Nuclei findings (waf-relevant): $(python3 -c "import json; d=json.load(open('${OUT_DIR}/detection.json')); print(d.get('waf_relevant_findings', 'n/a'))")"

--- a/benchmarks/lab/runners/run-zap.sh
+++ b/benchmarks/lab/runners/run-zap.sh
@@ -130,9 +130,9 @@ with open(os.path.join(out_dir, "detection.json"), "w") as f:
 PY
 
 DETECTION="$(cat "${OUT_DIR}/detection.json")"
-POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+resolve_policy
 
-write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}"
+write_summary "${SCENARIO}" "${TARGET_VHOST}" "${POLICY_NAME}" "${DETECTION}" "{}" "{}" "${POLICY_PARANOIA}"
 
 echo ""
 echo "ZAP alerts: $(python3 -c "import json; d=json.load(open('${OUT_DIR}/detection.json')); print(d.get('total_alerts', 'n/a'))")"

--- a/benchmarks/lab/set-policy.sh
+++ b/benchmarks/lab/set-policy.sh
@@ -96,7 +96,7 @@ token="$(api_json POST /auth/login "" "${login_body}" | python3 -c 'import json,
 
 echo "Looking up policy '${TARGET_POLICY_NAME}'..."
 policies_response="$(api_json GET /policies "${token}")"
-read -r policy_id policy_paranoia <<<"$(POLICIES="${policies_response}" POLICY_NAME="${TARGET_POLICY_NAME}" python3 - <<'PY'
+policy_lookup="$(POLICIES="${policies_response}" POLICY_NAME="${TARGET_POLICY_NAME}" python3 - <<'PY'
 import json, os, sys
 data = json.loads(os.environ["POLICIES"])
 name = os.environ["POLICY_NAME"]
@@ -108,6 +108,7 @@ for item in items:
 sys.exit(f"Policy '{name}' not found. Run `make lab-up` (setup-lab.sh) first.")
 PY
 )"
+read -r policy_id policy_paranoia <<<"${policy_lookup}"
 
 echo "Fetching vhosts..."
 vhosts_response="$(api_json GET /vhosts "${token}")"

--- a/benchmarks/lab/set-policy.sh
+++ b/benchmarks/lab/set-policy.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# set-policy.sh — Switch all lab vhosts to the PL1 or PL2 policy and reload config.
+#
+# setup-lab.sh creates both the "Lab Baseline" (PL1) and "Lab PL2" policies and binds
+# all lab vhosts to PL1 by default. This script re-points the vhosts to the requested
+# policy and applies the generated HAProxy/Coraza config, so a PL2 sweep can run
+# against the same lab targets without re-running setup-lab.sh.
+#
+# Prerequisites:
+#   - benchmarks/lab/.env (copy from benchmarks/lab/.env.example)
+#   - Lab already brought up via `make lab-up` (setup-lab.sh has already created
+#     the "Lab Baseline" and "Lab PL2" policies and the four lab vhosts)
+#
+# Usage:
+#   POLICY=pl1 bash benchmarks/lab/set-policy.sh
+#   POLICY=pl2 bash benchmarks/lab/set-policy.sh
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+CORE_ENV="${REPO_ROOT}/deploy/docker/.env"
+LAB_ENV="${SCRIPT_DIR}/.env"
+POLICY="${POLICY:-pl1}"
+
+for f in "${CORE_ENV}" "${LAB_ENV}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "Missing ${f}. Copy the matching .env.example first." >&2
+    exit 1
+  fi
+done
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+env_value() {
+  local name="$1"
+  local fallback="${2:-}"
+  local value
+  value="$(grep -E "^${name}=" "${CORE_ENV}" "${LAB_ENV}" 2>/dev/null | tail -n 1 | cut -d= -f2- || true)"
+  if [[ -z "${value}" ]]; then printf '%s' "${fallback}"; else printf '%s' "${value}"; fi
+}
+
+json_string() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+api_json() {
+  local method="$1"; local path="$2"; local token="${3:-}"; local body="${4:-}"
+  local response_file http_code
+  response_file="$(mktemp)"
+  if [[ -n "${body}" ]]; then
+    http_code="$(curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
+      --request "${method}" --header "Content-Type: application/json" \
+      ${token:+--header "Authorization: Bearer ${token}"} --data "${body}" "${API_BASE_URL}${path}")"
+  else
+    http_code="$(curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
+      --request "${method}" ${token:+--header "Authorization: Bearer ${token}"} "${API_BASE_URL}${path}")"
+  fi
+  if [[ "${http_code}" -lt 200 || "${http_code}" -ge 300 ]]; then
+    echo "API ${method} ${path} failed with HTTP ${http_code}:" >&2
+    cat "${response_file}" >&2; rm -f "${response_file}"; return 1
+  fi
+  cat "${response_file}"; rm -f "${response_file}"
+}
+
+# ── Resolve target policy ────────────────────────────────────────────────────
+
+case "${POLICY}" in
+  pl1)
+    TARGET_POLICY_NAME="$(env_value LAB_POLICY_NAME 'Lab Baseline')"
+    ;;
+  pl2)
+    TARGET_POLICY_NAME="$(env_value LAB_PL2_POLICY_NAME 'Lab PL2')"
+    ;;
+  *)
+    echo "Unknown POLICY '${POLICY}' (expected pl1 or pl2)." >&2
+    exit 1
+    ;;
+esac
+
+ADMIN_EMAIL="$(env_value ADMIN_EMAIL admin@example.com)"
+ADMIN_PASSWORD="$(env_value ADMIN_PASSWORD GuardProxyDemo12345)"
+BACKEND_HTTP_PORT="$(env_value BACKEND_HTTP_PORT 8000)"
+API_BASE_URL="http://127.0.0.1:${BACKEND_HTTP_PORT}"
+
+LAB_JUICESHOP_DOMAIN="$(env_value LAB_JUICESHOP_DOMAIN juice.local)"
+LAB_FTW_DOMAIN="$(env_value LAB_FTW_DOMAIN ftw.local)"
+LAB_DVWA_DOMAIN="$(env_value LAB_DVWA_DOMAIN dvwa.local)"
+LAB_WP_DOMAIN="$(env_value LAB_WP_DOMAIN wp.local)"
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+echo "Logging in..."
+login_body="$(printf '{"email":%s,"password":%s}' "$(json_string "${ADMIN_EMAIL}")" "$(json_string "${ADMIN_PASSWORD}")")"
+token="$(api_json POST /auth/login "" "${login_body}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')"
+
+echo "Looking up policy '${TARGET_POLICY_NAME}'..."
+policies_response="$(api_json GET /policies "${token}")"
+read -r policy_id policy_paranoia <<<"$(POLICIES="${policies_response}" POLICY_NAME="${TARGET_POLICY_NAME}" python3 - <<'PY'
+import json, os, sys
+data = json.loads(os.environ["POLICIES"])
+name = os.environ["POLICY_NAME"]
+items = data if isinstance(data, list) else [data]
+for item in items:
+    if item["name"] == name:
+        print(item["id"], item.get("paranoia_level", "?"))
+        sys.exit(0)
+sys.exit(f"Policy '{name}' not found. Run `make lab-up` (setup-lab.sh) first.")
+PY
+)"
+
+echo "Fetching vhosts..."
+vhosts_response="$(api_json GET /vhosts "${token}")"
+
+set_vhost_policy() {
+  local domain="$1"
+  local vhost_id
+  vhost_id="$(VHOSTS="${vhosts_response}" DOMAIN="${domain}" python3 - <<'PY'
+import json, os, sys
+data = json.loads(os.environ["VHOSTS"]); domain = os.environ["DOMAIN"]
+for item in data:
+    if item["domain"] == domain:
+        print(item["id"]); sys.exit(0)
+sys.exit(f"vhost {domain!r} not found. Run `make lab-up` (setup-lab.sh) first.")
+PY
+  )"
+  echo "  ${domain} -> policy_id=${policy_id}"
+  api_json PATCH "/vhosts/${vhost_id}" "${token}" "{\"policy_id\":${policy_id}}" >/dev/null
+}
+
+echo "Switching lab vhosts to '${TARGET_POLICY_NAME}' (paranoia ${policy_paranoia})..."
+set_vhost_policy "${LAB_JUICESHOP_DOMAIN}"
+set_vhost_policy "${LAB_FTW_DOMAIN}"
+set_vhost_policy "${LAB_DVWA_DOMAIN}"
+set_vhost_policy "${LAB_WP_DOMAIN}"
+
+echo "Applying generated HAProxy/Coraza config..."
+api_json POST /config/apply "${token}" >/dev/null
+
+echo
+echo "Active policy: ${TARGET_POLICY_NAME} (paranoia ${policy_paranoia})"

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -240,7 +240,7 @@ cp benchmarks/lab/.env.example benchmarks/lab/.env
 # deploy/docker/.env must include ADMIN_EMAIL and ADMIN_PASSWORD for lab seeding.
 
 # 5. Bring up the lab
-make eval-up
+make lab-up
 ```
 
 ### 8.2 Running the evaluation
@@ -258,7 +258,7 @@ for i in 1 2 3; do
 done
 
 # View results summary:
-make eval-results
+make results
 ```
 
 ### 8.3 Changing target vhost
@@ -281,6 +281,47 @@ RUN_ID=<id> make eval-metrics
 
 # Copy curated results to thesis:
 cp benchmarks/results/run-<id>/results.csv thesis/assets/figures/eval-results-<id>.csv
+```
+
+### 8.5 Paranoia level sweep (PL1 vs PL2)
+
+`make lab-up` (via `setup-lab.sh`) seeds two policies — `Lab Baseline` (PL1, anomaly
+threshold 5) and `Lab PL2` (PL2, anomaly threshold 3, see `benchmarks/lab/.env.example`
+`LAB_PL2_POLICY_*`) — and binds all lab vhosts to PL1 by default.
+
+`POLICY=pl1|pl2` selects which of these policies is active for an `eval-*` target
+(default `pl1`). Each policy pass writes to its own results directory,
+`benchmarks/results/run-<RUN_ID>-pl1/` or `run-<RUN_ID>-pl2/`, and every `summary.json` /
+`results.csv` row is tagged with the active `paranoia_level` (1 or 2) so the two passes
+can be compared side-by-side.
+
+Run both passes for every tool/target with one command:
+
+```bash
+# Runs eval-all at PL1, switches the lab vhosts to PL2, then runs eval-all again.
+# Produces benchmarks/results/run-<id>-pl1/ and run-<id>-pl2/.
+make eval-sweep
+```
+
+Equivalent manual steps (e.g. to re-run just one tool at PL2):
+
+```bash
+# Switch all lab vhosts to PL2 and reload HAProxy/Coraza config:
+make set-policy POLICY=pl2
+
+# Run (or re-run) any eval target at PL2:
+make eval-nuclei POLICY=pl2
+
+# Switch back to PL1 when done:
+make set-policy POLICY=pl1
+```
+
+For the thesis, copy both CSVs (or concatenate them — they share the same column set
+plus `paranoia_level`):
+
+```bash
+cp benchmarks/results/run-<id>-pl1/results.csv thesis/assets/figures/eval-results-<id>-pl1.csv
+cp benchmarks/results/run-<id>-pl2/results.csv thesis/assets/figures/eval-results-<id>-pl2.csv
 ```
 
 ---
@@ -349,4 +390,7 @@ ZAP and Nuclei do not provide clean request-level denominators for WAF TP/FN/TN/
 
 Flat CSV with one row per scenario run. Consumed directly by `thesis/chapters/06-testy.md` tables.
 
-Columns include: `run_id`, `scenario`, `target_vhost`, `policy`, `tpr`, `fpr`, `crs_conformance_rate`, `crs_passed`, `crs_failed`, `tp`, `fn`, `tn`, `fp`, `corpus_cases`, `zap_total_alerts`, `nuclei_findings`, `waf_blocks_from_log`, `rps_waf`, `rps_direct`, `rps_degradation_pct`, latency percentiles, and resource fields.
+Columns include: `run_id`, `scenario`, `target_vhost`, `policy`, `paranoia_level`, `tpr`, `fpr`, `crs_conformance_rate`, `crs_passed`, `crs_failed`, `tp`, `fn`, `tn`, `fp`, `corpus_cases`, `zap_total_alerts`, `nuclei_findings`, `waf_blocks_from_log`, `rps_waf`, `rps_direct`, `rps_degradation_pct`, latency percentiles, and resource fields.
+
+`paranoia_level` is `1` for the baseline (`Lab Baseline`) policy and `2` for the high-paranoia
+(`Lab PL2`) policy — see §8.5 for running both passes.


### PR DESCRIPTION
## Summary

- Closes #232.
- The eval lab only ever ran benchmarks at PL1 (`LAB_POLICY_PARANOIA=1`), even though a PL2 policy (`LAB_PL2_POLICY_*`) was already seeded by `setup-lab.sh` but never bound to any vhost or exercised by any Make target.
- Adds `benchmarks/lab/set-policy.sh` which re-points the lab vhosts (juice/ftw/dvwa/wp) to either the `Lab Baseline` (PL1) or `Lab PL2` policy and reloads HAProxy/Coraza config via `POST /config/apply`.
- `lib.sh` gains `resolve_policy()` (reads `POLICY=pl1|pl2`, default `pl1`) and `write_summary()` now tags each `summary.json` with `policy.paranoia`.
- All five runners (`run-ftw`, `run-corpus`, `run-zap`, `run-nuclei`, `run-load`) resolve and forward the active policy's paranoia level.
- `collect-metrics.sh` adds a `paranoia_level` column to `results.csv`/`report.json`.
- `Makefile`: new `POLICY=pl1|pl2` flag (default `pl1`) on all `eval-*` targets, per-policy result directories (`run-<id>-pl1` / `run-<id>-pl2`), a `set-policy` target, and a new `eval-sweep` target that runs the full suite at PL1, switches to PL2, and runs it again under one shared `RUN_ID`.
- `docs/evaluation-plan.md`: new §8.5 documenting the PL2 sweep (`make eval-sweep`, `make set-policy POLICY=pl2`, etc.), updated results.csv column list, and fixed stale `eval-up`/`eval-results` target references to `lab-up`/`results`.

## Test plan

- [x] `bash -n` on all new/edited shell scripts (set-policy.sh, lib.sh, all 5 runners, collect-metrics.sh) — all pass.
- [x] `make -n eval-ftw POLICY=pl2`, `make -n set-policy POLICY=pl2`, `make -n eval-sweep` dry-runs — expand correctly to `run-<id>-pl1`/`-pl2` paths with `POLICY` propagated to runners.
- [x] On the lab host: `make lab-up` then `make eval-sweep` to produce `benchmarks/results/run-<id>-pl1/` and `run-<id>-pl2/` with `paranoia_level=1`/`2` respectively, and commit those results for the thesis (per issue acceptance criteria — deferred to the dedicated lab host as documented).
