### PR TITLE
Fix policy UI polish and session refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,12 @@ CODEX.md
 .opencode/
 .opencodeignore
 opencode.json
+.agents/
 
 scripts/setup-worktree.sh
 
+.ruff_cache/
+
+workspace
+
+.dockerignore

--- a/README.architecture.md
+++ b/README.architecture.md
@@ -109,9 +109,10 @@ machine-readable degraded reason header.
 ## Authentication & Rate Limiting
 
 The FastAPI backend issues short-lived **JWT access tokens** (30 min, HS256) and
-long-lived **refresh tokens** (7 days) stored in an `HttpOnly` cookie at path
-`/auth`. The refresh cookie is unavailable to JavaScript, so the frontend keeps
-no long-lived secret in memory or `localStorage`.
+long-lived **refresh tokens** (7 days) stored in an `HttpOnly` cookie. The
+refresh cookie path defaults to `/` so it is sent through proxied API prefixes
+such as `/api/v1/auth/refresh`, while remaining unavailable to JavaScript. The
+frontend keeps no long-lived secret in memory or `localStorage`.
 
 ### Brute-force protection
 

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -27,6 +27,7 @@ DEBUG=false
 
 # Optional auth cookie settings
 # AUTH_REFRESH_COOKIE_NAME=guard_proxy_refresh_token
+# AUTH_REFRESH_COOKIE_PATH=/
 # AUTH_REFRESH_COOKIE_SECURE=false
 # AUTH_REFRESH_COOKIE_SAMESITE=lax
 #

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -108,6 +108,7 @@ class Settings(EnvFileSettings):
     jwt_access_token_expire_minutes: int = 30
     jwt_refresh_token_expire_days: int = 7
     auth_refresh_cookie_name: str = "guard_proxy_refresh_token"
+    auth_refresh_cookie_path: str = "/"
     auth_refresh_cookie_secure: bool = False
     auth_refresh_cookie_samesite: Literal["lax", "strict", "none"] = "lax"
     log_ingest_shared_secret: str
@@ -123,6 +124,14 @@ class Settings(EnvFileSettings):
         if not v.strip():
             raise ValueError("AUTH_REFRESH_COOKIE_NAME must not be empty.")
         return v
+
+    @field_validator("auth_refresh_cookie_path")
+    @classmethod
+    def auth_refresh_cookie_path_must_be_absolute(cls, v: str) -> str:
+        value = v.strip()
+        if not value.startswith("/"):
+            raise ValueError("AUTH_REFRESH_COOKIE_PATH must start with '/'.")
+        return value
 
     @field_validator("log_ingest_shared_secret")
     @classmethod

--- a/src/backend/app/routers/auth.py
+++ b/src/backend/app/routers/auth.py
@@ -14,7 +14,6 @@ from app.schemas.user import UserResponse
 from app.services import auth_service
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-_REFRESH_COOKIE_PATH = "/auth"
 
 # Precomputed bcrypt hash used for timing-attack mitigation when user is missing.
 # Keep this as a constant to avoid bcrypt work during module import/startup.
@@ -35,7 +34,7 @@ def _set_refresh_cookie(response: Response, refresh_token: str) -> None:
         httponly=True,
         secure=settings.auth_refresh_cookie_secure,
         samesite=settings.auth_refresh_cookie_samesite,
-        path=_REFRESH_COOKIE_PATH,
+        path=settings.auth_refresh_cookie_path,
     )
 
 
@@ -45,7 +44,7 @@ def _clear_refresh_cookie(response: Response) -> None:
         httponly=True,
         secure=settings.auth_refresh_cookie_secure,
         samesite=settings.auth_refresh_cookie_samesite,
-        path=_REFRESH_COOKIE_PATH,
+        path=settings.auth_refresh_cookie_path,
     )
 
 

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -143,10 +143,7 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
             status=ApplyStatus.success,
             correlation_id=correlation_id,
             checksum=checksum,
-            message=(
-                "Configuration applied. HAProxy reloaded; Coraza is reloading "
-                "the updated WAF ruleset (within ~1s)."
-            ),
+            message="Configuration applied.",
             candidate_path=str(candidate_dir),
             active_path=str(_resolve_current(current_link)),
             validation_output=validation.output,

