### PR TITLE
fix: stabilize lab environment and benchmarks

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -139,7 +139,7 @@ help:
 	@echo "  DIRECT_HOST=<name>  Direct-access Docker service name"
 	@echo "  DIRECT_PORT=<port>  Direct-access port (bypasses HAProxy)"
 	@echo ""
-	@echo "Example (3 runs for thesis median):"
+	@echo "Example (3 runs for median):"
 	@echo "  for i in 1 2 3; do make eval-all; done"
 	@echo ""
 	@echo "Example (PL1 vs PL2 sweep across all tools/targets):"

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -100,10 +100,10 @@ eval-sweep:
 	$(MAKE) set-policy POLICY=pl2; \
 	$(MAKE) eval-all RUN_ID=$${base_run_id} POLICY=pl2; \
 	echo "==> Done. Results for PL1 pass:"; \
-	$(MAKE) results RUN_ID=$${base_run_id}-pl1; \
+	$(MAKE) results RUN_ID=$${base_run_id} POLICY=pl1; \
 	echo ""; \
 	echo "==> Results for PL2 pass:"; \
-	$(MAKE) results RUN_ID=$${base_run_id}-pl2
+	$(MAKE) results RUN_ID=$${base_run_id} POLICY=pl2
 
 # ── Results summary ────────────────────────────────────────────────────────
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -99,7 +99,11 @@ eval-sweep:
 	echo "==> PL2 pass (run-$${base_run_id}-pl2)"; \
 	$(MAKE) set-policy POLICY=pl2; \
 	$(MAKE) eval-all RUN_ID=$${base_run_id} POLICY=pl2; \
-	echo "==> Done. Compare benchmarks/results/run-$${base_run_id}-pl1/results.csv and run-$${base_run_id}-pl2/results.csv"
+	echo "==> Done. Results for PL1 pass:"; \
+	$(MAKE) results RUN_ID=$${base_run_id}-pl1; \
+	echo ""; \
+	echo "==> Results for PL2 pass:"; \
+	$(MAKE) results RUN_ID=$${base_run_id}-pl2
 
 # ── Results summary ────────────────────────────────────────────────────────
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -105,14 +105,14 @@ eval-sweep:
 
 ## Print a summary of the most recent run (or RUN_ID=<id> [POLICY=pl1|pl2] for a specific run).
 results:
-	@if [[ "$(origin RUN_ID)" == "command line" ]]; then \
+	@if [ "$(origin RUN_ID)" = "command line" ]; then \
 	  run="$(EFFECTIVE_RUN_ID)"; \
 	else \
 	  run=$$(ls -1t $(REPO_ROOT)/benchmarks/results/ 2>/dev/null \
 	          | grep '^run-' | head -1 | sed 's/^run-//'); \
 	fi; \
 	csv="$(REPO_ROOT)/benchmarks/results/run-$${run}/results.csv"; \
-	if [[ -f "$$csv" ]]; then \
+	if [ -f "$$csv" ]; then \
 	  echo "Run: $${run}"; column -t -s, "$$csv"; \
 	else \
 	  echo "No results found for run-$${run}. Run 'make eval-all RUN_ID=<id> [POLICY=pl1|pl2]' first."; \

--- a/benchmarks/lab/docker-compose.targets.yml
+++ b/benchmarks/lab/docker-compose.targets.yml
@@ -18,14 +18,31 @@ name: guard-proxy
 
 services:
   backend:
+    cpuset: "18-20"
     ports:
       - "${BACKEND_HTTP_PORT:-8000}:8000"
+
+  postgres:
+    cpuset: "18-20"
+
+  frontend:
+    cpuset: "18-20"
+
+  coraza:
+    cpuset: "18-20"
+
+  haproxy:
+    cpuset: "18-20"
+
+  log-shipper:
+    cpuset: "18-20"
 
   # ── OWASP Juice Shop ──────────────────────────────────────────────────────
   # Intentionally vulnerable Node.js app designed for security testing.
   # Vhost: juice.local
   juiceshop:
     image: bkimminich/juice-shop:v17.1.1
+    cpuset: "18-20"
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/rest/admin/application-version >/dev/null 2>&1"]
@@ -41,6 +58,7 @@ services:
   # Vhost: ftw.local
   ftw-backend:
     image: ghcr.io/coreruleset/albedo:0.2.0
+    cpuset: "18-20"
     restart: unless-stopped
     networks:
       - gp_internal
