### PR TITLE
fix(frontend): policy row click, Apply config visibility, logs layout density

### DIFF
--- a/src/frontend/src/features/runtime/ApplyConfigButton.test.tsx
+++ b/src/frontend/src/features/runtime/ApplyConfigButton.test.tsx
@@ -10,7 +10,7 @@ vi.mock("./api", () => ({
 
 import { useAuth } from "@/hooks/use-auth";
 import { applyConfig } from "./api";
-import type { ConfigApplyResponse } from "./types";
+import type { ConfigApplyResponse, RuntimeStatusResponse } from "./types";
 import { ApplyConfigButton } from "./ApplyConfigButton";
 
 const mockedUseAuth = vi.mocked(useAuth);
@@ -36,7 +36,27 @@ function makeAuth(role: "admin" | "viewer") {
   };
 }
 
-const noop = { refresh: vi.fn() };
+const pendingStatus: RuntimeStatusResponse = {
+  frontend_contract_version: "1",
+  deployment_state: "deployed",
+  generated_config: {
+    can_generate: true,
+    checksum: "new-checksum",
+    generated_at: "2026-01-01T00:00:00Z",
+    error: null,
+  },
+  latest_validation: null,
+  latest_reload: {
+    id: 1,
+    operation_type: "reload",
+    status: "success",
+    config_checksum: "old-checksum",
+    message: null,
+    created_at: "2026-01-01T00:00:00Z",
+  },
+};
+
+const noop = { data: pendingStatus, refresh: vi.fn() };
 
 describe("ApplyConfigButton", () => {
   beforeEach(() => {
@@ -52,6 +72,29 @@ describe("ApplyConfigButton", () => {
   it("returns null for viewer", () => {
     mockedUseAuth.mockReturnValue(makeAuth("viewer"));
     const { container } = render(<ApplyConfigButton runtimeStatus={noop} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("returns null for admin when there are no pending changes", () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    const upToDateStatus: RuntimeStatusResponse = {
+      ...pendingStatus,
+      latest_reload: {
+        ...pendingStatus.latest_reload!,
+        config_checksum: pendingStatus.generated_config.checksum,
+      },
+    };
+    const { container } = render(
+      <ApplyConfigButton runtimeStatus={{ data: upToDateStatus, refresh: vi.fn() }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("returns null for admin when runtime status has not loaded yet", () => {
+    mockedUseAuth.mockReturnValue(makeAuth("admin"));
+    const { container } = render(
+      <ApplyConfigButton runtimeStatus={{ data: null, refresh: vi.fn() }} />,
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -94,7 +137,7 @@ describe("ApplyConfigButton", () => {
 
     render(
       <ApplyConfigButton
-        runtimeStatus={{ refresh: refreshMock }}
+        runtimeStatus={{ data: pendingStatus, refresh: refreshMock }}
         onResult={onResult}
       />,
     );

--- a/src/frontend/src/features/runtime/ApplyConfigButton.tsx
+++ b/src/frontend/src/features/runtime/ApplyConfigButton.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
 
 import { applyConfig } from "./api";
+import type { RuntimeStatusResponse } from "./types";
 
 type ApplyResult = {
   kind: "success" | "error";
@@ -14,7 +15,10 @@ type ApplyResult = {
 };
 
 type ApplyConfigButtonProps = {
-  runtimeStatus: { refresh: () => void };
+  runtimeStatus: {
+    data: RuntimeStatusResponse | null;
+    refresh: () => void;
+  };
   onResult?: (result: ApplyResult) => void;
 };
 
@@ -25,7 +29,13 @@ export function ApplyConfigButton({
   const { hasRole, accessToken } = useAuth();
   const [isApplying, setIsApplying] = useState(false);
 
-  if (!hasRole("admin")) return null;
+  const data = runtimeStatus.data;
+  const hasPendingChanges =
+    !!data &&
+    !!data.generated_config.checksum &&
+    data.generated_config.checksum !== data.latest_reload?.config_checksum;
+
+  if (!hasRole("admin") || !hasPendingChanges) return null;
 
   async function handleClick() {
     if (isApplying || !accessToken) return;

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -109,12 +109,44 @@ describe("LogsPage", () => {
     );
   });
 
+  it("hides filter inputs until the Filters toggle is opened", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    expect(screen.queryByLabelText(/vhost/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    expect(screen.getByLabelText(/vhost/i)).toBeInTheDocument();
+  });
+
+  it("shows an active filter count badge after applying filters", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await userEvent.type(screen.getByLabelText(/vhost/i), "api.example.com");
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /filters/i })).toHaveTextContent("1"),
+    );
+  });
+
   it("labels the allow filter option to clarify it means flagged-but-allowed", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
     vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
 
     expect(
       screen.getByRole("option", { name: "Allowed (flagged)" }),
@@ -128,6 +160,7 @@ describe("LogsPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
 
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/vhost/i), "api.example.com");
     await userEvent.click(screen.getByRole("button", { name: /apply/i }));
 
@@ -177,6 +210,7 @@ describe("LogsPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
 
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     fireEvent.change(screen.getByLabelText("From date"), {
       target: { value: "2026-06-01" },
     });
@@ -211,6 +245,7 @@ describe("LogsPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
 
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/vhost/i), "something");
     await userEvent.click(screen.getByRole("button", { name: /clear/i }));
 

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -180,6 +180,7 @@ describe("LogsPage", () => {
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
 
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.selectOptions(screen.getByLabelText(/severity/i), "critical");
     await userEvent.type(screen.getByLabelText(/^method$/i), "POST");
     await userEvent.type(screen.getByLabelText(/source ip/i), "203.0.113.10");

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CalendarClock } from "lucide-react";
+import { CalendarClock, SlidersHorizontal } from "lucide-react";
 
 import type { DataTableColumn } from "@/components/shared/DataTable";
 import { DataTable } from "@/components/shared/DataTable";
@@ -231,7 +231,14 @@ export function LogsPage() {
   const { logs, total, page, pageSize, policies, isLoading, error, setPage, applyFilters, refresh } =
     useLogs();
   const [draft, setDraft] = useState<LogFilters>(EMPTY_FILTERS);
+  const [appliedFilters, setAppliedFilters] = useState<LogFilters>(EMPTY_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [selected, setSelected] = useState<Log | null>(null);
+
+  const activeFilterCount = Object.entries(appliedFilters).filter(([key, value]) => {
+    if (key === "policy_id") return value !== null;
+    return value !== "";
+  }).length;
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const columns: DataTableColumn<Log>[] = [
@@ -311,155 +318,181 @@ export function LogsPage() {
 
   function handleApply() {
     applyFilters(draft);
+    setAppliedFilters(draft);
   }
 
   function handleClear() {
     setDraft(EMPTY_FILTERS);
     applyFilters(EMPTY_FILTERS);
+    setAppliedFilters(EMPTY_FILTERS);
   }
 
   return (
-    <section className="space-y-8">
+    <section className="space-y-6">
       <PageHeader
         title="Logs"
         description="Browse and filter WAF events captured by Guard Proxy."
       />
 
-      <SectionCard title="Filters">
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(24rem,0.95fr)] lg:items-start">
-          <div className="grid gap-4 md:grid-cols-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-vhost">VHost</Label>
-              <Input
-                id="filter-vhost"
-                type="text"
-                value={draft.vhost}
-                onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
-                placeholder="example.com (exact match)"
-              />
-            </div>
+      <SectionCard
+        title="Events"
+        description="Most recent events first."
+        actions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setFiltersOpen((open) => !open)}
+            aria-expanded={filtersOpen}
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/10 px-1 text-xs font-medium text-primary">
+                {activeFilterCount}
+              </span>
+            )}
+          </Button>
+        }
+      >
+        {filtersOpen && (
+          <div className="mb-5 rounded-md border border-border bg-muted/30 p-4">
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(24rem,0.95fr)] lg:items-start">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-vhost">VHost</Label>
+                  <Input
+                    id="filter-vhost"
+                    type="text"
+                    value={draft.vhost}
+                    onChange={(e) => setDraft({ ...draft, vhost: e.target.value })}
+                    placeholder="example.com (exact match)"
+                  />
+                </div>
 
-            <div className="space-y-1.5">
-              <div className="flex items-center gap-1.5">
-                <Label htmlFor="filter-action">Action</Label>
-                <InfoTooltip label="Guard Proxy only logs requests that triggered at least one WAF rule. 'Allowed (flagged)' means a rule matched but the combined score stayed under the policy's anomaly threshold, so the request was let through. Fully clean traffic that never matches a rule is not logged." />
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5">
+                    <Label htmlFor="filter-action">Action</Label>
+                    <InfoTooltip label="Guard Proxy only logs requests that triggered at least one WAF rule. 'Allowed (flagged)' means a rule matched but the combined score stayed under the policy's anomaly threshold, so the request was let through. Fully clean traffic that never matches a rule is not logged." />
+                  </div>
+                  <Select
+                    id="filter-action"
+                    value={draft.action}
+                    onChange={(e) =>
+                      setDraft({ ...draft, action: e.target.value as LogFilters["action"] })
+                    }
+                  >
+                    <option value="">All actions</option>
+                    <option value="allow">Allowed (flagged)</option>
+                    <option value="deny">Deny</option>
+                    <option value="monitor">Monitor</option>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-policy">Policy</Label>
+                  <Select
+                    id="filter-policy"
+                    value={draft.policy_id ?? ""}
+                    onChange={(e) =>
+                      setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
+                    }
+                  >
+                    <option value="">All policies</option>
+                    {policies.map((p) => (
+                      <option key={p.id} value={String(p.id)}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-severity">Severity</Label>
+                  <Select
+                    id="filter-severity"
+                    value={draft.severity}
+                    onChange={(e) =>
+                      setDraft({ ...draft, severity: e.target.value as LogFilters["severity"] })
+                    }
+                  >
+                    <option value="">All severities</option>
+                    <option value="info">Info</option>
+                    <option value="warning">Warning</option>
+                    <option value="error">Error</option>
+                    <option value="critical">Critical</option>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-method">Method</Label>
+                  <Input
+                    id="filter-method"
+                    type="text"
+                    value={draft.method}
+                    onChange={(e) => setDraft({ ...draft, method: e.target.value })}
+                    placeholder="GET, POST, …"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-source-ip">Source IP</Label>
+                  <Input
+                    id="filter-source-ip"
+                    type="text"
+                    value={draft.source_ip}
+                    onChange={(e) => setDraft({ ...draft, source_ip: e.target.value })}
+                    placeholder="203.0.113.10"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-rule-id">Rule ID</Label>
+                  <Input
+                    id="filter-rule-id"
+                    type="number"
+                    value={draft.rule_id ?? ""}
+                    onChange={(e) =>
+                      setDraft({ ...draft, rule_id: e.target.value ? Number(e.target.value) : null })
+                    }
+                    placeholder="942290"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="filter-min-score">Min anomaly score</Label>
+                  <Input
+                    id="filter-min-score"
+                    type="number"
+                    value={draft.min_score ?? ""}
+                    onChange={(e) =>
+                      setDraft({ ...draft, min_score: e.target.value ? Number(e.target.value) : null })
+                    }
+                    placeholder="5"
+                  />
+                </div>
               </div>
-              <Select
-                id="filter-action"
-                value={draft.action}
-                onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
-              >
-                <option value="">All actions</option>
-                <option value="allow">Allowed (flagged)</option>
-                <option value="deny">Deny</option>
-                <option value="monitor">Monitor</option>
-              </Select>
-            </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-policy">Policy</Label>
-              <Select
-                id="filter-policy"
-                value={draft.policy_id ?? ""}
-                onChange={(e) =>
-                  setDraft({ ...draft, policy_id: e.target.value ? Number(e.target.value) : null })
-                }
-              >
-                <option value="">All policies</option>
-                {policies.map((p) => (
-                  <option key={p.id} value={String(p.id)}>
-                    {p.name}
-                  </option>
-                ))}
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-severity">Severity</Label>
-              <Select
-                id="filter-severity"
-                value={draft.severity}
-                onChange={(e) =>
-                  setDraft({ ...draft, severity: e.target.value as LogFilters["severity"] })
-                }
-              >
-                <option value="">All severities</option>
-                <option value="info">Info</option>
-                <option value="warning">Warning</option>
-                <option value="error">Error</option>
-                <option value="critical">Critical</option>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-method">Method</Label>
-              <Input
-                id="filter-method"
-                type="text"
-                value={draft.method}
-                onChange={(e) => setDraft({ ...draft, method: e.target.value })}
-                placeholder="GET, POST, …"
+              <DateTimeRangePicker
+                value={{
+                  date_from: draft.date_from,
+                  date_to: draft.date_to,
+                }}
+                onChange={(range) => setDraft({ ...draft, ...range })}
               />
             </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-source-ip">Source IP</Label>
-              <Input
-                id="filter-source-ip"
-                type="text"
-                value={draft.source_ip}
-                onChange={(e) => setDraft({ ...draft, source_ip: e.target.value })}
-                placeholder="203.0.113.10"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-rule-id">Rule ID</Label>
-              <Input
-                id="filter-rule-id"
-                type="number"
-                value={draft.rule_id ?? ""}
-                onChange={(e) =>
-                  setDraft({ ...draft, rule_id: e.target.value ? Number(e.target.value) : null })
-                }
-                placeholder="942290"
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="filter-min-score">Min anomaly score</Label>
-              <Input
-                id="filter-min-score"
-                type="number"
-                value={draft.min_score ?? ""}
-                onChange={(e) =>
-                  setDraft({ ...draft, min_score: e.target.value ? Number(e.target.value) : null })
-                }
-                placeholder="5"
-              />
+            <div className="mt-4 flex gap-3">
+              <Button type="button" onClick={handleApply}>
+                Apply
+              </Button>
+              <Button type="button" onClick={handleClear} variant="outline">
+                Clear
+              </Button>
             </div>
           </div>
+        )}
 
-          <DateTimeRangePicker
-            value={{
-              date_from: draft.date_from,
-              date_to: draft.date_to,
-            }}
-            onChange={(range) => setDraft({ ...draft, ...range })}
-          />
-        </div>
-
-        <div className="mt-4 flex gap-3">
-          <Button type="button" onClick={handleApply}>
-            Apply
-          </Button>
-          <Button type="button" onClick={handleClear} variant="outline">
-            Clear
-          </Button>
-        </div>
-      </SectionCard>
-
-      <SectionCard title="Events" description="Most recent events first.">
         {isLoading ? (
           <LoadingState label="Loading logs…" />
         ) : error ? (

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -235,10 +235,9 @@ export function LogsPage() {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [selected, setSelected] = useState<Log | null>(null);
 
-  const activeFilterCount = Object.entries(appliedFilters).filter(([key, value]) => {
-    if (key === "policy_id") return value !== null;
-    return value !== "";
-  }).length;
+  const activeFilterCount = Object.values(appliedFilters).filter(
+    (value) => value !== "" && value !== null,
+  ).length;
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const columns: DataTableColumn<Log>[] = [

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import type { DataTableColumn } from "@/components/shared/DataTable";
 import { DataTable } from "@/components/shared/DataTable";
@@ -23,6 +23,7 @@ type ModalState =
   | { type: "delete"; policy: Policy };
 
 export function PoliciesPage() {
+  const navigate = useNavigate();
   const { hasRole } = useAuth();
   const { policies, assignedPolicyIds, isLoading, error, refresh } = usePolicies();
   const [modal, setModal] = useState<ModalState>(null);
@@ -92,7 +93,10 @@ export function PoliciesPage() {
                 <div className="flex items-center gap-2">
                   <Button
                     type="button"
-                    onClick={() => setModal({ type: "edit", policy: row })}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setModal({ type: "edit", policy: row });
+                    }}
                     variant="outline"
                     size="sm"
                   >
@@ -108,7 +112,10 @@ export function PoliciesPage() {
                     <Button
                       type="button"
                       disabled={assigned}
-                      onClick={() => setModal({ type: "delete", policy: row })}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setModal({ type: "delete", policy: row });
+                      }}
                       variant="destructive"
                       size="sm"
                     >
@@ -164,6 +171,7 @@ export function PoliciesPage() {
             getRowKey={(row) => String(row.id)}
             emptyTitle="No policies yet"
             emptyDescription="Create your first WAF policy to start protecting your virtual hosts."
+            onRowClick={(row) => navigate(getPolicyDetailPath(row.id))}
           />
         )}
       </SectionCard>


### PR DESCRIPTION
## Summary
- Clicking anywhere on a policy row now navigates to its detail page; Edit/Delete buttons keep working via `stopPropagation`.
- The "Apply config" button is hidden when the generated config checksum already matches the last applied checksum, instead of always showing for admins.
- The Logs page filters are now a collapsible panel behind a "Filters" toggle next to the Events card title (with an active-filter-count badge), replacing the full-width Filters card that consumed over half the viewport at 1920x1080.

Addresses the frontend UX issues from the policy-row-navigation / Apply-config-visibility / logs-page-density triage (no tracked GitHub issues exist for these yet).

## Test plan
- [x] `pnpm run type-check` and `pnpm run lint` pass
- [x] `pnpm run test` — 83/83 tests pass, including new coverage for the no-pending-changes/not-loaded states and the filters toggle/badge
- [x] Manually verified on a running instance at 1920x1080: policy row click navigates to `/policies/:id`, Logs page header+Events card fit well above the fold, Filters toggle expands/collapses the panel