--- a/src/backend/tests/integration/test_auth_router.py
+++ b/src/backend/tests/integration/test_auth_router.py
@@ -22,6 +22,7 @@ def test_login_valid_admin_returns_200_and_sets_refresh_cookie(
     assert body["token_type"] == "bearer"
     assert settings.auth_refresh_cookie_name in resp.cookies
     assert "HttpOnly" in resp.headers["set-cookie"]
+    assert f"Path={settings.auth_refresh_cookie_path}" in resp.headers["set-cookie"]
 
 
 def test_login_valid_viewer_returns_200_and_sets_refresh_cookie(

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -114,6 +114,23 @@ def test_default_refresh_token_expire_days() -> None:
     assert getattr(s, "jwt_refresh_token_expire_days") == 7
 
 
+def test_default_auth_refresh_cookie_path_covers_api_prefix() -> None:
+    s = _make_settings(
+        JWT_SECRET_KEY="sekret",
+        LOG_INGEST_SHARED_SECRET="test-log-ingest-secret",
+    )
+    assert getattr(s, "auth_refresh_cookie_path") == "/"
+
+
+def test_auth_refresh_cookie_path_must_be_absolute() -> None:
+    with pytest.raises(ValidationError, match="AUTH_REFRESH_COOKIE_PATH"):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            AUTH_REFRESH_COOKIE_PATH="auth",
+        )
+
+
 def test_log_ingest_shared_secret_valid() -> None:
     s = _make_settings(
         JWT_SECRET_KEY="sekret",

--- a/src/frontend/src/components/shared/InfoTooltip.test.tsx
+++ b/src/frontend/src/components/shared/InfoTooltip.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InfoTooltip } from "./InfoTooltip";
+
+describe("InfoTooltip", () => {
+  it("exposes help text through the trigger and tooltip", () => {
+    render(<InfoTooltip label="Helpful policy explanation" />);
+
+    expect(
+      screen.getByRole("button", { name: "Helpful policy explanation" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Helpful policy explanation")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/shared/InfoTooltip.tsx
+++ b/src/frontend/src/components/shared/InfoTooltip.tsx
@@ -1,0 +1,23 @@
+import { CircleHelp } from "lucide-react";
+
+type InfoTooltipProps = {
+  label: string;
+};
+
+export function InfoTooltip({ label }: InfoTooltipProps) {
+  return (
+    <span className="group relative inline-flex">
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        aria-label={label}
+        title={label}
+      >
+        <CircleHelp className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <span className="pointer-events-none absolute left-1/2 top-6 z-50 hidden w-64 -translate-x-1/2 rounded-md border border-border bg-card px-3 py-2 text-xs font-normal leading-5 text-foreground shadow-lg group-hover:block group-focus-within:block">
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/src/frontend/src/components/shared/SectionCard.tsx
+++ b/src/frontend/src/components/shared/SectionCard.tsx
@@ -8,9 +8,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
+import { InfoTooltip } from "./InfoTooltip";
+
 type SectionCardProps = {
   title: string;
   description?: string;
+  descriptionDisplay?: "visible" | "tooltip";
   icon?: ReactNode;
   actions?: ReactNode;
   children: ReactNode;
@@ -19,6 +22,7 @@ type SectionCardProps = {
 export function SectionCard({
   title,
   description,
+  descriptionDisplay = "visible",
   icon,
   actions,
   children,
@@ -34,8 +38,13 @@ export function SectionCard({
           ) : null}
 
           <div className="space-y-1">
-            <CardTitle>{title}</CardTitle>
-            {description ? (
+            <div className="flex items-center gap-2">
+              <CardTitle>{title}</CardTitle>
+              {description && descriptionDisplay === "tooltip" ? (
+                <InfoTooltip label={description} />
+              ) : null}
+            </div>
+            {description && descriptionDisplay === "visible" ? (
               <CardDescription>{description}</CardDescription>
             ) : null}
           </div>

--- a/src/frontend/src/components/ui/badge.tsx
+++ b/src/frontend/src/components/ui/badge.tsx
@@ -8,12 +8,12 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "border-primary/30 bg-primary/10 text-primary",
-        secondary: "border-border bg-secondary text-secondary-foreground",
-        success: "border-success/30 bg-success/10 text-success",
-        warning: "border-warning/30 bg-warning/10 text-warning",
-        destructive: "border-destructive/30 bg-destructive/10 text-destructive",
-        outline: "border-border text-muted-foreground",
+        default: "border-primary/30 bg-primary/10 text-foreground",
+        secondary: "border-border bg-secondary text-foreground",
+        success: "border-success/30 bg-success/10 text-foreground",
+        warning: "border-warning/30 bg-warning/10 text-foreground",
+        destructive: "border-destructive/30 bg-destructive/10 text-foreground",
+        outline: "border-border text-foreground",
       },
     },
     defaultVariants: {

--- a/src/frontend/src/features/logs/LogDetailModal.tsx
+++ b/src/frontend/src/features/logs/LogDetailModal.tsx
@@ -107,7 +107,7 @@ export function LogDetailModal({ log, onClose }: LogDetailModalProps) {
                   {showRawContext ? "Hide raw context" : "Show raw context"}
                 </Button>
                 {showRawContext && (
-                  <pre className="max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs text-foreground">
+                  <pre className="max-h-80 max-w-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs text-foreground">
                     {JSON.stringify(log.raw_context, null, 2)}
                   </pre>
                 )}

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useState } from "react";
 
+import { InfoTooltip } from "@/components/shared/InfoTooltip";
 import { Modal } from "@/components/shared/Modal";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -137,7 +138,10 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
         </div>
 
         <div className="space-y-1.5">
-          <Label htmlFor="policy-enforcement-mode">Enforcement mode</Label>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="policy-enforcement-mode">Enforcement mode</Label>
+            <InfoTooltip label="Block denies requests that exceed the policy threshold. Detect only logs matches without blocking traffic." />
+          </div>
           <Select
             id="policy-enforcement-mode"
             value={enforcementMode}
@@ -149,7 +153,10 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
         </div>
 
         <div className="space-y-1.5">
-          <Label htmlFor="policy-paranoia-level">Paranoia level</Label>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="policy-paranoia-level">Paranoia level</Label>
+            <InfoTooltip label="Higher paranoia levels enable stricter CRS checks. Start low and raise only when the application tolerates the extra sensitivity." />
+          </div>
           <Select
             id="policy-paranoia-level"
             value={paranoiaLevel}
@@ -163,7 +170,10 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
         </div>
 
         <div className="space-y-1.5">
-          <Label htmlFor="policy-inbound-threshold">Inbound threshold</Label>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="policy-inbound-threshold">Inbound threshold</Label>
+            <InfoTooltip label="Requests are treated as suspicious when their inbound anomaly score reaches this threshold." />
+          </div>
           <Input
             id="policy-inbound-threshold"
             type="number"

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -84,7 +84,6 @@ export function DashboardPage() {
       <div className="grid gap-5 xl:grid-cols-[1.25fr_1fr]">
         <SectionCard
           title="Recent activity"
-          description="Example of a section-level card that a teammate can later fill with API data."
         >
           <div className="space-y-4">
             <ActivityRow

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -193,4 +193,32 @@ describe("LogsPage", () => {
     expect(screen.getByText("SQL injection attack detected")).toBeInTheDocument();
     expect(screen.getByText("203.0.113.10")).toBeInTheDocument();
   });
+
+  it("wraps raw context in the detail modal", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue({
+      ...mockListResponse,
+      items: [
+        {
+          ...mockLog,
+          raw_context: {
+            long_value: "x".repeat(120),
+          },
+        },
+      ],
+    });
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /view/i }));
+    await userEvent.click(screen.getByRole("button", { name: /show raw context/i }));
+
+    const rawContext = screen.getByText((content, element) => {
+      return element?.tagName.toLowerCase() === "pre" && content.includes("long_value");
+    });
+    expect(rawContext).toHaveClass("whitespace-pre-wrap");
+    expect(rawContext).toHaveClass("break-words");
+    expect(rawContext).toHaveClass("overflow-x-hidden");
+  });
 });

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -112,10 +112,10 @@ function DateTimeRangePicker({ value, onChange }: DateTimeRangePickerProps) {
   }
 
   return (
-    <div className="rounded-lg border border-border bg-card p-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-          <span className="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <span className="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 text-foreground">
             <CalendarClock className="h-4 w-4" />
           </span>
           Time range
@@ -136,7 +136,7 @@ function DateTimeRangePicker({ value, onChange }: DateTimeRangePickerProps) {
         </div>
       </div>
 
-      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-3 xl:grid-cols-2">
         <DateTimeEndpoint
           label="From"
           dateId="filter-date-from"
@@ -325,52 +325,52 @@ export function LogsPage() {
       />
 
       <SectionCard title="Filters">
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          <div className="space-y-1.5">
-            <Label htmlFor="filter-vhost">VHost</Label>
-            <Input
-              id="filter-vhost"
-              type="text"
-              value={draft.vhost}
-              onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
-              placeholder="example.com (exact match)"
-            />
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(24rem,0.95fr)] lg:items-start">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="filter-vhost">VHost</Label>
+              <Input
+                id="filter-vhost"
+                type="text"
+                value={draft.vhost}
+                onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
+                placeholder="example.com (exact match)"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="filter-action">Action</Label>
+              <Select
+                id="filter-action"
+                value={draft.action}
+                onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
+              >
+                <option value="">All actions</option>
+                <option value="allow">Allow</option>
+                <option value="deny">Deny</option>
+                <option value="monitor">Monitor</option>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="filter-policy">Policy</Label>
+              <Select
+                id="filter-policy"
+                value={draft.policy_id ?? ""}
+                onChange={(e) =>
+                  setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
+                }
+              >
+                <option value="">All policies</option>
+                {policies.map((p) => (
+                  <option key={p.id} value={String(p.id)}>
+                    {p.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="filter-action">Action</Label>
-            <Select
-              id="filter-action"
-              value={draft.action}
-              onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
-            >
-              <option value="">All actions</option>
-              <option value="allow">Allow</option>
-              <option value="deny">Deny</option>
-              <option value="monitor">Monitor</option>
-            </Select>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="filter-policy">Policy</Label>
-            <Select
-              id="filter-policy"
-              value={draft.policy_id ?? ""}
-              onChange={(e) =>
-                setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
-              }
-            >
-              <option value="">All policies</option>
-              {policies.map((p) => (
-                <option key={p.id} value={String(p.id)}>
-                  {p.name}
-                </option>
-              ))}
-            </Select>
-          </div>
-        </div>
-
-        <div className="mt-4">
           <DateTimeRangePicker
             value={{
               date_from: draft.date_from,

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -40,7 +40,7 @@ export function PoliciesPage() {
       cell: (row) => (
         <Link
           to={getPolicyDetailPath(row.id)}
-          className="font-medium text-primary hover:underline"
+          className="font-medium text-foreground hover:underline"
         >
           {row.name}
         </Link>
@@ -65,7 +65,7 @@ export function PoliciesPage() {
       key: "thresholds",
       header: "Inbound threshold",
       cell: (row) => (
-        <span className="tabular-nums text-muted-foreground">
+        <span className="tabular-nums text-foreground">
           {row.inbound_anomaly_threshold}
         </span>
       ),
@@ -98,7 +98,13 @@ export function PoliciesPage() {
                   >
                     Edit
                   </Button>
-                  <span title={assigned ? "Assigned to a virtual host" : undefined}>
+                  <span
+                    title={
+                      assigned
+                        ? "Cannot delete because this policy is assigned to a virtual host"
+                        : undefined
+                    }
+                  >
                     <Button
                       type="button"
                       disabled={assigned}

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -100,8 +100,12 @@ export function PolicyDetailPage() {
         />
       ) : policy ? (
         <>
-          <SectionCard title="Policy settings" description="Current configuration for this WAF policy.">
-            <dl className="grid grid-cols-2 gap-x-8 gap-y-4 text-sm sm:grid-cols-3">
+          <SectionCard
+            title="Policy settings"
+            description="Current configuration for this WAF policy."
+            descriptionDisplay="tooltip"
+          >
+            <dl className="grid gap-4 text-sm sm:grid-cols-2 xl:grid-cols-4">
               <div>
                 <dt className="font-medium text-muted-foreground">Enforcement mode</dt>
                 <dd className="mt-1">
@@ -134,6 +138,7 @@ export function PolicyDetailPage() {
           <SectionCard
             title="Rule overrides"
             description="Individual CRS rules enabled or disabled for this policy."
+            descriptionDisplay="tooltip"
           >
             <DataTable
               columns={overrideColumns}


### PR DESCRIPTION
## Summary
- add reusable info tooltips for policy sections and policy form settings
- adjust policy list/detail colors, badge text, disabled-delete tooltip, and detail layout
- fix refresh cookie path so sessions survive page reloads through the /api/v1 proxy
- compact log filters with vhost/action/policy on the left and time range on the right
- wrap raw log context, simplify apply success copy, and remove dashboard placeholder text
- update docs, env example, and regression tests

Fixes #245

## Validation
- pnpm test
- pnpm run type-check
- pnpm run lint
- uv run pytest --cov=app
- uv run mypy app/
- uv run ruff check app/
- haproxy -c -f configs/haproxy/haproxy.cfg failed locally because /usr/local/etc/haproxy/coraza.cfg is not present on this host