### PR TITLE
Fix policy enforcement (Coraza config reload) and relocate Apply config

### DIFF
--- a/configs/coraza/coraza.conf
+++ b/configs/coraza/coraza.conf
@@ -1,10 +1,10 @@
-# Baseline Coraza/CRS configuration for the M1 Docker Compose stack.
+# Baseline Coraza configuration for the Docker Compose stack.
 #
 # This file is included by coraza-spoa.yaml for the default application.
-# M2 will generate per-policy Coraza configuration from the database; until
-# then these defaults provide a reproducible CRS-backed WAF.
-
-SecRuleEngine On
+# Per-policy CRS setup (SecRuleEngine, anomaly thresholds, paranoia level) is
+# generated from the database and written to /runtime/current/crs-setup.conf
+# by the backend's config-apply pipeline. The backend seeds this file on
+# startup so it always exists before Coraza starts.
 
 SecRequestBodyAccess On
 SecResponseBodyAccess Off
@@ -18,6 +18,6 @@ SecAuditLogParts ABIJDEFHZ
 SecDefaultAction "phase:1,log,auditlog,pass"
 SecDefaultAction "phase:2,log,auditlog,pass"
 
-Include /etc/coraza/crs-setup.conf
+Include /runtime/current/crs-setup.conf
 Include /etc/coraza/crs/rules/*.conf
 Include /runtime/current/rule-overrides.conf

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -13,7 +13,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
-from app.database import get_db
+from app.database import SessionLocal, get_db
+from app.models.policy import Policy
+from app.models.rule_override import RuleOverride
+from app.models.vhost import VHost
 from app.rate_limit import limiter, rate_limit_exceeded_handler
 from app.routers import (
     auth,
@@ -24,6 +27,8 @@ from app.routers import (
     runtime_status,
     vhosts,
 )
+from app.services.config_apply import seed_runtime_config
+from app.services.config_generator import generate
 
 logger = logging.getLogger(__name__)
 
@@ -49,8 +54,30 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Application lifespan — startup and shutdown events."""
     # Startup
     validate_runtime_settings(settings)
+    _seed_runtime_config()
     yield
     # Shutdown
+
+
+def _seed_runtime_config() -> None:
+    """Seed the runtime config directory from the database, if needed.
+
+    HAProxy and Coraza read their config from the runtime "current"
+    release on startup. If no admin has run "Apply config" yet, that
+    release does not exist. Best-effort: failures are logged but must not
+    block backend startup.
+    """
+    db = SessionLocal()
+    try:
+        vhosts = db.query(VHost).all()
+        policies = db.query(Policy).all()
+        rule_overrides = db.query(RuleOverride).all()
+        generated = generate(vhosts, policies, rule_overrides)
+        seed_runtime_config(generated)
+    except Exception:
+        logger.exception("Failed to seed runtime config on startup")
+    finally:
+        db.close()
 
 
 app = FastAPI(

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -137,7 +137,10 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
             status=ApplyStatus.success,
             correlation_id=correlation_id,
             checksum=checksum,
-            message="Configuration applied and HAProxy reloaded successfully.",
+            message=(
+                "Configuration applied. HAProxy reloaded; Coraza is reloading "
+                "the updated WAF ruleset (within ~1s)."
+            ),
             candidate_path=str(candidate_dir),
             active_path=str(_resolve_current(current_link)),
             validation_output=validation.output,
@@ -240,6 +243,53 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
         validation_output=validation.output,
         reload_output=reload_result.output,
         rollback_output=rollback_reload.output,
+    )
+
+
+def seed_runtime_config(generated: GeneratedConfig) -> None:
+    """Write an initial runtime release if none exists yet.
+
+    HAProxy and Coraza both read their config from
+    `<runtime_root>/current` on startup. Until the first admin "Apply
+    config" runs, that symlink does not exist, so Coraza's
+    `Include /runtime/current/crs-setup.conf` resolves to nothing and CRS
+    fails to load. Called once during backend startup to seed `current`
+    from the database state, without reloading anything (no service has
+    started yet, so there is nothing to reload).
+    """
+    runtime_root = Path(settings.runtime_generated_config_root).resolve()
+    current_link = runtime_root / "current"
+
+    if (current_link / "crs-setup.conf").exists():
+        return
+
+    correlation_id = uuid.uuid4().hex
+    candidate_dir = runtime_root / "releases" / correlation_id
+
+    try:
+        _sweep_orphaned_temp_links(runtime_root)
+        _write_candidate(candidate_dir, generated)
+        validation = _validate_haproxy(candidate_dir / "haproxy.cfg")
+        if not validation.ok:
+            logger.error(
+                "config-seed validation failed correlation_id=%s output=%s",
+                correlation_id,
+                validation.output,
+            )
+            shutil.rmtree(candidate_dir, ignore_errors=True)
+            return
+        _swap_current_link(current_link, candidate_dir, runtime_root)
+    except OSError:
+        logger.exception(
+            "config-seed failed correlation_id=%s",
+            correlation_id,
+        )
+        shutil.rmtree(candidate_dir, ignore_errors=True)
+        return
+
+    logger.info(
+        "config-seed wrote initial runtime config correlation_id=%s",
+        correlation_id,
     )
 
 

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -5,11 +5,12 @@ from pathlib import Path
 
 from app.config import settings
 from app.services.config_apply import (
+    _RELOAD_ERROR_RE,
     ApplyStatus,
     CommandResult,
-    _RELOAD_ERROR_RE,
     _read_current_symlink,
     apply,
+    seed_runtime_config,
 )
 from app.services.config_generator import GeneratedConfig
 
@@ -305,6 +306,66 @@ def test_apply_returns_state_invalid_when_current_is_directory(
 # ---------------------------------------------------------------------------
 # MED M4 — rollback path must validate previous release before reloading
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# seed_runtime_config — backend startup must populate /runtime/current so
+# Coraza's `Include /runtime/current/crs-setup.conf` resolves on first boot.
+# ---------------------------------------------------------------------------
+
+
+def test_seed_runtime_config_writes_current_when_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=True, output="valid"),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    current = runtime_root / "current"
+    assert current.is_symlink()
+    assert (current / "crs-setup.conf").read_text(
+        encoding="utf-8"
+    ) == "SecRuleEngine On\n"
+
+
+def test_seed_runtime_config_is_noop_when_current_already_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    previous = _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: (_ for _ in ()).throw(AssertionError("should not validate")),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    assert (runtime_root / "current").resolve() == previous.resolve()
+
+
+def test_seed_runtime_config_does_not_swap_current_when_validation_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=False, output="parse error"),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    assert not (runtime_root / "current").exists()
+    assert not (runtime_root / "current").is_symlink()
 
 
 def test_apply_skips_rollback_reload_when_previous_no_longer_validates(

--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -5,6 +5,9 @@ import { Leaf, LogOut, Menu, Shield, Snowflake, X } from "lucide-react";
 import { appRoutes } from "@/app/routes";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ApplyConfigButton } from "@/features/runtime/ApplyConfigButton";
+import { useApplyNotice } from "@/features/runtime/use-apply-notice";
+import { useRuntimeStatus } from "@/features/runtime/use-runtime-status";
 import { useAuth } from "@/hooks/use-auth";
 import { THEMES, type Theme, getThemeStorageKey } from "@/lib/theme";
 import { cn } from "@/lib/utils";
@@ -59,6 +62,8 @@ function applyTheme(theme: Theme) {
 export function NavBar() {
   const navigate = useNavigate();
   const { signOut, user } = useAuth();
+  const runtimeStatus = useRuntimeStatus();
+  const { showNotice } = useApplyNotice();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [theme, setTheme] = useState<Theme>(getStoredTheme);
 
@@ -123,6 +128,8 @@ export function NavBar() {
         </nav>
 
         <div className="hidden items-center gap-2 md:flex">
+          <ApplyConfigButton runtimeStatus={runtimeStatus} onResult={showNotice} />
+
           <Button
             type="button"
             onClick={toggleTheme}
@@ -200,6 +207,8 @@ export function NavBar() {
             ))}
 
             <div className="my-3 h-px bg-border" />
+
+            <ApplyConfigButton runtimeStatus={runtimeStatus} onResult={showNotice} />
 
             <Button
               type="button"

--- a/src/frontend/src/features/runtime/apply-notice-context.ts
+++ b/src/frontend/src/features/runtime/apply-notice-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+import type { ApplyResult } from "./ApplyConfigButton";
+
+export type ApplyNoticeContextValue = {
+  showNotice: (result: ApplyResult) => void;
+};
+
+export const ApplyNoticeContext = createContext<ApplyNoticeContextValue | null>(
+  null,
+);

--- a/src/frontend/src/features/runtime/apply-notice.tsx
+++ b/src/frontend/src/features/runtime/apply-notice.tsx
@@ -1,0 +1,55 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+import type { ApplyResult } from "./ApplyConfigButton";
+import { ApplyNoticeContext } from "./apply-notice-context";
+
+const SUCCESS_AUTO_DISMISS_MS = 6000;
+
+export function ApplyNoticeProvider({ children }: PropsWithChildren) {
+  const [notice, setNotice] = useState<ApplyResult | null>(null);
+
+  const dismiss = useCallback(() => setNotice(null), []);
+  const showNotice = useCallback((result: ApplyResult) => {
+    setNotice(result);
+  }, []);
+
+  useEffect(() => {
+    if (!notice || notice.kind !== "success") return;
+    const timer = setTimeout(dismiss, SUCCESS_AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [notice, dismiss]);
+
+  return (
+    <ApplyNoticeContext.Provider value={{ showNotice }}>
+      {children}
+      {notice ? (
+        <div className="pointer-events-none fixed inset-x-0 top-16 z-[100] flex justify-center px-4 sm:justify-end sm:px-6">
+          <Alert
+            variant={notice.kind === "success" ? "success" : "destructive"}
+            className="pointer-events-auto flex w-full max-w-md items-start justify-between gap-4 shadow-lg"
+          >
+            <span>{notice.message}</span>
+            <Button
+              type="button"
+              onClick={dismiss}
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-current hover:bg-current/10"
+              aria-label="Dismiss apply result"
+            >
+              Close
+            </Button>
+          </Alert>
+        </div>
+      ) : null}
+    </ApplyNoticeContext.Provider>
+  );
+}

--- a/src/frontend/src/features/runtime/use-apply-notice.ts
+++ b/src/frontend/src/features/runtime/use-apply-notice.ts
@@ -1,0 +1,14 @@
+import { useContext } from "react";
+
+import {
+  ApplyNoticeContext,
+  type ApplyNoticeContextValue,
+} from "./apply-notice-context";
+
+export function useApplyNotice(): ApplyNoticeContextValue {
+  const context = useContext(ApplyNoticeContext);
+  if (!context) {
+    throw new Error("useApplyNotice must be used within an ApplyNoticeProvider");
+  }
+  return context;
+}

--- a/src/frontend/src/layouts/AppLayout.tsx
+++ b/src/frontend/src/layouts/AppLayout.tsx
@@ -1,14 +1,17 @@
 import { Outlet } from "react-router-dom";
 
 import { NavBar } from "@/components/layout/NavBar";
+import { ApplyNoticeProvider } from "@/features/runtime/apply-notice";
 
 export function AppLayout() {
   return (
-    <div className="min-h-screen bg-app text-foreground">
-      <NavBar />
-      <main className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
-        <Outlet />
-      </main>
-    </div>
+    <ApplyNoticeProvider>
+      <div className="min-h-screen bg-app text-foreground">
+        <NavBar />
+        <main className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
+          <Outlet />
+        </main>
+      </div>
+    </ApplyNoticeProvider>
   );
 }

--- a/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -13,9 +13,6 @@ vi.mock("@/features/vhosts/api");
 vi.mock("@/features/runtime/use-runtime-status", () => ({
   useRuntimeStatus: () => ({ data: null, isLoading: false, error: null, refresh: vi.fn() }),
 }));
-vi.mock("@/features/runtime/ApplyConfigButton", () => ({
-  ApplyConfigButton: () => null,
-}));
 vi.mock("@/features/runtime/RuntimeStatusCard", () => ({
   RuntimeStatusCard: () => null,
 }));

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import {
   AlertTriangleIcon,
@@ -6,15 +6,11 @@ import {
   ServerIcon,
   ShieldIcon,
 } from "@/components/icons";
-import { Alert } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { RoleBadge } from "@/components/shared/RoleBadge";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatCard } from "@/components/shared/StatCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
-import { ApplyConfigButton } from "@/features/runtime/ApplyConfigButton";
-import type { ApplyResult } from "@/features/runtime/ApplyConfigButton";
 import { RuntimeStatusCard } from "@/features/runtime/RuntimeStatusCard";
 import { useRuntimeStatus } from "@/features/runtime/use-runtime-status";
 import { useDashboardStats } from "@/features/dashboard/use-dashboard-stats";
@@ -24,7 +20,6 @@ export function DashboardPage() {
   const { role } = useAuth();
   const runtimeStatus = useRuntimeStatus();
   const stats = useDashboardStats();
-  const [applyResult, setApplyResult] = useState<ApplyResult | null>(null);
 
   return (
     <section className="space-y-8">
@@ -35,32 +30,9 @@ export function DashboardPage() {
           <>
             {role ? <RoleBadge role={role} /> : null}
             <StatusBadge label="Development" tone="info" />
-            <ApplyConfigButton
-              runtimeStatus={runtimeStatus}
-              onResult={(result) => setApplyResult(result)}
-            />
           </>
         }
       />
-
-      {applyResult ? (
-        <Alert
-          variant={applyResult.kind === "success" ? "success" : "destructive"}
-          className="flex items-start justify-between gap-4"
-        >
-          <span>{applyResult.message}</span>
-          <Button
-            type="button"
-            onClick={() => setApplyResult(null)}
-            variant="ghost"
-            size="sm"
-            className="h-6 px-2 text-current hover:bg-current/10"
-            aria-label="Dismiss apply result"
-          >
-            Close
-          </Button>
-        </Alert>
-      ) : null}
 
       <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         <StatCard


### PR DESCRIPTION
## Summary
- Coraza no longer includes a static `crs-setup.conf` with hardcoded `SecRuleEngine On`. It now includes the database-generated `/runtime/current/crs-setup.conf`, the same release `coraza-supervisor.sh` already watches and reloads on. This fixes policy "anomaly threshold" and "enforcement mode" changes having no effect on the running WAF.
- Backend seeds `/runtime/current` from the database on startup so Coraza always has a valid CRS config, even before the first "Apply config" run.
- "Apply config" moved from the Dashboard page header to the nav bar (global, admin-only action), with a new global toast notice (`ApplyNoticeProvider`/`useApplyNotice`) so the result is visible from any page.
- Apply success message now also mentions Coraza reloading the WAF ruleset, not just HAProxy.

## Test plan
- [x] Backend unit tests (`pytest`) pass, including new `seed_runtime_config` tests
- [x] Frontend unit tests (`vitest`), `tsc`, and `eslint` pass
- [x] Manual verification on lab server: Coraza starts cleanly with seeded `/runtime/current/crs-setup.conf`, switching a policy to detect-only + Apply allows a previously-blocked payload through (logged but not blocked)
