### PR TITLE
fix(backend): persist runtime operations and clean up haproxy config

### DIFF
--- a/configs/haproxy/README.md
+++ b/configs/haproxy/README.md
@@ -137,8 +137,7 @@ mode uses `info` logging.
 
    - the request should pass through `fe_http`;
    - non-`/health` requests should trigger `send-spoe-group coraza coraza-req`;
-   - denied requests should show a `403` generated before `be_app`;
-   - allowed requests with a score should include the `X-WAF-Score` header.
+   - denied requests should show a `403` generated before `be_app`.
 
 4. Check Coraza output next:
 

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -1,22 +1,11 @@
-# Reference HAProxy configuration for Guard Proxy M1.
-#
-# Goals:
-#   - Single frontend listening on :80
-#   - Virtual hosts routed to their configured backends
-#   - Reject unknown hosts before WAF inspection
-#   - SPOE filter forwarding request metadata to Coraza SPOA
-#   - Fail closed (503) if SPOA is unavailable or returns an error
-#   - Block requests when Coraza returns action=deny
-#
-# This file is the hand-written seed that the M2 Jinja2 template
-# generator will later reproduce from the policy database.
+# Guard Proxy HAProxy configuration.
+# Generated from the policy database; manual edits are overwritten on the
+# next config apply.
 
 global
     log stdout format raw local0 info
     maxconn 2000
-    # The SPOE filter expects a writable runtime directory.
-    # Use operator level to avoid exposing administrative Runtime API
-    # commands via the local socket.
+    # Operator level avoids exposing administrative Runtime API commands.
     stats socket /tmp/haproxy.sock mode 660 level operator
 
 defaults
@@ -28,82 +17,75 @@ defaults
     timeout client  30s
     timeout server  30s
 
-# --- Public frontend ----------------------------------------------
 frontend fe_http
     bind *:80
-    # Tag every request with a stable id so log lines and SPOE frames
-    # can be correlated.
+    # Correlate log lines and SPOE frames.
     unique-id-format %[uuid()]
     unique-id-header X-Request-ID
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Let's Encrypt HTTP-01 challenge routing
-    # Defined first so the deny rule below can reference it.
+    # Let's Encrypt HTTP-01 challenges bypass the unknown-host deny rule.
     acl is_acme path_beg /.well-known/acme-challenge/
 
-    # Known vhosts. Match Host without the optional request port so local
-    # Docker/browser requests such as app.local:8080 still route correctly.
-    # Unknown hosts are rejected here, before WAF inspection, so that
-    # Coraza does not process traffic destined for no valid backend.
-    # ACME HTTP-01 challenges are exempted: Let's Encrypt verification
-    # must pass through even when a domain's first config-apply is pending.
+    # Reject unknown hosts before WAF inspection. The request port is
+    # stripped from Host so app.local:8080 still matches app.local.
+
     acl host_app hdr(host),field(1,:) -i app.local localhost 127.0.0.1
+
+
     http-request deny deny_status 421 if !host_app !is_acme
 
-    # HTTP to HTTPS redirection for domains with SSL enabled
 
-    # Overwrite any client-supplied X-Forwarded-For with the real source IP
-    # so the backend rate limiter cannot be bypassed by header spoofing.
+    # Redirect to HTTPS for SSL-enabled vhosts.
+
+
+
+
+    # Overwrite client-supplied X-Forwarded-For so the backend rate limiter
+    # cannot be bypassed by header spoofing.
     http-request set-header X-Forwarded-For %[src]
 
-
-    # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
-    # server. This covers startup and unhealthy-container windows.
+    # Fail closed (503) when HAProxy has no usable Coraza SPOA server.
     http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
     http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
     http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason coraza-unavailable if { var(txn.waf_degraded_reason) -m str coraza-unavailable }
 
-    # Hand the request off to the Coraza SPOA. The engine name
-    # ("coraza") must match the [coraza] section in coraza.cfg.
+    # WAF inspection via the Coraza SPOA ("coraza" matches coraza.cfg).
     filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
     http-request send-spoe-group coraza coraza-req unless is_health
 
