### PR TITLE
fix(waf): relabel allow filter, fix PostHog cookie false positive, document multi-rule logging

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -106,6 +106,21 @@ machine-readable degraded reason header.
 5. FastAPI validates and normalizes payloads into the persisted `Log` model.
 6. `GET /logs` exposes stored events for the admin panel log viewer.
 
+**Limitation — one log row per request, even when multiple rules fire.** A
+single Coraza transaction can trigger several CRS rules at once (e.g. an SQL
+injection probe matching `942100`, `942190`, `942270`, and `942360`
+simultaneously). The `Log` model has no per-rule child table, so the shipper
+picks the **first** rule-bearing message as `rule_id`/`rule_message`
+(`_primary_rule_data` in `src/log-shipper/app/mapping.py`); the request still
+produces exactly one ingested log row, and `anomaly_score` reflects the
+*combined* score from all matched rules, not just the first one. The other
+matched rules are not lost — they remain in `raw_context` (the full Coraza
+event JSON) for manual inspection in the log detail view, but are not
+independently queryable or filterable. See
+`src/log-shipper/tests/test_mapping.py::test_multi_rule_request_collapses_to_one_ingest_payload`
+and `::test_multi_rule_request_preserves_all_matched_rules_in_raw_context`
+for the tested behavior. A per-rule breakdown is deferred post-MVP.
+
 ## Authentication & Rate Limiting
 
 The FastAPI backend issues short-lived **JWT access tokens** (30 min, HS256) and

--- a/configs/coraza/README.md
+++ b/configs/coraza/README.md
@@ -27,6 +27,7 @@ git submodule update --init --recursive
 | `coraza.conf` | Baseline Coraza directives and CRS includes |
 | `crs-setup.conf` | CRS paranoia and anomaly-scoring defaults |
 | `crs/` | Pinned OWASP CRS 4.x submodule |
+| `guard-proxy-exceptions.conf` | Guard Proxy-owned CRS false-positive exceptions, loaded after CRS rules. Not part of the `crs/` submodule, so it survives CRS version bumps. |
 
 ## Defaults
 
@@ -34,6 +35,38 @@ git submodule update --init --recursive
 - Response body inspection is disabled for M1, matching ADR-007.
 - Blocking paranoia level is `1`.
 - Inbound and outbound anomaly thresholds are `5`.