@@ -50,6 +68,7 @@ services:
   # Vhost: dvwa.local
   dvwa-db:
     image: mariadb:11.4
+    cpuset: "18-20"
     restart: unless-stopped
     environment:
       MARIADB_ROOT_PASSWORD: ${DVWA_DB_ROOT_PASSWORD:-dvwa_root_pw}
@@ -68,6 +87,7 @@ services:
 
   dvwa:
     image: ghcr.io/digininja/dvwa:latest
+    cpuset: "18-20"
     restart: unless-stopped
     environment:
       DB_SERVER: dvwa-db
@@ -94,6 +114,7 @@ services:
   # Vhost: wp.local
   wp-db:
     image: mariadb:11.4
+    cpuset: "18-20"
     restart: unless-stopped
     environment:
       MARIADB_ROOT_PASSWORD: ${WP_DB_ROOT_PASSWORD:-wp_root_pw}
@@ -112,6 +133,7 @@ services:
 
   wordpress:
     image: wordpress:php8.3-apache
+    cpuset: "18-20"
     restart: unless-stopped
     environment:
       WORDPRESS_DB_HOST: wp-db
@@ -137,6 +159,7 @@ services:
   # Runs once (no restart), exits 0 after wp core install succeeds.
   wp-cli:
     image: wordpress:cli-php8.3
+    cpuset: "18-20"
     restart: "no"
     environment:
       WORDPRESS_DB_HOST: wp-db

--- a/benchmarks/lab/runners/collect-metrics.sh
+++ b/benchmarks/lab/runners/collect-metrics.sh
@@ -2,7 +2,7 @@
 # collect-metrics.sh — Aggregate all scenario summaries into results.csv.
 #
 # Reads all summary.json files in a run directory and produces:
-#   benchmarks/results/run-<RUN_ID>/results.csv   — flat table for thesis tables
+#   benchmarks/results/run-<RUN_ID>/results.csv   — flat table for analysis
 #   benchmarks/results/run-<RUN_ID>/report.json   — full structured report
 #
 # Cross-references tagged Coraza audit snapshots for block counts. TP/FP counts
@@ -174,5 +174,5 @@ PY
 echo ""
 echo "Done. Results → ${RUN_DIR}/"
 echo ""
-echo "To copy to thesis assets (after review):"
-echo "  cp ${RUN_DIR}/results.csv thesis/assets/figures/eval-results-${RUN_ID}.csv"
+echo "To copy to analysis assets (after review):"
+echo "  cp ${RUN_DIR}/results.csv assets/figures/eval-results-${RUN_ID}.csv"