-    # Fail closed when SPOE processing starts but fails. set-on-error
-    # in coraza.cfg stores the HAProxy/SPOP error code in
-    # txn.coraza.error; using -m found ensures every code is blocked.
+    # Fail closed (503) when SPOE processing starts but fails.
     http-request set-var(txn.waf_degraded_reason) str(spoe-processing-error) if { var(txn.coraza.error) -m found }
     http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
     http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
 
-    # If the engine explicitly returns action=deny we stop the
-    # transaction with 403.
+    # Block requests the WAF denies.
     http-request deny deny_status 403 if { var(txn.coraza.action) -m str deny }
 
-    # Optional: log the WAF anomaly score on allowed requests so it
-    # shows up in the access log for debugging.
-    http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
-
     use_backend backend_acme if is_acme
+
     use_backend be_app if host_app
-    default_backend be_app
+
+
+
+
 
 # --- Application backends ----------------------------------------
+
 backend be_app
     option httpchk GET /
-    # 200-499 (rather than just 200) so apps that 404/redirect on `/`
-    # without a dedicated health endpoint (e.g. WordPress, DVWA) are
-    # still marked healthy. Only 5xx/connection failures count as down.
+    # Accept 200-499 so apps without a dedicated health endpoint still pass;
+    # only 5xx/connection failures mark a backend down.
     http-check expect status 200-499
-    # init-addr none lets `haproxy -c` succeed even when the
-    # `backend` DNS name is not resolvable (e.g. outside compose).
+    # init-addr lets `haproxy -c` succeed when the DNS name is unresolvable.
     server app backend:8000 check inter 5s fall 3 rise 2 init-addr last,libc,none
 
-# --- Coraza SPOA backend used by the SPOE filter -----------------
-# The SPOA speaks SPOP (binary, request/response) over TCP, so this
-# backend runs in mode tcp and must NOT have an HTTP check.
+
+
+# The Coraza SPOA speaks SPOP (binary) over TCP; no HTTP check.
 backend coraza-spoa
     mode tcp
     option spop-check
@@ -111,14 +93,6 @@ backend coraza-spoa
     timeout server  3m
     server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
-# --- Certbot backend for ACME challenge --------------------------
+# Certbot backend for ACME HTTP-01 challenges.
 backend backend_acme
     server certbot backend:8888 init-addr last,libc,none
-
-# --- Local stats endpoint (dev convenience, not exposed publicly) -
-listen stats
-    bind 127.0.0.1:8404
-    mode http
-    stats enable
-    stats uri /stats
-    stats refresh 10s

--- a/src/backend/app/routers/config.py
+++ b/src/backend/app/routers/config.py
@@ -10,10 +10,15 @@ from app.database import get_db
 from app.dependencies import require_admin
 from app.models.policy import Policy
 from app.models.rule_override import RuleOverride
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
 from app.models.user import User
 from app.models.vhost import VHost
 from app.schemas.config import ConfigApplyResponse, GeneratedConfigOut
-from app.services.config_apply import ApplyStatus
+from app.services.config_apply import ApplyResult, ApplyStatus
 from app.services.config_apply import apply as _apply
 from app.services.config_generator import generate
 
@@ -30,6 +35,45 @@ _HTTP_STATUS: dict[ApplyStatus, int] = {
     ApplyStatus.reload_failed_rolled_back: status.HTTP_500_INTERNAL_SERVER_ERROR,
     ApplyStatus.rollback_failed: status.HTTP_500_INTERNAL_SERVER_ERROR,
 }
+
+
+def _record_runtime_operations(db: Session, result: ApplyResult) -> None:
+    """Persist validation/reload snapshots so /runtime/status reflects deploys."""
+    # When writing the candidate already failed, validation never ran.
+    if result.status in (ApplyStatus.write_failed, ApplyStatus.state_invalid):
+        return
+
+    validation_ok = result.status != ApplyStatus.validation_failed
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.validation,
+            status=(
+                RuntimeOperationStatus.success
+                if validation_ok
+                else RuntimeOperationStatus.failed
+            ),
+            config_checksum=result.checksum,
+            message=result.validation_output,
+            metadata_json={"correlation_id": result.correlation_id},
+        )
+    )
+
+    if validation_ok:
+        db.add(
+            RuntimeOperation(
+                operation_type=RuntimeOperationType.reload,
+                status=(
+                    RuntimeOperationStatus.success
+                    if result.status == ApplyStatus.success
+                    else RuntimeOperationStatus.failed
+                ),
+                config_checksum=result.checksum,
+                message=result.reload_output,
+                metadata_json={"correlation_id": result.correlation_id},
+            )
+        )
+
+    db.commit()
 
 
 @router.post("/apply", response_model=ConfigApplyResponse)
