### PR TITLE
fix(makefile): forward bare args to make users target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,13 @@ ps:
 seed:
 	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/seed_admin.py
 
+ifeq (users,$(firstword $(MAKECMDGOALS)))
+  USERS_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(USERS_ARGS):;@:)
+endif
+
 users:
-	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(ARGS)
+	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(if $(USERS_ARGS),$(USERS_ARGS),$(ARGS))
 
 coraza-build:
 	docker build -f deploy/docker/coraza.Dockerfile -t guard-proxy/coraza-spoa:dev .

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq (users,$(firstword $(MAKECMDGOALS)))
 endif
 
 users:
-	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(if $(USERS_ARGS),$(USERS_ARGS),$(ARGS))
+	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(if $(USERS_ARGS),$(patsubst help,--help,$(USERS_ARGS)),$(ARGS))
 
 coraza-build:
 	docker build -f deploy/docker/coraza.Dockerfile -t guard-proxy/coraza-spoa:dev .

--- a/README.commands.md
+++ b/README.commands.md
@@ -81,7 +81,15 @@ make users ARGS="list --role admin --active"          # Filtered list
 make users ARGS="update alice@example.com --role admin"  # Promote by email
 make users ARGS="update 3 --deactivate"               # Deactivate by user ID
 make users ARGS="update 3 --password '<new password>'"   # Reset a password
+
+# Bare subcommands (no --flags) can skip ARGS=, e.g.:
+make users list
+make users help
 ```
+
+Note: any argument starting with `-` (e.g. `--role`, `--active`, `-h`) is
+consumed by `make` itself before it reaches the Makefile, so those must be
+passed via `ARGS="..."` as shown above.
 
 Outside Docker (local backend checkout):
 


### PR DESCRIPTION
## Summary
- `make users -h` couldn't reach the script because GNU Make consumes `-h` as its own flag before the Makefile is even read.
- Adds a `MAKECMDGOALS`-based passthrough so bare (non-dash) arguments after `users` (e.g. `make users help`, `make users list`) are forwarded directly to `scripts/manage_users.py` without needing `ARGS=`.
- Dash-flags still require `make users ARGS="-h"` since that limitation is in `make` itself and can't be worked around.

## Test plan
- [x] `make -n users help` forwards `help` to the script
- [x] `make -n users ARGS="-h"` still forwards `-h` via the existing fallback