### PR TITLE
docs: rewrite README, document user management, trim lab-up output

### DIFF
--- a/README.commands.md
+++ b/README.commands.md
@@ -64,6 +64,33 @@ make clean                                                           # Stop stac
 make seed                                                            # Seed admin user in backend container
 ```
 
+## User Management
+
+There is no REST endpoint for managing users; accounts are managed with the
+backend CLI scripts (run inside the backend container via `make`).
+
+```bash
+# Bootstrap the first admin (idempotent; reads ADMIN_EMAIL / ADMIN_PASSWORD
+# from deploy/docker/.env when --email/--password are omitted)
+make seed
+
+# Manage further accounts with the manage_users.py CLI
+make users ARGS="create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice' --role viewer"
+make users ARGS="list"                                # All users (add --json for JSON output)
+make users ARGS="list --role admin --active"          # Filtered list
+make users ARGS="update alice@example.com --role admin"  # Promote by email
+make users ARGS="update 3 --deactivate"               # Deactivate by user ID
+make users ARGS="update 3 --password '<new password>'"   # Reset a password
+```
+
+Outside Docker (local backend checkout):
+
+```bash
+cd src/backend
+uv run python scripts/seed_admin.py --email admin@example.com --password '<min 12 chars>'
+uv run python scripts/manage_users.py --help
+```
+
 ## Smoke Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Developed as a master's thesis at Wrocław University DSW.
 
 ---
 
+## Features
+
+- **Reverse proxy + WAF** — HAProxy 3.0 inspects every request through the Coraza SPOA (OWASP CRS 4.x), blocks attacks with 403, and fails closed (503) when the WAF is unavailable.
+- **Virtual host management** — register domains and backend targets from the admin panel; unknown hosts are rejected before WAF inspection.
+- **Policy management** — paranoia level, anomaly thresholds, enforcement mode (block / detect-only), and per-policy CRS rule overrides.
+- **One-click config deployment** — `POST /config/apply` renders HAProxy/Coraza config from the database, validates it, atomically swaps it in, reloads HAProxy, and rolls back on failure. Deployment status is shown live on the dashboard.
+- **WAF event logs** — a sidecar log shipper ingests Coraza audit events into PostgreSQL; the panel provides filtering, pagination, and event detail views.
+- **Authentication and roles** — JWT-based login with admin/viewer roles and CLI user management.
+- **Evaluation lab** — reproducible benchmark environment (Juice Shop, DVWA, WordPress, go-ftw) for measuring WAF effectiveness and overhead.
+
 ## Architecture
 
 ```mermaid
@@ -16,32 +26,15 @@ graph TB
     H -.->|SPOE| CS[Coraza WAF]
     CS -.->|Allow / Deny| H
     H --> APP[Backend Apps]
