### PR TITLE
fix(ui): polish dashboard, vhost form, apply notice, and nav bar

### DIFF
--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -141,17 +141,20 @@ export function NavBar() {
             {theme === "emerald" ? <Leaf /> : <Snowflake />}
           </Button>
 
-          <Badge>Dev Mode</Badge>
-          <Badge variant="secondary">
+          <div className="mx-1 h-6 w-px bg-border" aria-hidden="true" />
+
+          <span className="max-w-48 truncate text-sm text-muted-foreground">
             {user?.full_name || user?.email || "No user"}
-          </Badge>
+          </span>
           <Button
             type="button"
             onClick={() => void handleLogout()}
             variant="ghost"
+            size="icon"
+            aria-label="Log out"
+            title="Log out"
           >
             <LogOut />
-            Logout
           </Button>
         </div>
 
@@ -223,7 +226,6 @@ export function NavBar() {
             <div className="my-3 h-px bg-border" />
 
             <div className="flex flex-wrap gap-2 px-1">
-              <Badge>Dev Mode</Badge>
               <Badge variant="secondary">
                 {user?.full_name || user?.email || "No user"}
               </Badge>

--- a/src/frontend/src/features/runtime/apply-notice.tsx
+++ b/src/frontend/src/features/runtime/apply-notice.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import type { ApplyResult } from "./ApplyConfigButton";
 import { ApplyNoticeContext } from "./apply-notice-context";
 
-const SUCCESS_AUTO_DISMISS_MS = 6000;
+const SUCCESS_AUTO_DISMISS_MS = 10000;
 
 export function ApplyNoticeProvider({ children }: PropsWithChildren) {
   const [notice, setNotice] = useState<ApplyResult | null>(null);
@@ -31,10 +31,15 @@ export function ApplyNoticeProvider({ children }: PropsWithChildren) {
     <ApplyNoticeContext.Provider value={{ showNotice }}>
       {children}
       {notice ? (
-        <div className="pointer-events-none fixed inset-x-0 top-16 z-[100] flex justify-center px-4 sm:justify-end sm:px-6">
+        <div className="pointer-events-none fixed inset-x-0 top-16 z-[100] flex justify-center px-4">
           <Alert
             variant={notice.kind === "success" ? "success" : "destructive"}
-            className="pointer-events-auto flex w-full max-w-md items-start justify-between gap-4 shadow-lg"
+            className={
+              "pointer-events-auto flex w-full max-w-xl items-start justify-between gap-4 bg-card text-foreground shadow-lg " +
+              (notice.kind === "success"
+                ? "border-success/60"
+                : "border-destructive/60")
+            }
           >
             <span>{notice.message}</span>
             <Button

--- a/src/frontend/src/features/vhosts/VHostFormModal.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.tsx
@@ -163,7 +163,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
           </Select>
         </div>
 
-        <div className="space-y-1.5 border-t pt-4">
+        <div className="space-y-1.5 pt-2">
           <Label className="flex cursor-pointer items-center gap-2 font-semibold">
             <Checkbox
               checked={sslEnabled}
@@ -173,7 +173,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
           </Label>
 
           {sslEnabled && (
-            <div className="mt-4 space-y-4 rounded-md border p-4">
+            <div className="mt-4 space-y-4">
               <div className="space-y-1.5">
                 <Label htmlFor="vhost-ssl-provider">SSL Provider</Label>
                 <Select
@@ -215,7 +215,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
           )}
         </div>
 
-        <div className="border-t pt-4">
+        <div className="pt-2">
           <Label className="flex cursor-pointer items-center gap-2">
             <Checkbox
               checked={isActive}

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -42,7 +42,6 @@ export function DashboardPage() {
               ? "—"
               : String(stats.vhosts.count)
           }
-          hint="Number of virtual hosts currently configured in the WAF."
           tone="info"
           icon={<ServerIcon />}
           isLoading={stats.vhosts.isLoading}
@@ -54,7 +53,6 @@ export function DashboardPage() {
               ? "—"
               : String(stats.policies.count)
           }
-          hint="Policies define the WAF behaviour applied to host traffic."
           tone="success"
           icon={<ShieldIcon />}
           isLoading={stats.policies.isLoading}
@@ -66,7 +64,6 @@ export function DashboardPage() {
               ? "—"
               : String(stats.blocked.count)
           }
-          hint="Total requests denied by Coraza rules (action: deny)."
           tone="warning"
           icon={<AlertTriangleIcon />}
           isLoading={stats.blocked.isLoading}
@@ -78,7 +75,6 @@ export function DashboardPage() {
               ? "—"
               : String(stats.alerts.count)
           }
-          hint="Log entries with severity: critical across all hosts."
           tone="error"
           icon={<PulseIcon />}
           isLoading={stats.alerts.isLoading}

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -40,7 +40,7 @@ export function PoliciesPage() {
       cell: (row) => (
         <Link
           to={getPolicyDetailPath(row.id)}
-          className="font-medium text-accent hover:underline"
+          className="font-medium text-primary hover:underline"
         >
           {row.name}
         </Link>

--- a/src/frontend/src/styles/globals.css
+++ b/src/frontend/src/styles/globals.css
@@ -117,6 +117,8 @@
   }
 
   html {
+    /* Bump the rem base so the UI reads comfortably at 100% browser zoom. */
+    font-size: 110%;
     transition:
       background-color 0.3s ease,
       color 0.3s ease;


### PR DESCRIPTION
## Summary
- Bump base font size to 110% so the UI reads comfortably at 100% browser zoom (#3)
- Drop redundant hint text from dashboard stat cards (#2)
- Fix near-invisible policy name link contrast: `text-accent` -> `text-primary` (#9)
- Remove unnecessary borders/dividers from the vhost SSL section (#4)
- Center the apply notice, raise its contrast (solid card background), extend auto-dismiss 6s -> 10s (#16)
- Simplify the nav bar: drop the "Dev Mode" badge, replace the user badge + Logout button with a muted username and an icon-only logout button (#15)

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test` (70 tests passed)