+
+### Why a single PL1 rule can block a request at the default threshold
+
+CRS scores each fired rule by severity and sums the scores per transaction
+into `tx.inbound_anomaly_score`. A request is blocked once that sum reaches
+`inbound_anomaly_threshold`. Severity → score: `critical` = 5, `error` = 4,
+`warning` = 3, `notice` = 2. At the default threshold of `5`, **one single
+`critical`-severity PL1 rule match is enough to block the request by
+itself** — there's no need for multiple rules to combine.
+
+This is exactly what happened with a real plain WordPress site
+(`wp.bihius.me`) under the default policy (`paranoia_level=1`,
+`inbound_anomaly_threshold=5`): rule **942290** ("Finds basic MongoDB SQL
+injection attempts", PL1, `critical` severity = score 5) fired on every
+request because the browser sent a PostHog analytics cookie
+(`ph_phc_<project_key>_posthog`) whose JSON value contains `$`-prefixed keys
+like `"$initialization_time"` — the literal substring `$in` collides with
+942290's MongoDB `$in` operator heuristic. One critical false positive ==
+threshold 5 → the request was denied (403), even though nothing in the
+request was attacker-controlled.
+
+This is a known false-positive class — CRS already ships built-in exclusions
+for the same pattern with Google Analytics/Ads cookies (`_ga`, `__gads`, see
+`crs/rules/REQUEST-999-COMMON-EXCEPTIONS-AFTER.conf`). The fix here follows
+the same approach for the PostHog cookie via `guard-proxy-exceptions.conf`
+(see the Files table above) rather than lowering the global anomaly
+threshold, which would weaken protection against real SQL/NoSQL injection
+attempts site-wide. Operators hitting similar noisy false positives from
+other third-party cookies/headers can add the same
+`SecRuleUpdateTargetById <rule> "!REQUEST_COOKIES:/pattern/"` pattern to that
+file, or raise `inbound_anomaly_threshold` for a specific noisy policy via
+the Policies UI as a coarser, per-vhost workaround.
 
 ## Audit log output
 

--- a/configs/coraza/coraza.conf
+++ b/configs/coraza/coraza.conf
@@ -20,4 +20,5 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 
 Include /runtime/current/crs-setup.conf
 Include /etc/coraza/crs/rules/*.conf
+Include /etc/coraza/guard-proxy-exceptions.conf
 Include /runtime/current/rule-overrides.conf

--- a/configs/coraza/guard-proxy-exceptions.conf
+++ b/configs/coraza/guard-proxy-exceptions.conf
@@ -1,0 +1,21 @@
+# Guard Proxy-owned CRS false-positive exceptions.
+#
+# Unlike configs/coraza/crs/rules/REQUEST-999-COMMON-EXCEPTIONS-AFTER.conf,
+# this file is NOT part of the OWASP CRS git submodule, so edits here survive
+# `git submodule update` / CRS version bumps. It follows the same
+# SecRuleUpdateTargetById pattern CRS itself uses for noisy third-party
+# cookies (see the _ga/__gads exclusions in the file above).
+#
+# Loaded after all CRS rule files (see coraza.conf), before per-policy
+# rule-overrides.conf.
+
+# PostHog analytics JS snippet (posthog-js) cookie: ph_phc_<project_key>_posthog
+# Stores a JSON blob with literal $-prefixed property names
+# (e.g. "$initialization_time", "$sesid", "$configured_session_timeout_ms").
+# The "$in" substring inside "$initialization_time" collides with rule
+# 942290's MongoDB "$in" operator heuristic, scoring a false-positive
+# critical hit (anomaly score 5) on every request from a browser that has
+# the cookie set — enough to single-handedly reach the default inbound
+# anomaly threshold of 5 and block the request. This is a third-party
+# analytics cookie, not attacker-controlled input.
+SecRuleUpdateTargetById 942290 "!REQUEST_COOKIES:/^ph_phc_.*_posthog$/"

--- a/deploy/docker/coraza.Dockerfile
+++ b/deploy/docker/coraza.Dockerfile
@@ -10,6 +10,7 @@ COPY --from=upstream /coraza-spoa /usr/local/bin/coraza-spoa
 COPY configs/coraza/coraza-spoa.yaml /etc/coraza-spoa/coraza-spoa.yaml
 COPY configs/coraza/coraza.conf /etc/coraza/coraza.conf
 COPY configs/coraza/crs-setup.conf /etc/coraza/crs-setup.conf
+COPY configs/coraza/guard-proxy-exceptions.conf /etc/coraza/guard-proxy-exceptions.conf
 COPY configs/coraza/crs /etc/coraza/crs
 COPY deploy/docker/coraza-supervisor.sh /usr/local/bin/coraza-supervisor
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       - ../../configs/coraza/coraza-spoa.yaml:/etc/coraza-spoa/coraza-spoa.yaml:ro
       - ../../configs/coraza/coraza.conf:/etc/coraza/coraza.conf:ro
       - ../../configs/coraza/crs-setup.conf:/etc/coraza/crs-setup.conf:ro
+      - ../../configs/coraza/guard-proxy-exceptions.conf:/etc/coraza/guard-proxy-exceptions.conf:ro
       - ../../configs/coraza/crs:/etc/coraza/crs:ro
       - generated_config:/runtime:ro
       - coraza_audit:/var/log/coraza

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -108,6 +108,18 @@ describe("LogsPage", () => {
     );
   });
 
+  it("labels the allow filter option to clarify it means flagged-but-allowed", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    expect(
+      screen.getByRole("option", { name: "Allowed (flagged)" }),
+    ).toBeInTheDocument();
+  });
+
   it("applying filters re-fetches with filter params", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
     vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);

--- a/src/frontend/src/pages/logs/LogsPage.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.tsx
@@ -6,6 +6,7 @@ import { DataTable } from "@/components/shared/DataTable";
 import { ErrorState } from "@/components/shared/ErrorState";
 import { LoadingState } from "@/components/shared/LoadingState";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { InfoTooltip } from "@/components/shared/InfoTooltip";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { Button } from "@/components/ui/button";
@@ -339,14 +340,17 @@ export function LogsPage() {
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="filter-action">Action</Label>
+              <div className="flex items-center gap-1.5">
+                <Label htmlFor="filter-action">Action</Label>
+                <InfoTooltip label="Guard Proxy only logs requests that triggered at least one WAF rule. 'Allowed (flagged)' means a rule matched but the combined score stayed under the policy's anomaly threshold, so the request was let through. Fully clean traffic that never matches a rule is not logged." />
+              </div>
               <Select
                 id="filter-action"
                 value={draft.action}
                 onChange={(e) => setDraft({ ...draft, action: e.target.value as LogFilters["action"] })}
               >
                 <option value="">All actions</option>
-                <option value="allow">Allow</option>
+                <option value="allow">Allowed (flagged)</option>
                 <option value="deny">Deny</option>
                 <option value="monitor">Monitor</option>
               </Select>

--- a/src/log-shipper/tests/test_mapping.py
+++ b/src/log-shipper/tests/test_mapping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from app.mapping import coraza_event_to_ingest
+from app.mapping import _BRACKET_INT, coraza_event_to_ingest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -421,3 +421,82 @@ def test_absent_variables_gives_none_score_and_level() -> None:
     assert payload is not None
     assert payload["anomaly_score"] is None
     assert payload["paranoia_level"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: a request flagged by multiple rules collapses to one log row
+# ---------------------------------------------------------------------------
+
+# Captured from a real SQLi probe against a lab WordPress vhost: four
+# distinct CRS attack rules fired on the same request (libinjection, MSSQL,
+# basic SQLi, concatenated SQLi), plus the blocking-evaluation meta-rule.
+_MULTI_RULE_EVENT: dict[str, Any] = {
+    "transaction": {
+        "timestamp": "2026/06/23 20:37:13",
+        "id": "multi-rule-tx-1",
+        "client_ip": "203.0.113.50",
+        "is_interrupted": True,
+        "request": {
+            "method": "GET",
+            "uri": "/?id=1 UNION SELECT username,password FROM users",
+            "headers": {"host": ["wp.example.com"]},
+        },
+        "response": {"status": 0},
+    },
+    "messages": [
+        _message_entry(
+            "942100", "SQL Injection Attack Detected via libinjection", "critical"
+        ),
+        _message_entry(
+            "942190",
+            "Detects MSSQL code execution and information gathering attempts",
+            "critical",
+        ),
+        _message_entry(
+            "942270", "Looking for basic sql injection", "critical"
+        ),
+        _message_entry(
+            "942360",
+            "Detects concatenated basic SQL injection and SQLLFI attempts",
+            "critical",
+        ),
+        {
+            "actionset": "", "message": "",
+            "error_message": (
+                '[client "203.0.113.50"] Coraza: Access denied (phase 2). '
+                'Inbound Anomaly Score Exceeded (Total Score: 20) '
+                '[file "/etc/coraza/crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf"] '
+                '[id "949110"] [msg "Inbound Anomaly Score Exceeded"] '
+                '[data ""] [severity "emergency"]'
+            ),
+            "data": None,
+        },
+    ],
+}
+
+
+def test_multi_rule_request_collapses_to_one_ingest_payload() -> None:
+    """A single request flagged by several rules still produces one payload."""
+    payload = coraza_event_to_ingest(_MULTI_RULE_EVENT)
+    assert payload is not None
+    # The first rule-bearing message wins for rule_id/rule_message...
+    assert payload["rule_id"] == 942100
+    assert payload["rule_message"] == "SQL Injection Attack Detected via libinjection"
+    # ...but the combined score (parsed from the blocking rule's message)
+    # reflects all four matches, not just the first.
+    assert payload["anomaly_score"] == 20
+    assert payload["action"] == "deny"
+
+
+def test_multi_rule_request_preserves_all_matched_rules_in_raw_context() -> None:
+    """The other matched rules are not lost — they survive in raw_context."""
+    payload = coraza_event_to_ingest(_MULTI_RULE_EVENT)
+    assert payload is not None
+    assert payload["raw_context"] is _MULTI_RULE_EVENT
+    raw_messages = payload["raw_context"]["messages"]
+    assert len(raw_messages) == 5
+    matched_ids = [
+        _BRACKET_INT.search(m["error_message"]).group(1)  # type: ignore[union-attr]
+        for m in raw_messages
+    ]
+    assert matched_ids == ["942100", "942190", "942270", "942360", "949110"]


### PR DESCRIPTION
## Summary
- Relabel the Logs "Allow" filter to "Allowed (flagged)" with an inline tooltip explaining that Guard Proxy only logs requests that triggered at least one WAF rule (`SecAuditEngine RelevantOnly`) — fully clean traffic is never logged, so "Allow" never meant "all traffic that reached the backend".
- Root-caused and fixed a real false positive: a plain request to a lab WordPress site (`wp.bihius.me`) was blocked under the default policy (`paranoia_level=1`, `inbound_anomaly_threshold=5`). The browser's PostHog analytics cookie stores JSON with `$`-prefixed keys (e.g. `"$initialization_time"`), and the literal `$in` substring collides with rule **942290**'s MongoDB injection heuristic — one critical false positive alone reaches the default threshold of 5. Added `configs/coraza/guard-proxy-exceptions.conf` (loaded after CRS, outside the `crs/` submodule so it survives CRS version bumps) excluding that cookie from rule 942290, following the same pattern CRS itself uses for Google Analytics/Ads cookies. **Verified live against the real vhost**: the replayed request now fires zero rules (no audit log entry at all), while a genuine SQL injection probe against the same vhost still fires four rules and is logged correctly. The global anomaly threshold is unchanged.
- Documented the anomaly-score math and this diagnosis in `configs/coraza/README.md` so a single critical PL1 rule reaching the default threshold isn't mistaken for a bug again.
- Added a test (`test_multi_rule_request_collapses_to_one_ingest_payload` / `..._preserves_all_matched_rules_in_raw_context`) using a real captured 4-rule SQLi probe, confirming a request flagged by multiple rules still collapses to one log row (first rule wins `rule_id`/`rule_message`, combined score preserved, other matches survive in `raw_context`). Documented the limitation in `README.architecture.md`.

## Test plan
- [x] `pytest --cov=app` (396 passed, 90% coverage), `mypy app/`, `ruff check app/` — backend unaffected by this phase, gates still pass
- [x] `uv run pytest`, `uv run mypy .` in `src/log-shipper/` — 31/31 tests pass including the 2 new multi-rule tests; `ruff check` shows only pre-existing, unrelated line-length warnings
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm run test` in `src/frontend/` — 80/80 tests pass including the new relabel assertion
- [x] Live-verified the 942290 fix on the lab environment by rebuilding/restarting the `coraza` container with the new exceptions file and replaying the exact false-positive request against `wp.bihius.me` plus a control SQL injection probe