### PR TITLE
feat(auth): refresh expired sessions and link vhost rows to detail view

### DIFF
--- a/src/frontend/src/features/auth/auth-context.test.tsx
+++ b/src/frontend/src/features/auth/auth-context.test.tsx
@@ -1,8 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useAuth } from "@/hooks/use-auth";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError } from "@/lib/api-client";
+import { ApiError, apiRequest } from "@/lib/api-client";
 import type { CurrentUser } from "@/types/api";
 import type { TokenResponse } from "@/types/api";
 
@@ -117,6 +117,10 @@ async function waitForReady() {
 describe("AuthProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("restores a session through refresh and me calls", async () => {
@@ -363,6 +367,69 @@ describe("AuthProvider", () => {
     expect(screen.getByTestId("user")).toHaveTextContent(latestUser.email);
     expect(screen.getByTestId("token")).toHaveTextContent("session-access");
     expect(screen.getByTestId("error")).toHaveTextContent("no-error");
+  });
+
+  it("refreshes the current user after an automatic 401 token refresh", async () => {
+    const signedInUser = createUser({ email: "old@example.com" });
+    const refreshedUser = createUser({
+      email: "updated@example.com",
+      full_name: "Updated User",
+    });
+
+    mockedRefreshSession
+      .mockRejectedValueOnce(new Error("No session"))
+      .mockResolvedValueOnce({
+        access_token: "new-access",
+        token_type: "bearer",
+      });
+    mockedLogin.mockResolvedValueOnce({
+      access_token: "old-access",
+      token_type: "bearer",
+    });
+    mockedGetCurrentUser
+      .mockResolvedValueOnce(signedInUser)
+      .mockResolvedValueOnce(refreshedUser);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Invalid or expired token" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    render(
+      <AuthProvider>
+        <AuthConsumer />
+      </AuthProvider>,
+    );
+
+    await waitForReady();
+    fireEvent.click(screen.getByRole("button", { name: "sign in" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("token")).toHaveTextContent("old-access");
+      expect(screen.getByTestId("user")).toHaveTextContent(signedInUser.email);
+    });
+
+    await expect(
+      apiRequest<{ status: string }>("/vhosts", { token: "old-access" }),
+    ).resolves.toEqual({ status: "ok" });
+
+    expect(mockedRefreshSession).toHaveBeenCalledTimes(2);
+    expect(mockedGetCurrentUser).toHaveBeenLastCalledWith("new-access");
+    const retryHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(retryHeaders.get("Authorization")).toBe("Bearer new-access");
+    await waitFor(() => {
+      expect(screen.getByTestId("token")).toHaveTextContent("new-access");
+      expect(screen.getByTestId("user")).toHaveTextContent(refreshedUser.email);
+    });
   });
 
   it("aborts restore requests on unmount", async () => {

--- a/src/frontend/src/features/auth/auth-context.tsx
+++ b/src/frontend/src/features/auth/auth-context.tsx
@@ -112,9 +112,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setUnauthorizedHandler(async () => {
       try {
         const tokens = await refreshSession();
+        const currentUser = await getCurrentUser(tokens.access_token);
 
         if (isMountedRef.current) {
           setAccessToken(tokens.access_token);
+          setUser(currentUser);
+          setLoginError(null);
         }
 
         return tokens.access_token;

--- a/src/frontend/src/features/auth/auth-context.tsx
+++ b/src/frontend/src/features/auth/auth-context.tsx
@@ -7,7 +7,7 @@ import {
   type PropsWithChildren,
 } from "react";
 
-import { ApiError } from "@/lib/api-client";
+import { ApiError, setUnauthorizedHandler } from "@/lib/api-client";
 import type { CurrentUser, LoginRequest, UserRole } from "@/types/api";
 
 import { getCurrentUser, login, logout, refreshSession } from "./api";
@@ -104,6 +104,33 @@ export function AuthProvider({ children }: PropsWithChildren) {
       currentAbortControllerRef.current = null;
     };
   }, [beginOperation, finishOperation, isCurrentOperation]);
+
+  // When an API call hits a 401 (expired access token), try the refresh
+  // cookie once; on failure clear auth state so ProtectedRoute redirects
+  // to the login page instead of pages surfacing raw errors.
+  useEffect(() => {
+    setUnauthorizedHandler(async () => {
+      try {
+        const tokens = await refreshSession();
+
+        if (isMountedRef.current) {
+          setAccessToken(tokens.access_token);
+        }
+
+        return tokens.access_token;
+      } catch {
+        if (isMountedRef.current) {
+          setAccessToken(null);
+          setUser(null);
+          setLoginError(null);
+        }
+
+        return null;
+      }
+    });
+
+    return () => setUnauthorizedHandler(null);
+  }, []);
 
   const signIn = useCallback(async (credentials: LoginRequest) => {
     const { operationId, signal } = beginOperation();

--- a/src/frontend/src/lib/api-client.test.ts
+++ b/src/frontend/src/lib/api-client.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { InvalidResponseError, apiRequest } from "./api-client";
+import {
+  InvalidResponseError,
+  apiRequest,
+  setUnauthorizedHandler,
+} from "./api-client";
 
 describe("apiRequest", () => {
   afterEach(() => {
+    setUnauthorizedHandler(null);
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
@@ -145,5 +150,66 @@ describe("apiRequest", () => {
       detail: "Backend exploded",
       status: 500,
     });
+  });
+
+  it("retries an authenticated request once after a 401 refresh", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Invalid or expired token" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const handler = vi.fn().mockResolvedValue("new-token");
+    setUnauthorizedHandler(handler);
+
+    await expect(
+      apiRequest<{ status: string }>("/vhosts", { token: "stale-token" }),
+    ).resolves.toEqual({ status: "ok" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const retryHeaders = new Headers(fetchMock.mock.calls[1]?.[1]?.headers);
+    expect(retryHeaders.get("Authorization")).toBe("Bearer new-token");
+  });
+
+  it("throws the original 401 when the refresh handler fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Invalid or expired token" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const handler = vi.fn().mockResolvedValue(null);
+    setUnauthorizedHandler(handler);
+
+    await expect(
+      apiRequest("/vhosts", { token: "stale-token" }),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke the refresh handler for unauthenticated requests", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Invalid credentials" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const handler = vi.fn().mockResolvedValue("new-token");
+    setUnauthorizedHandler(handler);
+
+    await expect(
+      apiRequest("/auth/login", { method: "POST", body: {} }),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -30,6 +30,36 @@ export class InvalidResponseError extends Error {
   }
 }
 
+/**
+ * Called when an authenticated request gets a 401. Should attempt a session
+ * refresh and return the new access token, or null when the session is gone
+ * (in which case auth state is expected to be cleared by the handler).
+ */
+type UnauthorizedHandler = () => Promise<string | null>;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+let pendingTokenRefresh: Promise<string | null> | null = null;
+
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+  unauthorizedHandler = handler;
+  pendingTokenRefresh = null;
+}
+
+function refreshAccessToken(): Promise<string | null> {
+  if (!unauthorizedHandler) {
+    return Promise.resolve(null);
+  }
+
+  // Deduplicate concurrent 401s into a single refresh attempt.
+  pendingTokenRefresh ??= unauthorizedHandler()
+    .catch(() => null)
+    .finally(() => {
+      pendingTokenRefresh = null;
+    });
+
+  return pendingTokenRefresh;
+}
+
 function getApiBaseUrl() {
   const envUrl = import.meta.env.VITE_API_BASE_URL;
   if (envUrl && envUrl.trim() !== "") {
@@ -77,9 +107,17 @@ function buildBody(body: ApiClientOptions["body"]) {
   return JSON.stringify(body);
 }
 
-export async function apiRequest<T>(
+export function apiRequest<T>(
   path: string,
   options: ApiClientOptions = {}
+): Promise<T> {
+  return executeRequest<T>(path, options, false);
+}
+
+async function executeRequest<T>(
+  path: string,
+  options: ApiClientOptions,
+  isRetry: boolean
 ): Promise<T> {
   const headers = new Headers(options.headers);
 
@@ -113,6 +151,13 @@ export async function apiRequest<T>(
   });
 
   if (!response.ok) {
+    if (response.status === 401 && options.token && !isRetry) {
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        return executeRequest<T>(path, { ...options, token: newToken }, true);
+      }
+    }
+
     let detail = "Request failed";
 
     try {

--- a/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import { AuthContext } from "@/features/auth/auth-context.shared";
@@ -46,7 +47,12 @@ const mockPolicies = [{ id: 1, name: "Default" }];
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
     <AuthContext.Provider value={makeAuthContext(authOverrides)}>
-      <VHostsPage />
+      <MemoryRouter initialEntries={["/vhosts"]}>
+        <Routes>
+          <Route path="/vhosts" element={<VHostsPage />} />
+          <Route path="/vhosts/:vhostId" element={<p>VHost detail page</p>} />
+        </Routes>
+      </MemoryRouter>
     </AuthContext.Provider>,
   );
 }
@@ -122,6 +128,35 @@ describe("VHostsPage", () => {
     expect(screen.queryByRole("button", { name: /new vhost/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it("navigates to the vhost detail page when a row is clicked", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByText("app.example.com"));
+
+    expect(screen.getByText("VHost detail page")).toBeInTheDocument();
+  });
+
+  it("does not navigate when row action buttons are clicked", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(true) });
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /edit/i }));
+
+    expect(screen.queryByText("VHost detail page")).not.toBeInTheDocument();
+    expect(screen.getByText("Edit virtual host")).toBeInTheDocument();
   });
 
   it("retry button calls refresh after error", async () => {

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
+import { getVHostDetailPath } from "@/app/routes";
 import type { DataTableColumn } from "@/components/shared/DataTable";
 import { DataTable } from "@/components/shared/DataTable";
 import { ErrorState } from "@/components/shared/ErrorState";
@@ -21,6 +23,7 @@ type ModalState =
   | { type: "delete"; vhost: VHost };
 
 export function VHostsPage() {
+  const navigate = useNavigate();
   const { hasRole } = useAuth();
   const { vhosts, policies, policyNameById, isLoading, error, refresh } = useVHosts();
   const [modal, setModal] = useState<ModalState>(null);
@@ -84,7 +87,11 @@ export function VHostsPage() {
             header: "",
             className: "w-px whitespace-nowrap",
             cell: (row: VHost) => (
-              <div className="flex items-center gap-2">
+              // Keep Edit/Delete clicks from triggering row navigation.
+              <div
+                className="flex items-center gap-2"
+                onClick={(event) => event.stopPropagation()}
+              >
                 <Button
                   type="button"
                   onClick={() => setModal({ type: "edit", vhost: row })}
@@ -147,6 +154,7 @@ export function VHostsPage() {
             columns={columns}
             rows={vhosts}
             getRowKey={(row) => String(row.id)}
+            onRowClick={(row) => navigate(getVHostDetailPath(row.id))}
             emptyTitle="No virtual hosts yet"
             emptyDescription="Create your first virtual host to start routing traffic through Guard Proxy."
           />


### PR DESCRIPTION
## Summary
- `api-client`: on a 401 from an authenticated request, attempt one deduplicated session refresh and retry the original request with the new token; `auth-context` wires this up via `setUnauthorizedHandler` and clears auth state on failure so `ProtectedRoute` redirects to login instead of pages rendering raw error responses (#5)
- `VHostsPage`: clicking a row now navigates to its detail page via `getVHostDetailPath`; Edit/Delete clicks call `stopPropagation` so they don't trigger row navigation (#6)

## Dependencies
This PR is based on `feat/logs-ux` (#240) because it relies on `DataTable.onRowClick` introduced there. **Merge #240 first**; this PR's diff will shrink to just its own files once that lands.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test` (76 tests passed)
