### PR TITLE
ci: fix smoke e2e, publish images to GHCR, bump to 0.1.0-alpha.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish images
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: publish-${{ matrix.image.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: backend
+            context: src/backend
+            dockerfile: src/backend/Dockerfile
+          - name: frontend
+            context: src/frontend
+            dockerfile: src/frontend/Dockerfile
+          - name: coraza
+            context: .
+            dockerfile: deploy/docker/coraza.Dockerfile
+          - name: log-shipper
+            context: src/log-shipper
+            dockerfile: src/log-shipper/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/guard-proxy-${{ matrix.image.name }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=alpha
+            type=sha,format=short
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}

--- a/benchmarks/smoke/e2e.sh
+++ b/benchmarks/smoke/e2e.sh
@@ -118,6 +118,45 @@ assert_status() {
   echo "${description}: got HTTP ${actual}."
 }
 
+# Like assert_status, but retries until the expected status is observed or
+# the timeout elapses. Needed right after a config apply: HAProxy reloads its
+# routing ACLs synchronously, but Coraza's supervisor only restarts
+# coraza-spoa with the new crs-setup.conf on its next 1s poll tick (see
+# deploy/docker/coraza-supervisor.sh), so a request fired immediately after
+# /config/apply can still hit the previous (pre-policy, DetectionOnly) engine.
+wait_for_status() {
+  local description="$1"
+  local expected="$2"
+  local url="$3"
+  local timeout="${4:-30}"
+  local deadline=$((SECONDS + timeout))
+  local actual=""
+
+  while (( SECONDS < deadline )); do
+    actual="$(
+      curl \
+        --silent \
+        --show-error \
+        --output /dev/null \
+        --write-out '%{http_code}' \
+        --header "Host: ${HOST_HEADER}" \
+        --max-time 5 \
+        "${url}" \
+        2>/dev/null || true
+    )"
+
+    if [[ "${actual}" == "${expected}" ]]; then
+      echo "${description}: got HTTP ${actual}."
+      return 0
+    fi
+
+    sleep 1
+  done
+
+  echo "${description}: expected HTTP ${expected}, got ${actual} after ${timeout}s." >&2
+  return 1
+}
+
 assert_header() {
   local description="$1"
   local expected="$2"
@@ -141,6 +180,77 @@ assert_header() {
   fi
 
   echo "${description}: found '${expected}'."
+}
+
+SMOKE_ADMIN_EMAIL="smoke-admin@example.com"
+SMOKE_ADMIN_PASSWORD="smoke-admin-password-123"
+
+# Runs an HTTP request against the backend's own port from inside the
+# backend container (bypassing HAProxy, which has no usable ACL yet at
+# this point) and prints the JSON response body to stdout.
+backend_api() {
+  local method="$1"
+  local path="$2"
+  local token="${3:-}"
+  local payload="${4:-}"
+
+  REQ_METHOD="${method}" REQ_PATH="${path}" REQ_TOKEN="${token}" REQ_PAYLOAD="${payload}" \
+    "${COMPOSE[@]}" exec -T -e REQ_METHOD -e REQ_PATH -e REQ_TOKEN -e REQ_PAYLOAD backend python3 -c '
+import json
+import os
+import sys
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+method = os.environ["REQ_METHOD"]
+path = os.environ["REQ_PATH"]
+token = os.environ.get("REQ_TOKEN") or None
+payload_raw = os.environ.get("REQ_PAYLOAD") or ""
+
+headers = {"Accept": "application/json"}
+body = None
+if payload_raw:
+    body = payload_raw.encode("utf-8")
+    headers["Content-Type"] = "application/json"
+if token:
+    headers["Authorization"] = "Bearer " + token
+
+request = Request("http://127.0.0.1:8000" + path, data=body, headers=headers, method=method)
+try:
+    with urlopen(request, timeout=10) as resp:
+        sys.stdout.write(resp.read().decode("utf-8"))
+except HTTPError as exc:
+    sys.stderr.write(exc.read().decode("utf-8"))
+    sys.exit(1)
+'
+}
+
+setup_vhost_and_apply_config() {
+  echo "Seeding admin user and a vhost so HAProxy has a routable host ACL..."
+  "${COMPOSE[@]}" exec -T backend /app/.venv/bin/python scripts/seed_admin.py \
+    --email "${SMOKE_ADMIN_EMAIL}" \
+    --password "${SMOKE_ADMIN_PASSWORD}" \
+    --full-name "Smoke Test Admin"
+
+  local token
+  token="$(
+    backend_api POST /auth/login "" \
+      "$(printf '{"email":"%s","password":"%s"}' "${SMOKE_ADMIN_EMAIL}" "${SMOKE_ADMIN_PASSWORD}")" \
+      | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])'
+  )"
+
+  local policy_id
+  policy_id="$(
+    backend_api POST /policies "${token}" \
+      '{"name":"Smoke test policy","paranoia_level":1,"inbound_anomaly_threshold":5,"outbound_anomaly_threshold":4,"enforcement_mode":"block"}' \
+      | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])'
+  )"
+
+  backend_api POST /vhosts "${token}" \
+    "$(printf '{"domain":"%s","backend_url":"http://backend:8000","ssl_enabled":false,"is_active":true,"policy_id":%s}' "${HOST_HEADER}" "${policy_id}")" \
+    >/dev/null
+
+  backend_api POST /config/apply "${token}" "{}" >/dev/null
 }
 
 wait_for_header() {
@@ -190,8 +300,14 @@ wait_for_healthy backend
 wait_for_healthy coraza
 wait_for_healthy haproxy
 
+# A fresh database has no vhosts, so the generated HAProxy config has no
+# host-routing ACL and denies every non-ACME request with 421. Create a
+# policy + vhost and apply the config so HAProxy reloads with a real route
+# for HOST_HEADER before running the WAF assertions below.
+setup_vhost_and_apply_config
+
 assert_status "Benign request through WAF" "200" "${HAPROXY_BASE_URL}/docs"
-assert_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%20%271%27%3D%271"
+wait_for_status "SQL injection request" "403" "${HAPROXY_BASE_URL}/?id=1%27%20OR%20%271%27%3D%271" 30
 
 "${COMPOSE[@]}" stop coraza
 # Wait until HAProxy starts returning the explicit unavailable reason.

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-backend"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Guard Proxy — admin panel REST API"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-backend"
-version = "0.1.0"
+version = "0.1.0a0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guard-proxy-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.0",
   "type": "module",
   "packageManager": "pnpm@10.30.0",
   "scripts": {

--- a/src/log-shipper/pyproject.toml
+++ b/src/log-shipper/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-log-shipper"
-version = "0.1.0"
+version = "0.1.0a0"
 description = "Guard Proxy — Coraza audit log to ingest endpoint sidecar"
 requires-python = ">=3.13"
 dependencies = []   # runtime: stdlib only

--- a/src/log-shipper/uv.lock
+++ b/src/log-shipper/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-log-shipper"
-version = "0.1.0"
+version = "0.1.0a0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- **Smoke e2e fix**: the stack never created a vhost, so the backend's startup-time config generation wrote a route-less HAProxy config (zero vhosts → no host ACL), and every non-ACME request — including the supposedly "benign" `/docs` check — was denied with 421 before ever reaching the WAF. Reproduced locally, fixed by mirroring `tests/e2e/test_policy_apply.py`: seed an admin, create a policy + vhost for `HOST_HEADER`, and `POST /config/apply` before the WAF assertions. Also found and fixed a second, more subtle race: HAProxy picks up the new routing ACL synchronously on apply, but Coraza's supervisor only restarts `coraza-spoa` with the new `crs-setup.conf` on its next 1s poll tick, so the SQL-injection assertion needs a short retry loop instead of a single immediate check.
- **GHCR publish workflow**: new `.github/workflows/publish.yml` builds and pushes all four images (`backend`, `frontend`, `coraza`, `log-shipper`) to `ghcr.io/<owner>/guard-proxy-<image>` on a `v*` tag push or manual dispatch, tagged with the git ref, `alpha`, and the short commit SHA.
- **Version bump**: `0.1.0-alpha.0` in `package.json` (npm/semver) and `0.1.0a0` in the two backend `pyproject.toml`s (PEP 440's alpha syntax — `0.1.0-alpha.0` isn't valid there), plus regenerated `uv.lock` files so the lockfiles match.

## Known limitation
The frontend image still runs `pnpm dev` (the Vite dev server), not a production build — accepted for the alpha tag per the triage plan; a prod build stage is a follow-up.

`workflow_dispatch` can't be tested from this PR's branch — GitHub only allows manually triggering a workflow that already exists on the default branch. I'll run a manual dispatch right after this merges, before cutting the `v0.1.0-alpha.0` tag, to confirm the publish actually succeeds and packages appear in GHCR.

## Test plan
- [x] Reproduced the original smoke failure locally (`bash benchmarks/smoke/e2e.sh`), fixed it, and re-ran the full script multiple times to confirm it passes reliably
- [x] `uv run pytest -m e2e tests/e2e/test_policy_apply.py` still passes (no regression in the related real pipeline test)
- [x] `pytest --cov=app`, `mypy app/`, `ruff check app/` pass for both `src/backend` and `src/log-shipper` after the version bump and lockfile regeneration
- [x] `pnpm run type-check`, `pnpm run lint`, `pnpm run test` pass in `src/frontend`
- [x] `publish.yml` validated for YAML syntax; live dispatch deferred until after merge (see limitation above)