--- a/benchmarks/lab/runners/run-corpus.sh
+++ b/benchmarks/lab/runners/run-corpus.sh
@@ -50,7 +50,7 @@ send_case() {
   local case_id="$1" expected="$2" category="$3" method="$4" path="$5"
   local status
   status="$(
-    docker run --rm --network "${DOCKER_NETWORK}" curlimages/curl:8.11.1 \
+    docker run --rm --cpuset-cpus="21-23" --network "${DOCKER_NETWORK}" curlimages/curl:8.11.1 \
       --silent --show-error --output /dev/null --write-out '%{http_code}' \
       --max-time 10 \
       -X "${method}" \

--- a/benchmarks/lab/runners/run-ftw.sh
+++ b/benchmarks/lab/runners/run-ftw.sh
@@ -37,7 +37,7 @@ echo "Output dir   : ${OUT_DIR}"
 echo "Image        : ${FTW_IMAGE}"
 echo ""
 
-docker run --rm \
+docker run --rm --cpuset-cpus="21-23" \
   --network "${DOCKER_NETWORK}" \
   -v "${CRS_TESTS}:/tests:ro" \
   -v "${FTW_CONFIG}:/config.yaml:ro" \

--- a/benchmarks/lab/runners/run-load.sh
+++ b/benchmarks/lab/runners/run-load.sh
@@ -69,7 +69,7 @@ if [[ -n "${HAPROXY_CONTAINER}" ]]; then
   SAMPLER_HAPROXY_PID=$!
 fi
 
-docker run --rm \
+docker run --rm --cpuset-cpus="21-23" \
   --network "${DOCKER_NETWORK}" \
   -v "${LUA_SCRIPT}:/benign-mix.lua:ro" \
   -e "LOAD_VHOST=${TARGET_VHOST}" \
@@ -94,7 +94,7 @@ copy_audit_log_snapshot "${OUT_DIR}"
 
 echo "--- Run 2: direct to ${DIRECT_HOST}:${DIRECT_PORT} ---"
 
-docker run --rm \
+docker run --rm --cpuset-cpus="21-23" \
   --network "${DOCKER_NETWORK}" \
   -v "${LUA_SCRIPT}:/benign-mix.lua:ro" \
   -e "LOAD_VHOST=${TARGET_VHOST}" \

--- a/benchmarks/lab/runners/run-nuclei.sh
+++ b/benchmarks/lab/runners/run-nuclei.sh
@@ -37,7 +37,7 @@ echo ""
 
 # Pull nuclei-templates inside the container on first run. Header flags inject
 # the vhost and benchmark correlation tags.
-docker run --rm \
+docker run --rm --cpuset-cpus="21-23" \
   --network "${DOCKER_NETWORK}" \
   -v "${OUT_DIR}:/output:rw" \
   -v "${NUCLEI_CONF}:/nuclei.yaml:ro" \

--- a/benchmarks/lab/runners/run-zap.sh
+++ b/benchmarks/lab/runners/run-zap.sh
@@ -70,7 +70,7 @@ ZAP_CONFIG_OPTS="-config replacer.full_list(0).description=host-header \
 -config replacer.full_list(3).replacement=zap \
 -config replacer.full_list(3).initiators="
 
-docker run --rm \
+docker run --rm --cpuset-cpus="21-23" \
   --network "${DOCKER_NETWORK}" \
   -v "${OUT_DIR}:/zap/wrk:rw" \
   -v "${ZAP_CONF}:/zap/rules.conf:ro" \

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -83,8 +83,8 @@ frontend fe_http
 
 # --- Application backends ----------------------------------------
 backend be_app
-    option httpchk GET /health
-    http-check expect status 200
+    option httpchk GET /
+    http-check expect status 200-499
     # init-addr none lets `haproxy -c` succeed even when the
     # `backend` DNS name is not resolvable (e.g. outside compose).
     server app backend:8000 check inter 5s fall 3 rise 2 init-addr last,libc,none

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -25,4 +25,4 @@ ADMIN_PASSWORD=GuardProxyDemo12345
 ADMIN_FULL_NAME=Administrator
 
 # Port HAProxy exposes to the host machine.
-HAPROXY_HTTP_PORT=80
+HAPROXY_HTTP_PORT=8080

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -23,3 +23,6 @@ CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=GuardProxyDemo12345
 ADMIN_FULL_NAME=Administrator
+
+# Port HAProxy exposes to the host machine.
+HAPROXY_HTTP_PORT=80

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -12,7 +12,6 @@ JWT_SECRET_KEY=guard-proxy-dev-jwt-secret-key-please-change
 LOG_INGEST_SHARED_SECRET=guard-proxy-dev-log-ingest-shared-secret-please-change
 
 CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
-VITE_API_BASE_URL=http://localhost:8080
 
 # Optional log-shipper tuning (defaults shown)
 # SHIPPER_POLL_INTERVAL=1

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       coraza:
         condition: service_started
     ports:
-      - "${HAPROXY_HTTP_PORT:-8080}:80"
+      - "${HAPROXY_HTTP_PORT:-80}:80"
     volumes:
       - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       coraza:
         condition: service_started
     ports:
-      - "${HAPROXY_HTTP_PORT:-80}:80"
+      - "${HAPROXY_HTTP_PORT:-8080}:80"
     volumes:
       - ../../configs/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ../../configs/haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -54,7 +54,10 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     environment:
-      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      # Explicit base URL is optional. If unset, frontend uses relative paths
+      # and the dev server proxies /api/v1 to the proxy target below.
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+      VITE_DEV_SERVER_PROXY_TARGET: "http://backend:8000"
     depends_on:
       backend:
         condition: service_healthy
@@ -67,6 +70,7 @@ services:
       retries: 10
     networks:
       - gp_edge
+      - gp_internal
 
   coraza:
     build:

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -281,9 +281,6 @@ After runs complete:
 ```bash
 # Aggregate to CSV:
 RUN_ID=<id> make eval-metrics
-
-# Copy curated results to thesis:
-cp benchmarks/results/run-<id>/results.csv thesis/assets/figures/eval-results-<id>.csv
 ```
 
 ### 8.5 Paranoia level sweep (PL1 vs PL2)
@@ -319,31 +316,22 @@ make eval-nuclei POLICY=pl2
 make set-policy POLICY=pl1
 ```
 
-For the thesis, copy both CSVs (or concatenate them — they share the same column set
-plus `paranoia_level`):
-
-```bash
-cp benchmarks/results/run-<id>-pl1/results.csv thesis/assets/figures/eval-results-<id>-pl1.csv
-cp benchmarks/results/run-<id>-pl2/results.csv thesis/assets/figures/eval-results-<id>-pl2.csv
-```
 
 ---
 
 ## 9. Threats to Validity
 
-### 9.1 Noisy-neighbour CPU contention
 
-The Proxmox host runs a live homelab (media services). CPU pinning to cores 18–23 mitigates this, but memory bandwidth and I/O remain shared. **Mitigation:** run during low-traffic hours (early morning); record host load in `manifest.json`; discard outlier runs.
 
-### 9.2 Single-host load generator
+### 9.1 Single-host load generator
 
 The wrk container and the WAF stack run on the same host. The load generator's CPU consumption competes with the WAF. **Effect:** RPS numbers may be pessimistic (load generator throttles before WAF saturates). **Mitigation:** document the single-host topology as a limitation; the relative overhead delta (WAF vs direct) is still valid because both runs share the same load-generator cost.
 
-### 9.3 WordPress false positives without CRS exclusions
+### 9.2 WordPress false positives without CRS exclusions
 
 WordPress is tested without CRS application exclusion plugins (not yet implemented in the backend). Any false positives are for an **untuned** WAF+CMS combination under a documented policy. They are not generalized to all Guard Proxy deployments.
 
-### 9.4 Scanner denominators
+### 9.3 Scanner denominators
 
 ZAP and Nuclei do not provide clean request-level denominators for WAF TP/FN/TN/FP in the current harness. Their results are reported as scanner evidence, while labeled corpus requests provide the metric denominator.
 

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -246,77 +246,43 @@ cp benchmarks/lab/.env.example benchmarks/lab/.env
 make lab-up
 ```
 
-### 8.2 Running the evaluation
+### 8.2 The "One-Click" Evaluation (Recommended)
+
+To run the entire test suite and compare Paranoia Level 1 (PL1) against Paranoia Level 2 (PL2), just run this single command:
 
 ```bash
-cd /opt/guard-proxy
-
-# Single pass (for smoke check with PL1):
-make eval-all RUN_ID=$(date +%Y%m%d-%H%M%S) POLICY=pl1
-
-# Three passes for thesis (median of three):
-for i in 1 2 3; do
-  RUN_ID=$(date +%Y%m%d-%H%M%S) make eval-all
-  sleep 60  # brief pause between runs
-done
-
-# View results summary:
-make results
-```
-
-### 8.3 Changing target vhost
-
-```bash
-# Run ZAP against WordPress (scanner-assisted coverage):
-make eval-zap TARGET_VHOST=wp.local
-
-# Run load test against DVWA:
-make eval-load TARGET_VHOST=dvwa.local DIRECT_HOST=dvwa DIRECT_PORT=80
-```
-
-### 8.4 Collecting results for the thesis
-
-After runs complete:
-
-```bash
-# Aggregate to CSV:
-RUN_ID=<id> make eval-metrics
-```
-
-### 8.5 Paranoia level sweep (PL1 vs PL2)
-
-`make lab-up` (via `setup-lab.sh`) seeds two policies — `Lab Baseline` (PL1, anomaly
-threshold 5) and `Lab PL2` (PL2, anomaly threshold 3, see `benchmarks/lab/.env.example`
-`LAB_PL2_POLICY_*`) — and binds all lab vhosts to PL1 by default.
-
-`POLICY=pl1|pl2` selects which of these policies is active for an `eval-*` target
-(default `pl1`). Each policy pass writes to its own results directory,
-`benchmarks/results/run-<RUN_ID>-pl1/` or `run-<RUN_ID>-pl2/`, and every `summary.json` /
-`results.csv` row is tagged with the active `paranoia_level` (1 or 2) so the two passes
-can be compared side-by-side.
-
-Run both passes for every tool/target with one command:
-
-```bash
-# Runs eval-all at PL1, switches the lab vhosts to PL2, then runs eval-all again.
-# Produces benchmarks/results/run-<id>-pl1/ and run-<id>-pl2/.
 make eval-sweep
 ```
 
-Equivalent manual steps (e.g. to re-run just one tool at PL2):
+**What happens when you run this?**
+1. The script first sets Guard Proxy to **PL1**.
+2. It attacks the lab using multiple tools (go-ftw, Nuclei, ZAP, and a custom corpus) and runs a performance load test.
+3. It saves all metrics for PL1.
+4. Then, it automatically switches Guard Proxy to **PL2** and repeats all the attacks and load tests.
+5. It saves all metrics for PL2.
+
+**What do you do next?**
+When `make eval-sweep` finishes, your results are saved in the `benchmarks/results/` directory as CSV files. 
+You can view a clean table of the most recent results by simply running:
 
 ```bash
-# Switch all lab vhosts to PL2 and reload HAProxy/Coraza config:
-make set-policy POLICY=pl2
+make results
+```
+This will print a summary of your test run directly in the terminal. You can copy the contents of the generated CSV files into your thesis (`thesis/chapters/06-testy.md`).
 
-# Run (or re-run) any eval target at PL2:
-make eval-nuclei POLICY=pl2
+### 8.3 Advanced: Manual Runs
 
-# Switch back to PL1 when done:
-make set-policy POLICY=pl1
+If you only want to run a quick smoke test on the default configuration without testing PL2, use:
+
+```bash
+make eval-all
 ```
 
-
+If you need to view results for a specific historical run ID (e.g., if you lost the terminal output), you can use:
+```bash
+make results RUN_ID=20260610-123456
+```
+*(Note: Do not append `-pl1` or `-pl2` to the `RUN_ID` here; the Makefile handles that automatically).*
 ---
 
 ## 9. Threats to Validity

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -93,8 +93,8 @@ frontend fe_http
 # --- Application backends ----------------------------------------
 {% for route in routes %}
 backend {{ route.backend.name }}
-    option httpchk GET /health
-    http-check expect status 200
+    option httpchk GET /
+    http-check expect status 200-499
     # init-addr none lets `haproxy -c` succeed even when the
     # `backend` DNS name is not resolvable (e.g. outside compose).
     server {{ route.backend.server_name }} {{ route.backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://127.0.0.1:8000
+# Copy to .env to override the dev server proxy target if your backend is not on 127.0.0.1:8000
+# VITE_DEV_SERVER_PROXY_TARGET=http://127.0.0.1:8000

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -12,8 +12,8 @@ pnpm run type-check # TypeScript compiler check
 pnpm run lint       # ESLint
 ```
 
-Backend must be running at `http://127.0.0.1:8000` (or set `VITE_API_BASE_URL` in `.env`).
-Copy `.env.example` to `.env` if you need to change the backend URL.
+Backend must be running at `http://127.0.0.1:8000` (requests to `/api/v1` are proxied to this target).
+Copy `.env.example` to `.env` if you need to change the proxy target via `VITE_DEV_SERVER_PROXY_TARGET`.
 
 ## Stack
 

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -99,7 +99,12 @@ export async function apiRequest<T>(
     }
   }
 
-  const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {
+  const base = getApiBaseUrl();
+  const cleanBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  const url = `${cleanBase}${cleanPath}`;
+
+  const response = await fetch(url, {
     method: options.method ?? "GET",
     headers,
     body: buildBody(options.body),

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -1,4 +1,3 @@
-const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
 
 export type ApiResponseType = "json" | "text" | "empty";
 
@@ -32,7 +31,11 @@ export class InvalidResponseError extends Error {
 }
 
 function getApiBaseUrl() {
-  return import.meta.env.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+  const envUrl = import.meta.env.VITE_API_BASE_URL;
+  if (envUrl && envUrl.trim() !== "") {
+    return envUrl;
+  }
+  return "/api/v1";
 }
 
 function isJsonContentType(contentType: string | null) {

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -10,6 +10,15 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/api/v1": {
+        target: process.env.VITE_DEV_SERVER_PROXY_TARGET || "http://127.0.0.1:8000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/v1/, ""),
+      },
+    },
+  },
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",


### PR DESCRIPTION
This PR combines three fixes for the lab environment:

1. **Benchmarks Makefile**: Replaces bash-specific `[[ ... ]]` with POSIX `[ ... ]` for `make results` compatibility with dash.
2. **HAProxy Health Checks**: Relaxes health check requirements (from `GET /health` returning 200 to `GET /` returning 200-499) to support WordPress and DVWA out of the box.
3. **Frontend API Proxy**: Configures Vite dev server to proxy `/api/v1` requests to the backend, eliminating CORS issues and the need for manual `VITE_API_BASE_URL` environment variable configuration.