+    CS --> LS[Log shipper]
+    LS -->|Ingest API| BE
 
     FE[React Admin Panel] -->|REST API| BE[FastAPI]
     BE -->|Generated config| H
     BE --> DB[(PostgreSQL)]
 ```
 
----
-
-## What's Implemented
-
-### Milestone 1 — Vertical slice ✅
-- HAProxy 3.0 reverse proxy with SPOE integration
-- Coraza SPOA + OWASP CRS 4.x for request inspection
-- Fail-closed degraded mode when Coraza is unavailable
-- FastAPI backend: auth, vhosts, policies, rule overrides, WAF logs, health
-- React admin panel: dashboard, login, vhost management, policy editing
-- Docker Compose full-stack deployment
-
-### Milestone 2 — Config generator ✅
-- Multi-vhost HAProxy + Coraza config generation from stored policies
-- `POST /config/apply` endpoint with atomic swap and automatic rollback
-- inotify-based config reload supervisor (no Docker socket dependency)
-- Live runtime deployment status card in the dashboard
-- Apply-config button in the admin panel
-
----
+See [README.architecture.md](README.architecture.md) for the full data flow.
 
 ## Tech Stack
 
@@ -53,39 +46,6 @@ graph TB
 | Frontend | React, TypeScript, Vite, Tailwind CSS |
 | Package mgmt | uv (Python), pnpm (Node) |
 | Infrastructure | Docker Compose |
-
----
-
-## Roadmap
-
-| Milestone | Scope | Status |
-|---|---|---|
-| M0 | Cleanup & scaffolding | Done |
-| M1 | Vertical slice — full stack end-to-end | Done |
-| M2 | Config generator & live apply | Done |
-| M3 | WAF log ingestion, presentation, and dashboard evidence | Done |
-| M4 | Policy hardening and per-vhost rule tuning | Path B |
-| M5 | Panel hardening and DevEx | Done |
-| M6 | Thesis evaluation — benchmarks, ZAP, Nuclei, CRS suite, comparison work | Path A active |
-| Post-MVP | Product expansion outside the thesis MVP | Deferred |
-
-### Delivery order
-
-The thesis-critical path is:
-
-```text
-M3 -> M5 -> M6
-```
-
-That path should produce the demo and thesis evidence first: visible WAF logs, runtime/dashboard status, health checks, user/admin basics, benchmark harnesses, effectiveness tests, and false-positive/false-negative analysis.
-
-Path B work can run after that convergence point, or in parallel only when it does not slow the thesis path:
-
-```text
-M4 policy depth -> M3/M5 polish -> optional M6 comparisons -> Post-MVP backlog
-```
-
-Path B covers richer policy tuning, path-scoped bindings, custom rules, live log streaming, pagination, password-management polish, product analytics, GeoIP/DDoS features, TLS automation, and advanced backend routing.
 
 ---
 
@@ -105,8 +65,17 @@ cp deploy/docker/.env.example deploy/docker/.env
 make run       # normal mode or
 make dev       # HAProxy + Coraza debug logging
 
-make seed      # add the initial admin user
+make seed      # add the initial admin user (ADMIN_EMAIL / ADMIN_PASSWORD from .env)
 ```