@@ -50,6 +94,7 @@ def apply_config(
 
         generated = generate(vhosts, policies, rule_overrides)
         result = _apply(generated)
+        _record_runtime_operations(db, result)
 
         response = ConfigApplyResponse(
             generated_config=GeneratedConfigOut(

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -260,7 +260,14 @@ def seed_runtime_config(generated: GeneratedConfig) -> None:
     runtime_root = Path(settings.runtime_generated_config_root).resolve()
     current_link = runtime_root / "current"
 
-    if (current_link / "crs-setup.conf").exists():
+    # A complete release contains both files. The container entrypoint seeds a
+    # minimal crs-setup.conf stub (without haproxy.cfg) so Coraza can start
+    # before the backend; that stub must be replaced with the full rendered
+    # config here, so only skip seeding when a real release is active.
+    if (
+        (current_link / "crs-setup.conf").exists()
+        and (current_link / "haproxy.cfg").exists()
+    ):
         return
 
     correlation_id = uuid.uuid4().hex

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -172,10 +172,7 @@ def render_haproxy_cfg_multi(vhost_contexts: list[HaproxyRenderContext]) -> str:
 
 def _render_haproxy_routes(routes: tuple[HaproxyRoute, ...]) -> str:
     template = _ENVIRONMENT.get_template("haproxy.cfg.j2")
-    return template.render(
-        routes=routes,
-        default_backend=routes[0].backend if routes else None,
-    )
+    return template.render(routes=routes)
 
 
 def render_crs_setup(policy: CrsPolicyRenderContext) -> str:

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -1,22 +1,11 @@
-# Reference HAProxy configuration for Guard Proxy M1.
-#
-# Goals:
-#   - Single frontend listening on :80
-#   - Virtual hosts routed to their configured backends
-#   - Reject unknown hosts before WAF inspection
-#   - SPOE filter forwarding request metadata to Coraza SPOA
-#   - Fail closed (503) if SPOA is unavailable or returns an error
-#   - Block requests when Coraza returns action=deny
-#
-# This file is the hand-written seed that the M2 Jinja2 template
-# generator will later reproduce from the policy database.
+# Guard Proxy HAProxy configuration.
+# Generated from the policy database; manual edits are overwritten on the
+# next config apply.
 
 global
     log stdout format raw local0 info
     maxconn 2000
-    # The SPOE filter expects a writable runtime directory.
-    # Use operator level to avoid exposing administrative Runtime API
-    # commands via the local socket.
+    # Operator level avoids exposing administrative Runtime API commands.
     stats socket /tmp/haproxy.sock mode 660 level operator
 
 defaults
@@ -28,26 +17,19 @@ defaults
     timeout client  30s
     timeout server  30s
 
-# --- Public frontend ----------------------------------------------
 frontend fe_http
     bind *:80
-    # Tag every request with a stable id so log lines and SPOE frames
-    # can be correlated.
+    # Correlate log lines and SPOE frames.
     unique-id-format %[uuid()]
     unique-id-header X-Request-ID
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Let's Encrypt HTTP-01 challenge routing
-    # Defined first so the deny rule below can reference it.
+    # Let's Encrypt HTTP-01 challenges bypass the unknown-host deny rule.
     acl is_acme path_beg /.well-known/acme-challenge/
 
-    # Known vhosts. Match Host without the optional request port so local
-    # Docker/browser requests such as app.local:8080 still route correctly.
-    # Unknown hosts are rejected here, before WAF inspection, so that
-    # Coraza does not process traffic destined for no valid backend.
-    # ACME HTTP-01 challenges are exempted: Let's Encrypt verification
-    # must pass through even when a domain's first config-apply is pending.
+    # Reject unknown hosts before WAF inspection. The request port is
+    # stripped from Host so app.local:8080 still matches app.local.
 {% for route in routes %}
     acl {{ route.vhost_acl_name }} hdr(host),field(1,:) -i {{ route.vhost_hosts | join(" ") }}
 {% endfor %}
@@ -57,56 +39,43 @@ frontend fe_http
     http-request deny deny_status 421 if !is_acme
 {% endif %}
 
-    # HTTP to HTTPS redirection for domains with SSL enabled
+    # Redirect to HTTPS for SSL-enabled vhosts.
 {% for route in routes %}
 {% if route.ssl_provider != "none" %}
     http-request redirect scheme https code 301 if {{ route.vhost_acl_name }} !is_acme
 {% endif %}
 {% endfor %}
 
-    # Overwrite any client-supplied X-Forwarded-For with the real source IP
-    # so the backend rate limiter cannot be bypassed by header spoofing.
+    # Overwrite client-supplied X-Forwarded-For so the backend rate limiter
+    # cannot be bypassed by header spoofing.
     http-request set-header X-Forwarded-For %[src]
 
-    # Fail closed before SPOE when HAProxy has no usable Coraza SPOA
-    # server. This covers startup and unhealthy-container windows.
+    # Fail closed (503) when HAProxy has no usable Coraza SPOA server.
     http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
     http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
     http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason coraza-unavailable if { var(txn.waf_degraded_reason) -m str coraza-unavailable }
 
-    # Hand the request off to the Coraza SPOA. The engine name
-    # ("coraza") must match the [coraza] section in coraza.cfg.
+    # WAF inspection via the Coraza SPOA ("coraza" matches coraza.cfg).
     filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
     http-request send-spoe-group coraza coraza-req unless is_health
 
-    # Fail closed when SPOE processing starts but fails. set-on-error
-    # in coraza.cfg stores the HAProxy/SPOP error code in
-    # txn.coraza.error; using -m found ensures every code is blocked.
+    # Fail closed (503) when SPOE processing starts but fails.
     http-request set-var(txn.waf_degraded_reason) str(spoe-processing-error) if { var(txn.coraza.error) -m found }
     http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
     http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
 
-    # If the engine explicitly returns action=deny we stop the
-    # transaction with 403.
+    # Block requests the WAF denies.
     http-request deny deny_status 403 if { var(txn.coraza.action) -m str deny }
-
-    # Optional: log the WAF anomaly score on allowed requests so it
-    # shows up in the access log for debugging.
-    http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
 
     use_backend backend_acme if is_acme
 {% for route in routes %}
     use_backend {{ route.backend.name }} if {{ route.vhost_acl_name }}
 {% endfor %}
-{% if default_backend is not none %}
-    default_backend {{ default_backend.name }}
-{% endif %}
 
 {% set has_ssl = routes | selectattr("ssl_provider", "ne", "none") | list | length > 0 %}
 {% if has_ssl %}
-# --- Public HTTPS frontend ----------------------------------------
 frontend fe_https
     bind *:443 ssl crt /etc/haproxy/generated/certs/
     unique-id-format %[uuid()]
@@ -114,10 +83,9 @@ frontend fe_https
     acl is_health path /health
     http-request set-log-level silent if is_health
 
-    # Let's Encrypt HTTP-01 challenge routing (failsafe)
     acl is_acme path_beg /.well-known/acme-challenge/
 
-    # Known vhosts validation — ACME challenges are exempted (see fe_http).
+    # Reject unknown hosts before WAF inspection (see fe_http).
 {% for route in routes %}
     acl {{ route.vhost_acl_name }} hdr(host),field(1,:) -i {{ route.vhost_hosts | join(" ") }}
 {% endfor %}
@@ -130,7 +98,7 @@ frontend fe_https
     http-request set-header X-Forwarded-For %[src]
     http-request set-header X-Forwarded-Proto https
 
-    # SPOA WAF inspection (same as HTTP)
+    # WAF inspection and fail-closed handling (same as fe_http).
     http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
     http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
     http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
@@ -145,15 +113,11 @@ frontend fe_https
     http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
 
     http-request deny deny_status 403 if { var(txn.coraza.action) -m str deny }
-    http-request set-header X-WAF-Score %[var(txn.coraza.anomaly_score)] if { var(txn.coraza.anomaly_score) -m found }
 
     use_backend backend_acme if is_acme
 {% for route in routes %}
     use_backend {{ route.backend.name }} if {{ route.vhost_acl_name }}
 {% endfor %}
-{% if default_backend is not none %}
-    default_backend {{ default_backend.name }}
-{% endif %}
 
 {% endif %}
 
@@ -161,19 +125,15 @@ frontend fe_https
 {% for route in routes %}
 backend {{ route.backend.name }}
     option httpchk GET /
-    # 200-499 (rather than just 200) so apps that 404/redirect on `/`
-    # without a dedicated health endpoint (e.g. WordPress, DVWA) are
-    # still marked healthy. Only 5xx/connection failures count as down.
+    # Accept 200-499 so apps without a dedicated health endpoint still pass;
+    # only 5xx/connection failures mark a backend down.
     http-check expect status 200-499
-    # init-addr none lets `haproxy -c` succeed even when the
-    # `backend` DNS name is not resolvable (e.g. outside compose).
+    # init-addr lets `haproxy -c` succeed when the DNS name is unresolvable.
     server {{ route.backend.server_name }} {{ route.backend.address }} check inter 5s fall 3 rise 2 init-addr last,libc,none
 
 {% endfor %}
 
-# --- Coraza SPOA backend used by the SPOE filter -----------------
-# The SPOA speaks SPOP (binary, request/response) over TCP, so this
-# backend runs in mode tcp and must NOT have an HTTP check.
+# The Coraza SPOA speaks SPOP (binary) over TCP; no HTTP check.
 backend coraza-spoa
     mode tcp
     option spop-check
@@ -181,14 +141,6 @@ backend coraza-spoa
     timeout server  3m
     server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
 
-# --- Certbot backend for ACME challenge --------------------------
+# Certbot backend for ACME HTTP-01 challenges.
 backend backend_acme
     server certbot backend:8888 init-addr last,libc,none
-
-# --- Local stats endpoint (dev convenience, not exposed publicly) -
-listen stats
-    bind 127.0.0.1:8404
-    mode http
-    stats enable
-    stats uri /stats
-    stats refresh 10s

--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -9,7 +9,14 @@ seed_runtime_config() {
     if [ ! -f "${runtime_dir}/current/rule-overrides.conf" ]; then
         mkdir -p "${runtime_dir}/releases/seed"
         if [ ! -f "${runtime_dir}/releases/seed/crs-setup.conf" ]; then
-            printf "SecRuleEngine On\n" > "${runtime_dir}/releases/seed/crs-setup.conf"
+            # Rule 900990 marks crs-setup.conf as loaded; without it CRS rule
+            # 901001 reports "CRS is deployed without configuration!" on every
+            # request until the first apply. The app replaces this stub with
+            # the full template-rendered config during backend startup.
+            {
+                printf "SecRuleEngine On\n"
+                printf "SecAction \"id:900990,phase:1,pass,nolog,tag:'OWASP_CRS',ver:'OWASP_CRS/4.25.0',setvar:tx.crs_setup_version=4250\"\n"
+            } > "${runtime_dir}/releases/seed/crs-setup.conf"
         fi
         if [ ! -f "${runtime_dir}/releases/seed/rule-overrides.conf" ]; then
             printf "# No generated CRS rule overrides yet.\n" > "${runtime_dir}/releases/seed/rule-overrides.conf"

--- a/src/backend/tests/integration/test_config_router.py
+++ b/src/backend/tests/integration/test_config_router.py
@@ -106,3 +106,66 @@ def test_apply_validation_failure(
     body = resp.json()
     assert body["status"] == "validation_failed"
     assert "parse error" in body["validation_output"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime operation recording (deployment status)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_success_marks_runtime_status_deployed(
+    client: TestClient,
+    admin_token: dict[str, str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "runtime_generated_config_root",
+        str(tmp_path / "generated"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        _mock_validate_ok,
+    )
+    monkeypatch.setattr("app.services.config_apply._reload_haproxy", _mock_reload_ok)
+
+    apply_resp = client.post("/config/apply", headers=admin_token)
+    assert apply_resp.status_code == 200
+
+    status_resp = client.get("/runtime/status", headers=admin_token)
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    assert body["deployment_state"] == "deployed"
+    assert body["latest_validation"]["status"] == "success"
+    assert body["latest_reload"]["status"] == "success"
+    assert body["latest_reload"]["config_checksum"] == apply_resp.json()["checksum"]
+
+
+def test_apply_validation_failure_records_failed_validation_only(
+    client: TestClient,
+    admin_token: dict[str, str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "runtime_generated_config_root",
+        str(tmp_path / "generated"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        _mock_validate_fail,
+    )
+    monkeypatch.setattr("app.services.config_apply._reload_haproxy", _mock_reload_ok)
+
+    apply_resp = client.post("/config/apply", headers=admin_token)
+    assert apply_resp.status_code == 422
+
+    status_resp = client.get("/runtime/status", headers=admin_token)
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    # No reload was attempted, so the deployment state is unchanged.
+    assert body["deployment_state"] == "never_deployed"
+    assert body["latest_validation"]["status"] == "failed"
+    assert body["latest_reload"] is None

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -335,6 +335,35 @@ def test_seed_runtime_config_writes_current_when_missing(
     ) == "SecRuleEngine On\n"
 
 
+def test_seed_runtime_config_replaces_entrypoint_stub_release(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """The shell entrypoint seeds crs-setup.conf without haproxy.cfg; the
+    Python seeder must replace that stub with the full rendered release so
+    CRS rule 901001 does not keep firing."""
+    runtime_root = tmp_path / "generated"
+    stub_dir = runtime_root / "releases" / "seed"
+    stub_dir.mkdir(parents=True)
+    (stub_dir / "crs-setup.conf").write_text("SecRuleEngine On\n", encoding="utf-8")
+    (stub_dir / "rule-overrides.conf").write_text("# stub\n", encoding="utf-8")
+    (runtime_root / "current").symlink_to("releases/seed")
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=True, output="valid"),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    current = runtime_root / "current"
+    assert current.resolve() != stub_dir.resolve()
+    assert (current / "haproxy.cfg").exists()
+    assert (current / "crs-setup.conf").read_text(
+        encoding="utf-8"
+    ) == "SecRuleEngine On\n"
+
+
 def test_seed_runtime_config_is_noop_when_current_already_exists(
     tmp_path: Path,
     monkeypatch,

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -74,7 +74,9 @@ def test_haproxy_template_parameterises_vhost_and_backend() -> None:
     assert "acl host_api hdr(host),field(1,:) -i api.example.com" in rendered
     assert "http-request deny deny_status 421 if !host_api" in rendered
     assert "use_backend be_api if host_api" in rendered
-    assert "default_backend be_api" in rendered
+    # Unknown hosts are denied with 421 before backend selection, so the
+    # generated config must not contain an unreachable default_backend.
+    assert "default_backend" not in rendered
     assert "server api api-backend:9000 check" in rendered
 
 


### PR DESCRIPTION
## Summary
- `/config/apply` now persists validation and reload `RuntimeOperation` rows, so `/runtime/status` reflects "Deployed"/"Failed" instead of always "Never Deployed" (#20)
- The entrypoint's CRS seed stub now includes rule `900990` (`crs_setup_version`), and `seed_runtime_config` replaces the stub once `haproxy.cfg` is missing, so CRS rule `901001` no longer fires after `make lab-up` (#19)
- `haproxy.cfg.j2`: drop the stale M1 narrative header, trim tutorial comments, remove the dev-only `X-WAF-Score` debug header and `listen stats` block, and remove the unreachable `default_backend` (unknown hosts are already rejected with 421 before any `use_backend`); the reference `configs/haproxy/haproxy.cfg` is regenerated to match (#14)
- Reload `RuntimeOperation` rows now record `reload_output` (was incorrectly using the top-level summary `message`), for consistency with the validation row's `validation_output`

## Test plan
- [x] `uv run --extra dev pytest` (390 passed)
- [x] `uv run --extra dev mypy app/`
- [x] `uv run --extra dev ruff check app/`
- [x] `haproxy -c` against the regenerated reference config (passes; only DNS-resolution notices outside Docker)