+
+Additional accounts are managed with the user CLI, e.g.:
+
+```bash
+make users ARGS="create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice'"
+make users ARGS="list"
+```
+
+See [User Management](README.commands.md#user-management) for all commands.
 
 ### Access
 
@@ -137,8 +106,12 @@ make clean   # stop containers and remove all volumes
 ## Documentation
 
 - [Architecture](README.architecture.md) — system architecture and data flow
-- [Development Commands](README.commands.md) — all dev commands
+- [Development Commands](README.commands.md) — all dev commands, including user management
 - [Testing Strategy](README.testing.md) — testing approach and targets
+- [Evaluation Plan](docs/evaluation-plan.md) — thesis benchmark methodology and lab scenarios
+- [HAProxy configs](configs/haproxy/README.md) — SPOE wiring, degraded mode, troubleshooting
+- [Coraza configs](configs/coraza/README.md) — CRS bundle, audit log mapping
+- [Frontend](src/frontend/README.md) — admin panel development notes
 - [Project board](https://github.com/users/bihius/projects/1) — task breakdown
 - [Milestones](https://github.com/bihius/guard-proxy/milestones)
 

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -28,18 +28,18 @@ EFFECTIVE_RUN_ID := $(RUN_ID)-$(POLICY)
 ## Bring up the real stack + all lab targets and register vhosts.
 lab-up:
 	@echo "==> Starting guard-proxy stack + lab targets..."
-	$(COMPOSE) up -d --build
+	@$(COMPOSE) up -d --build
 	@echo "==> Seeding admin user..."
-	$(COMPOSE) exec -T backend /app/.venv/bin/python scripts/seed_admin.py
+	@$(COMPOSE) exec -T backend /app/.venv/bin/python scripts/seed_admin.py
 	@echo "==> Waiting for HAProxy master socket..."
-	$(COMPOSE) exec -T backend sh -c \
+	@$(COMPOSE) exec -T backend sh -c \
 	  'deadline=$$((SECONDS+120)); \
 	   until test -S /var/run/haproxy/master.sock; do \
 	     if [ $$SECONDS -ge $$deadline ]; then echo "Timed out waiting for HAProxy master socket" >&2; exit 1; fi; \
 	     sleep 2; \
 	   done; echo "HAProxy master socket is ready."'
 	@echo "==> Seeding vhosts..."
-	bash $(REPO_ROOT)/benchmarks/lab/setup-lab.sh --skip-compose
+	@bash $(REPO_ROOT)/benchmarks/lab/setup-lab.sh --skip-compose
 
 ## Stop the lab (preserve volumes).
 lab-down:

--- a/benchmarks/lab/.env.example
+++ b/benchmarks/lab/.env.example
@@ -1,16 +1,16 @@
 # Copy to benchmarks/lab/.env before running the eval lab.
-# These are local-lab defaults only — never use these credentials in production.
+# These are local-lab defaults only -- never use these credentials in production.
 
-# ── DVWA database ─────────────────────────────────────────────────────────
+# --- DVWA database ----------------------------------------------------------
 DVWA_DB_ROOT_PASSWORD=dvwa_root_pw
 DVWA_DB_PASSWORD=dvwa_pw
 
-# ── WordPress database ────────────────────────────────────────────────────
+# --- WordPress database -----------------------------------------------------
 WP_DB_ROOT_PASSWORD=wp_root_pw
 WP_DB_PASSWORD=wp_pw
 WP_ADMIN_PASSWORD=LabAdmin12345!
 
-# ── Lab policy settings (used by setup-lab.sh) ────────────────────────────
+# --- Lab policy settings (used by setup-lab.sh) -----------------------------
 # Baseline policy: PL1, anomaly threshold 5, block mode
 LAB_POLICY_NAME=Lab Baseline
 LAB_POLICY_PARANOIA=1
@@ -23,10 +23,10 @@ LAB_PL2_POLICY_PARANOIA=2
 LAB_PL2_POLICY_INBOUND_THRESHOLD=3
 LAB_PL2_POLICY_OUTBOUND_THRESHOLD=3
 
-# ── CPU pinning (optional) ─────────────────────────────────────────────────
+# --- CPU pinning (optional) -------------------------------------------------
 # Pin the WAF stack + targets to one core range, and load-generator/scanner
 # containers to a separate range, to reduce noisy-neighbour contention on
-# shared hosts. Leave empty (default) for no pinning — required on hosts
+# shared hosts. Leave empty (default) for no pinning -- required on hosts
 # with fewer cores than the ranges below, or when running outside a
 # dedicated lab host.
 # Example used for the thesis lab (24-core host):
@@ -35,7 +35,7 @@ LAB_PL2_POLICY_OUTBOUND_THRESHOLD=3
 LAB_WAF_CPUSET=
 LAB_ATTACKER_CPUSET=
 
-# ── Vhost domains ─────────────────────────────────────────────────────────
+# --- Vhost domains -----------------------------------------------------------
 LAB_JUICESHOP_DOMAIN=juice.local
 LAB_JUICESHOP_BACKEND_URL=http://juiceshop:3000
 

--- a/benchmarks/lab/setup-lab.sh
+++ b/benchmarks/lab/setup-lab.sh
@@ -128,7 +128,6 @@ PY
 
 ensure_vhost() {
   local domain="$1"; local backend_url="$2"; local description="$3"; local policy_id="$4"
-  echo "Ensuring vhost ${domain} -> ${backend_url}..."
   local vhost_body vhost_response vhost_id
   vhost_body="$(printf '{"domain":%s,"backend_url":%s,"description":%s,"ssl_enabled":false,"is_active":true,"policy_id":%s}' \
     "$(json_string "${domain}")" "$(json_string "${backend_url}")" \
@@ -207,6 +206,7 @@ LAB_DVWA_BACKEND_URL="$(env_value LAB_DVWA_BACKEND_URL http://dvwa:80)"
 LAB_WP_DOMAIN="$(env_value LAB_WP_DOMAIN wp.local)"
 LAB_WP_BACKEND_URL="$(env_value LAB_WP_BACKEND_URL http://wordpress:80)"
 
+echo "Registering lab vhosts (${LAB_JUICESHOP_DOMAIN}, ${LAB_FTW_DOMAIN}, ${LAB_DVWA_DOMAIN}, ${LAB_WP_DOMAIN})..."
 ensure_vhost "${LAB_JUICESHOP_DOMAIN}" "${LAB_JUICESHOP_BACKEND_URL}" "OWASP Juice Shop — intentionally vulnerable app" "${baseline_policy_id}"
 ensure_vhost "${LAB_FTW_DOMAIN}" "${LAB_FTW_BACKEND_URL}" "Albedo — CRS go-ftw regression backend" "${baseline_policy_id}"
 ensure_vhost "${LAB_DVWA_DOMAIN}" "${LAB_DVWA_BACKEND_URL}" "DVWA — Damn Vulnerable Web Application" "${baseline_policy_id}"
@@ -225,12 +225,5 @@ curl -sf --max-time 30 \
   -H "Host: ${LAB_DVWA_DOMAIN}" >/dev/null || echo "DVWA setup.php returned non-200 (may already be initialised)"
 
 echo
-echo "Eval lab is ready."
-echo "  Juice Shop:  curl -H 'Host: ${LAB_JUICESHOP_DOMAIN}' ${WAF_BASE_URL}/"
-echo "  FTW backend: curl -H 'Host: ${LAB_FTW_DOMAIN}' ${WAF_BASE_URL}/"
-echo "  DVWA:        curl -H 'Host: ${LAB_DVWA_DOMAIN}' ${WAF_BASE_URL}/"
-echo "  WordPress:   curl -H 'Host: ${LAB_WP_DOMAIN}' ${WAF_BASE_URL}/"
-echo
-echo "Quick smoke:"
-echo "  curl -si -H 'Host: ${LAB_JUICESHOP_DOMAIN}' '${WAF_BASE_URL}/?q=1+UNION+SELECT+1--' | grep 'HTTP/'"
-echo "  (expect 403 — WAF blocking SQLi)"
+echo "Eval lab ready: ${LAB_JUICESHOP_DOMAIN}, ${LAB_FTW_DOMAIN}, ${LAB_DVWA_DOMAIN}, ${LAB_WP_DOMAIN} via ${WAF_BASE_URL} (curl -H 'Host: <domain>')."
+echo "Smoke (expect 403): curl -si -H 'Host: ${LAB_JUICESHOP_DOMAIN}' '${WAF_BASE_URL}/?q=1+UNION+SELECT+1--' | grep 'HTTP/'"

--- a/src/backend/scripts/seed_admin.py
+++ b/src/backend/scripts/seed_admin.py
@@ -30,14 +30,15 @@ from app.passwords import hash_password  # noqa: E402
 
 
 def seed_admin(email: str, password: str, full_name: str = "Administrator") -> None:
-    """Tworzy pierwszego admina jeśli żaden nie istnieje w bazie.
+    """Create the first admin user if none exists in the database.
 
-    Sprawdzamy czy istnieje *jakikolwiek* user z rolą admin — nie tylko
-    czy podany email jest zajęty. Dzięki temu skrypt jest idempotentny
-    i nie tworzy duplikatów adminów przy ponownym uruchomieniu.
+    The check looks for *any* user with the admin role, not just whether the
+    given email is taken. This keeps the script idempotent: re-running it
+    never creates duplicate admins.
 
-    Przed insertem sprawdzamy też czy podany email nie jest już zajęty
-    przez innego usera — unikamy IntegrityError na unikalnym kolumnie email.
+    Before inserting, the script also verifies the given email is not already
+    used by another user, avoiding an IntegrityError on the unique email
+    column.
     """
     db = SessionLocal()
     try:


### PR DESCRIPTION
## Summary
- `README.md`: drop the "What's Implemented" / Path A-B planning prose, keep a current feature overview, architecture diagram, quick start (including `make users`), and a docs index for sub-READMEs and the evaluation plan (#8)
- `README.commands.md`: add a "User Management" section documenting `scripts/seed_admin.py` and `scripts/manage_users.py` (#7)
- `seed_admin.py`: translate the Polish docstring to English (#7)
- `benchmarks`: silence compose command echo, condense per-vhost "Ensuring..." output to one summary line, and shorten the `make lab-up` closing banner (#17)
- `benchmarks/lab/.env.example`: replace UTF-8 box-drawing/em-dash characters with ASCII so the file renders correctly under any locale (#18)

## Test plan
- [x] `file benchmarks/lab/.env.example` -> ASCII text
- [x] `bash -n benchmarks/lab/setup-lab.sh`