### PR TITLE
feat(policies): add RuleExclusion model and CRUD API

### DIFF
--- a/src/backend/alembic/versions/a43bc7e65317_create_rule_exclusions_table.py
+++ b/src/backend/alembic/versions/a43bc7e65317_create_rule_exclusions_table.py
@@ -1,0 +1,69 @@
+"""create rule_exclusions table
+
+Revision ID: a43bc7e65317
+Revises: 0bc86f680ecc
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a43bc7e65317"
+down_revision: str | Sequence[str] | None = "0bc86f680ecc"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "rule_exclusions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("policy_id", sa.Integer(), nullable=False),
+        sa.Column("rule_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "target_type",
+            sa.Enum(
+                "request_uri",
+                "args",
+                "args_names",
+                "request_headers",
+                name="targettype",
+            ),
+            nullable=False,
+        ),
+        sa.Column("target_value", sa.Text(), nullable=False),
+        sa.Column("scope_path", sa.Text(), nullable=True),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["policy_id"], ["policies.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_rule_exclusions_policy_id"),
+        "rule_exclusions",
+        ["policy_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_rule_exclusions_policy_id"), table_name="rule_exclusions")
+    op.drop_table("rule_exclusions")
+
+    # PostgreSQL creates enum types as separate DB objects — drop them explicitly.
+    # SQLite has no native enum type, so this block must be skipped there.
+    context = op.get_context()
+    if context.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS targettype")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -23,6 +23,7 @@ from app.routers import (
     config,
     logs,
     policies,
+    rule_exclusions,
     rule_overrides,
     runtime_status,
     vhosts,
@@ -107,6 +108,7 @@ app.include_router(auth.router)
 app.include_router(config.router)
 app.include_router(logs.router)
 app.include_router(policies.router)
+app.include_router(rule_exclusions.router)
 app.include_router(rule_overrides.router)
 app.include_router(runtime_status.router)
 app.include_router(vhosts.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ Without this, Alembic generates an empty migration (it does not see tables).
 
 from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.runtime_operation import (
     RuntimeOperation,
@@ -30,4 +31,6 @@ __all__ = [
     "RuntimeOperationStatus",
     "RuleOverride",
     "RuleAction",
+    "RuleExclusion",
+    "TargetType",
 ]

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
 
 if TYPE_CHECKING:
+    from app.models.rule_exclusion import RuleExclusion
     from app.models.rule_override import RuleOverride
     from app.models.vhost import VHost
 
@@ -115,6 +116,16 @@ class Policy(Base):
     # cascade="all, delete-orphan" — remove rule_overrides when deleting policy
     rule_overrides: Mapped[list[RuleOverride]] = relationship(
         "RuleOverride",
+        back_populates="policy",
+        cascade="all, delete-orphan",
+    )
+
+    # ORM relationships — lets us use policy.rule_exclusions instead of manual JOIN
+    # "RuleExclusion" — class name as string to avoid circular imports
+    # back_populates — relationship is paired with 'policy' on the other side
+    # cascade="all, delete-orphan" — remove rule_exclusions when deleting policy
+    rule_exclusions: Mapped[list[RuleExclusion]] = relationship(
+        "RuleExclusion",
         back_populates="policy",
         cascade="all, delete-orphan",
     )

--- a/src/backend/app/models/rule_exclusion.py
+++ b/src/backend/app/models/rule_exclusion.py
@@ -1,0 +1,87 @@
+"""RuleExclusion model for path/target-scoped CRS rule exclusions in a WAF policy."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.policy import Policy
+
+
+class TargetType(enum.StrEnum):
+    """CRS variable a rule exclusion narrows inspection on.
+
+    Mirrors the targets supported by SecRuleRemoveTargetById:
+    REQUEST_URI, ARGS, ARGS_NAMES, REQUEST_HEADERS.
+    """
+
+    REQUEST_URI = "request_uri"
+    ARGS = "args"
+    ARGS_NAMES = "args_names"
+    REQUEST_HEADERS = "request_headers"
+
+
+class RuleExclusion(Base):
+    """rule_exclusions table storing policy-specific CRS rule target exclusions.
+
+    Example:
+    - Rule 942100 (SQL injection) false-positives on the "token" argument
+    - You add RuleExclusion(rule_id=942100, target_type=ARGS, target_value="token")
+      scoped to scope_path="/api/login"
+    - Guard Proxy can then generate config with
+      SecRuleRemoveTargetById 942100 ARGS:token for that path
+    """
+
+    __tablename__ = "rule_exclusions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # Relationship to Policy: every exclusion belongs to one policy.
+    # ondelete="CASCADE" means exclusions are removed when the policy is deleted.
+    policy_id: Mapped[int] = mapped_column(
+        ForeignKey("policies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,  # We often query "which exclusions belong to policy X?"
+    )
+
+    # OWASP CRS rule number, for example 941100 (XSS) or 942100 (SQLi).
+    rule_id: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Which CRS variable to narrow inspection on.
+    target_type: Mapped[TargetType] = mapped_column(Enum(TargetType), nullable=False)
+
+    # The specific target, for example an argument name like "token".
+    target_value: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Optional path prefix that scopes the exclusion, for example "/api/login".
+    # Nullable: a missing scope_path means the exclusion applies to all paths.
+    scope_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Optional note explaining why the exclusion exists.
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    # ORM relationship back to Policy (the other side is policy.rule_exclusions).
+    policy: Mapped[Policy] = relationship(
+        "Policy",
+        back_populates="rule_exclusions",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<RuleExclusion id={self.id} "
+            f"policy_id={self.policy_id} "
+            f"rule_id={self.rule_id} "
+            f"target_type={self.target_type} "
+            f"target_value={self.target_value}>"
+        )

--- a/src/backend/app/routers/rule_exclusions.py
+++ b/src/backend/app/routers/rule_exclusions.py
@@ -1,0 +1,160 @@
+"""Rule Exclusions API router for CRUD operations within a policy."""
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user, require_admin
+from app.models.rule_exclusion import RuleExclusion
+from app.models.user import User
+from app.schemas.rule_exclusion import (
+    RuleExclusionCreate,
+    RuleExclusionResponse,
+    RuleExclusionUpdate,
+)
+from app.services.exclusion_service import (
+    ExclusionDisallowedFieldError,
+    ExclusionFieldCannotBeNullError,
+    ExclusionNotFoundError,
+    ExclusionPolicyNotFoundError,
+    ExclusionService,
+)
+
+router = APIRouter(prefix="/policies/{policy_id}/exclusions", tags=["rule-exclusions"])
+
+
+@router.post(
+    "",
+    response_model=RuleExclusionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_rule_exclusion(
+    policy_id: int,
+    body: RuleExclusionCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> RuleExclusion:
+    """Create a CRS rule exclusion for the given policy (admin only)."""
+    service = ExclusionService(db)
+
+    try:
+        return service.create_exclusion(
+            policy_id,
+            rule_id=body.rule_id,
+            target_type=body.target_type,
+            target_value=body.target_value,
+            scope_path=body.scope_path,
+            comment=body.comment,
+        )
+    except ExclusionPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+
+
+@router.get("", response_model=list[RuleExclusionResponse])
+def list_rule_exclusions(
+    policy_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[RuleExclusion]:
+    """Return all rule exclusions for the given policy."""
+    service = ExclusionService(db)
+
+    try:
+        return service.list_exclusions(policy_id)
+    except ExclusionPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+
+
+@router.get("/{rule_exclusion_id}", response_model=RuleExclusionResponse)
+def get_rule_exclusion(
+    policy_id: int,
+    rule_exclusion_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> RuleExclusion:
+    """Return a single rule exclusion scoped to the given policy."""
+    service = ExclusionService(db)
+
+    try:
+        return service.get_exclusion(policy_id, rule_exclusion_id)
+    except ExclusionPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except ExclusionNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rule exclusion not found",
+        ) from error
+
+
+@router.patch("/{rule_exclusion_id}", response_model=RuleExclusionResponse)
+def update_rule_exclusion(
+    policy_id: int,
+    rule_exclusion_id: int,
+    body: RuleExclusionUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> RuleExclusion:
+    """Update selected fields of a rule exclusion (admin only)."""
+    service = ExclusionService(db)
+
+    try:
+        return service.update_exclusion(
+            policy_id,
+            rule_exclusion_id,
+            body.model_dump(exclude_unset=True),
+        )
+    except ExclusionPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except ExclusionNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rule exclusion not found",
+        ) from error
+    except ExclusionDisallowedFieldError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+    except ExclusionFieldCannotBeNullError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+
+
+@router.delete("/{rule_exclusion_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_rule_exclusion(
+    policy_id: int,
+    rule_exclusion_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> Response:
+    """Delete a rule exclusion from a policy (admin only)."""
+    service = ExclusionService(db)
+
+    try:
+        service.delete_exclusion(policy_id, rule_exclusion_id)
+    except ExclusionPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except ExclusionNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Rule exclusion not found",
+        ) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -3,6 +3,11 @@
 from app.schemas.auth import AccessTokenResponse, LoginRequest, TokenData
 from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
+from app.schemas.rule_exclusion import (
+    RuleExclusionCreate,
+    RuleExclusionResponse,
+    RuleExclusionUpdate,
+)
 from app.schemas.rule_override import (
     RuleOverrideCreate,
     RuleOverrideResponse,
@@ -38,4 +43,8 @@ __all__ = [
     "RuleOverrideCreate",
     "RuleOverrideResponse",
     "RuleOverrideUpdate",
+    # Rule exclusions
+    "RuleExclusionCreate",
+    "RuleExclusionResponse",
+    "RuleExclusionUpdate",
 ]

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.policy import PolicyEnforcementMode
+from app.schemas.rule_exclusion import RuleExclusionResponse
 from app.schemas.rule_override import RuleOverrideResponse
 
 
@@ -68,10 +69,11 @@ class PolicyResponse(BaseModel):
 
 
 class PolicyDetail(PolicyResponse):
-    """Response body for GET /policies/{id} — WITH nested rule_overrides.
+    """Response body for GET /policies/{id} — WITH nested overrides and exclusions.
 
-    Inherits from PolicyResponse and adds a list of rule overrides.
+    Inherits from PolicyResponse and adds a list of rule overrides and exclusions.
     Used only in GET /{id}, because loading relations for list would be slow.
     """
 
     rule_overrides: list[RuleOverrideResponse] = []
+    rule_exclusions: list[RuleExclusionResponse] = []

--- a/src/backend/app/schemas/rule_exclusion.py
+++ b/src/backend/app/schemas/rule_exclusion.py
@@ -1,0 +1,74 @@
+"""Pydantic schemas for WAF rule exclusions."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.models.rule_exclusion import TargetType
+
+
+class RuleExclusionCreate(BaseModel):
+    """Request body for POST /policies/{id}/exclusions."""
+
+    rule_id: int  # OWASP CRS rule number, for example 942100.
+    target_type: TargetType  # Which CRS variable to narrow inspection on.
+    target_value: str  # The specific target, for example an argument name.
+    scope_path: str | None = None  # Optional path prefix that scopes the exclusion.
+    comment: str | None = None
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_must_be_positive(cls, value: int) -> int:
+        """Require the rule ID to be a positive integer."""
+        if value <= 0:
+            raise ValueError("Rule ID must be greater than 0")
+        return value
+
+    @field_validator("target_value")
+    @classmethod
+    def target_value_must_not_be_blank(cls, value: str) -> str:
+        """Require the target value to be a non-empty string."""
+        if not value.strip():
+            raise ValueError("Target value must not be blank")
+        return value
+
+
+class RuleExclusionUpdate(BaseModel):
+    """Request body for PATCH /policies/{id}/exclusions/{rule_exclusion_id}."""
+
+    rule_id: int | None = None
+    target_type: TargetType | None = None
+    target_value: str | None = None
+    scope_path: str | None = None
+    comment: str | None = None
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_must_be_positive(cls, value: int | None) -> int | None:
+        """If rule_id is provided, it must be positive."""
+        if value is not None and value <= 0:
+            raise ValueError("Rule ID must be greater than 0")
+        return value
+
+    @field_validator("target_value")
+    @classmethod
+    def target_value_must_not_be_blank(cls, value: str | None) -> str | None:
+        """If target_value is provided, it must be a non-empty string."""
+        if value is not None and not value.strip():
+            raise ValueError("Target value must not be blank")
+        return value
+
+
+class RuleExclusionResponse(BaseModel):
+    """Response body for GET /policies/{id}/exclusions."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    policy_id: int
+    rule_id: int
+    target_type: TargetType
+    target_value: str
+    scope_path: str | None
+    comment: str | None
+    created_at: datetime

--- a/src/backend/app/services/exclusion_service.py
+++ b/src/backend/app/services/exclusion_service.py
@@ -1,0 +1,153 @@
+"""Exclusion service for WAF rule exclusion domain logic."""
+
+from sqlalchemy.orm import Session
+
+from app.models.policy import Policy
+from app.models.rule_exclusion import RuleExclusion, TargetType
+
+NON_NULLABLE_PATCH_FIELDS = {"rule_id", "target_type", "target_value"}
+
+# scope_path and comment are intentionally included: they are nullable and may be
+# set to None.
+PATCHABLE_FIELDS = {
+    "rule_id",
+    "target_type",
+    "target_value",
+    "scope_path",
+    "comment",
+}
+
+
+class ExclusionError(Exception):
+    """Base class for rule exclusion domain errors."""
+
+
+class ExclusionPolicyNotFoundError(ExclusionError):
+    """Raised when the policy a rule exclusion is scoped to does not exist."""
+
+
+class ExclusionNotFoundError(ExclusionError):
+    """Raised when a rule exclusion does not exist for the given policy."""
+
+
+class ExclusionFieldCannotBeNullError(ExclusionError):
+    """Raised when PATCH sets a non-nullable field to null."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be null")
+
+
+class ExclusionDisallowedFieldError(ExclusionError):
+    """Raised when PATCH contains a field that is not in the patchable allowlist."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be patched")
+
+
+class ExclusionService:
+    """Encapsulates rule exclusion CRUD business rules.
+
+    In simple terms:
+    - the router should deal with HTTP and auth
+    - this service should deal with exclusion rules and database changes
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_exclusion(
+        self,
+        policy_id: int,
+        *,
+        rule_id: int,
+        target_type: TargetType,
+        target_value: str,
+        scope_path: str | None,
+        comment: str | None,
+    ) -> RuleExclusion:
+        """Create and persist a new rule exclusion for the given policy."""
+        self._get_policy_or_raise(policy_id)
+
+        exclusion = RuleExclusion(
+            policy_id=policy_id,
+            rule_id=rule_id,
+            target_type=target_type,
+            target_value=target_value,
+            scope_path=scope_path,
+            comment=comment,
+        )
+        self.db.add(exclusion)
+        self.db.commit()
+        self.db.refresh(exclusion)
+        return exclusion
+
+    def list_exclusions(self, policy_id: int) -> list[RuleExclusion]:
+        """Return all rule exclusions for the given policy, ordered by ID."""
+        self._get_policy_or_raise(policy_id)
+        return (
+            self.db.query(RuleExclusion)
+            .filter(RuleExclusion.policy_id == policy_id)
+            .order_by(RuleExclusion.id.asc())
+            .all()
+        )
+
+    def get_exclusion(self, policy_id: int, exclusion_id: int) -> RuleExclusion:
+        """Return a single rule exclusion scoped to the given policy."""
+        self._get_policy_or_raise(policy_id)
+        return self._get_exclusion_or_raise(policy_id, exclusion_id)
+
+    def update_exclusion(
+        self, policy_id: int, exclusion_id: int, patch_data: dict[str, object]
+    ) -> RuleExclusion:
+        """Update selected fields of a rule exclusion."""
+        self._get_policy_or_raise(policy_id)
+        exclusion = self._get_exclusion_or_raise(policy_id, exclusion_id)
+        self._validate_patch_data(patch_data)
+
+        for field, value in patch_data.items():
+            setattr(exclusion, field, value)
+
+        self.db.commit()
+        self.db.refresh(exclusion)
+        return exclusion
+
+    def delete_exclusion(self, policy_id: int, exclusion_id: int) -> None:
+        """Delete a rule exclusion from a policy."""
+        self._get_policy_or_raise(policy_id)
+        exclusion = self._get_exclusion_or_raise(policy_id, exclusion_id)
+        self.db.delete(exclusion)
+        self.db.commit()
+
+    def _get_policy_or_raise(self, policy_id: int) -> Policy:
+        """Return a policy by primary key or raise a domain error."""
+        policy = self.db.get(Policy, policy_id)
+        if policy is None:
+            raise ExclusionPolicyNotFoundError
+        return policy
+
+    def _get_exclusion_or_raise(
+        self, policy_id: int, exclusion_id: int
+    ) -> RuleExclusion:
+        """Return an exclusion scoped to a policy or raise a domain error."""
+        exclusion = (
+            self.db.query(RuleExclusion)
+            .filter(
+                RuleExclusion.policy_id == policy_id,
+                RuleExclusion.id == exclusion_id,
+            )
+            .first()
+        )
+        if exclusion is None:
+            raise ExclusionNotFoundError
+        return exclusion
+
+    def _validate_patch_data(self, patch_data: dict[str, object]) -> None:
+        """Reject disallowed keys and nulls for non-nullable fields."""
+        for field in patch_data:
+            if field not in PATCHABLE_FIELDS:
+                raise ExclusionDisallowedFieldError(field)
+        for field in NON_NULLABLE_PATCH_FIELDS:
+            if field in patch_data and patch_data[field] is None:
+                raise ExclusionFieldCannotBeNullError(field)

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -109,10 +109,13 @@ class PolicyService:
         return self.db.query(Policy).order_by(Policy.id.asc()).all()
 
     def get_policy(self, policy_id: int) -> Policy:
-        """Return one policy with related rule overrides loaded."""
+        """Return one policy with related rule overrides and exclusions loaded."""
         policy = (
             self.db.query(Policy)
-            .options(selectinload(Policy.rule_overrides))
+            .options(
+                selectinload(Policy.rule_overrides),
+                selectinload(Policy.rule_exclusions),
+            )
             .filter(Policy.id == policy_id)
             .first()
         )

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.policy import Policy
+from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.vhost import VHost
 
 
@@ -70,6 +71,34 @@ def test_policy_negative_outbound_anomaly_threshold_raises_integrity_error(
     ):
         db.commit()
     db.rollback()
+
+
+def test_deleting_policy_cascades_to_rule_exclusions(db: Session) -> None:
+    """Deleting a policy must remove its rule exclusions (ondelete=CASCADE)."""
+    policy = Policy(
+        name="cascade-exclusions",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    db.add(policy)
+    db.flush()
+
+    exclusion = RuleExclusion(
+        policy_id=policy.id,
+        rule_id=942100,
+        target_type=TargetType.ARGS,
+        target_value="token",
+    )
+    db.add(exclusion)
+    db.flush()
+    exclusion_id = exclusion.id
+
+    db.delete(policy)
+    db.commit()
+
+    assert db.get(RuleExclusion, exclusion_id) is None
 
 
 def test_vhost_uppercase_domain_raises_integrity_error(db: Session) -> None:

--- a/src/backend/tests/integration/test_rule_exclusions_router.py
+++ b/src/backend/tests/integration/test_rule_exclusions_router.py
@@ -1,0 +1,367 @@
+"""Integration tests for the rule exclusions router."""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+def _create_policy(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    name: str = "Policy for exclusions",
+) -> dict[str, Any]:
+    """Helper that creates a policy for rule exclusion tests."""
+    resp = client.post(
+        "/policies",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Policy used in rule exclusion tests",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_rule_exclusion(
+    client: TestClient,
+    headers: dict[str, str],
+    policy_id: int,
+    *,
+    rule_id: int = 942100,
+    target_type: str = "args",
+    target_value: str = "token",
+    scope_path: str | None = "/api/login",
+    comment: str | None = "False positive on login token",
+) -> dict[str, Any]:
+    """Helper that creates a rule exclusion for the given policy."""
+    resp = client.post(
+        f"/policies/{policy_id}/exclusions",
+        headers=headers,
+        json={
+            "rule_id": rule_id,
+            "target_type": target_type,
+            "target_value": target_value,
+            "scope_path": scope_path,
+            "comment": comment,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_create_rule_exclusion_admin_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can add a rule exclusion to an existing policy."""
+    policy = _create_policy(client, admin_token)
+
+    resp = client.post(
+        f"/policies/{policy['id']}/exclusions",
+        headers=admin_token,
+        json={
+            "rule_id": 942100,
+            "target_type": "args",
+            "target_value": "token",
+            "scope_path": "/api/login",
+            "comment": "False positive on login token",
+        },
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["policy_id"] == policy["id"]
+    assert body["rule_id"] == 942100
+    assert body["target_type"] == "args"
+    assert body["target_value"] == "token"
+    assert body["scope_path"] == "/api/login"
+    assert body["comment"] == "False positive on login token"
+
+
+def test_create_rule_exclusion_without_scope_path_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """scope_path is optional; omitting it applies the exclusion to all paths."""
+    policy = _create_policy(client, admin_token, name="No scope path")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/exclusions",
+        headers=admin_token,
+        json={"rule_id": 942100, "target_type": "args", "target_value": "token"},
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["scope_path"] is None
+
+
+def test_create_rule_exclusion_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot create a rule exclusion."""
+    policy = _create_policy(client, admin_token, name="Viewer blocked")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/exclusions",
+        headers=viewer_token,
+        json={"rule_id": 942100, "target_type": "args", "target_value": "token"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_create_rule_exclusion_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Creating an exclusion for a missing policy returns 404."""
+    resp = client.post(
+        "/policies/99999/exclusions",
+        headers=admin_token,
+        json={"rule_id": 942100, "target_type": "args", "target_value": "token"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_create_rule_exclusion_blank_target_value_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An empty target_value is rejected by schema validation."""
+    policy = _create_policy(client, admin_token, name="Blank target value")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/exclusions",
+        headers=admin_token,
+        json={"rule_id": 942100, "target_type": "args", "target_value": "   "},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_list_rule_exclusions_admin_and_viewer_return_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """Admins and viewers can list exclusions assigned to a policy."""
+    policy = _create_policy(client, admin_token, name="List policy")
+    _create_rule_exclusion(client, admin_token, policy["id"], rule_id=941100)
+    _create_rule_exclusion(client, admin_token, policy["id"], rule_id=942100)
+
+    admin_resp = client.get(f"/policies/{policy['id']}/exclusions", headers=admin_token)
+    viewer_resp = client.get(
+        f"/policies/{policy['id']}/exclusions", headers=viewer_token
+    )
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert [item["rule_id"] for item in admin_resp.json()] == [941100, 942100]
+    assert [item["rule_id"] for item in viewer_resp.json()] == [941100, 942100]
+
+
+def test_list_rule_exclusions_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Listing exclusions requires an existing policy."""
+    resp = client.get("/policies/99999/exclusions", headers=admin_token)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_get_rule_exclusion_returns_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A single exclusion can be read by both admin and viewer."""
+    policy = _create_policy(client, admin_token, name="Detail policy")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    admin_resp = client.get(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+    )
+    viewer_resp = client.get(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert admin_resp.json()["id"] == created["id"]
+    assert viewer_resp.json()["id"] == created["id"]
+
+
+def test_get_rule_exclusion_not_found_for_other_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An exclusion from another policy cannot be read under the wrong policy ID."""
+    policy_one = _create_policy(client, admin_token, name="Policy one")
+    policy_two = _create_policy(client, admin_token, name="Policy two")
+    created = _create_rule_exclusion(client, admin_token, policy_one["id"])
+
+    resp = client.get(
+        f"/policies/{policy_two['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Rule exclusion not found"
+
+
+def test_patch_rule_exclusion_admin_partial_update(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH updates only the specified exclusion fields."""
+    policy = _create_policy(client, admin_token, name="Patch policy")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+        json={"scope_path": None, "comment": "No longer scoped"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rule_id"] == 942100
+    assert body["scope_path"] is None
+    assert body["comment"] == "No longer scoped"
+
+
+def test_patch_rule_exclusion_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot edit an exclusion."""
+    policy = _create_policy(client, admin_token, name="Patch blocked")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=viewer_token,
+        json={"comment": "Should not apply"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_patch_rule_exclusion_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH requires an existing policy."""
+    resp = client.patch(
+        "/policies/99999/exclusions/1",
+        headers=admin_token,
+        json={"comment": "irrelevant"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_patch_rule_exclusion_missing_exclusion_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH on a missing exclusion returns 404."""
+    policy = _create_policy(client, admin_token, name="Patch missing exclusion")
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/99999",
+        headers=admin_token,
+        json={"comment": "irrelevant"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Rule exclusion not found"
+
+
+def test_patch_rule_exclusion_null_rule_id_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting rule_id to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null rule_id")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+        json={"rule_id": None},
+    )
+
+    assert resp.status_code == 422
+    assert "rule_id" in resp.json()["detail"]
+
+
+def test_patch_rule_exclusion_null_target_type_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting target_type to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null target_type")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+        json={"target_type": None},
+    )
+
+    assert resp.status_code == 422
+    assert "target_type" in resp.json()["detail"]
+
+
+def test_patch_rule_exclusion_null_target_value_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting target_value to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null target_value")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+        json={"target_value": None},
+    )
+
+    assert resp.status_code == 422
+    assert "target_value" in resp.json()["detail"]
+
+
+def test_delete_rule_exclusion_admin_returns_204(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can delete an exclusion and it can no longer be fetched."""
+    policy = _create_policy(client, admin_token, name="Delete policy")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    delete_resp = client.delete(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+    )
+    get_resp = client.get(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert delete_resp.status_code == 204
+    assert delete_resp.text == ""
+    assert get_resp.status_code == 404
+    assert get_resp.json()["detail"] == "Rule exclusion not found"
+
+
+def test_delete_rule_exclusion_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot delete an exclusion."""
+    policy = _create_policy(client, admin_token, name="Delete blocked")
+    created = _create_rule_exclusion(client, admin_token, policy["id"])
+
+    resp = client.delete(
+        f"/policies/{policy['id']}/exclusions/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -13,9 +13,14 @@ from pydantic import ValidationError
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
 from app.models.policy import PolicyEnforcementMode  # noqa: E402
+from app.models.rule_exclusion import TargetType  # noqa: E402
 from app.models.rule_override import RuleAction  # noqa: E402
 from app.schemas.log import LogIngestRequest  # noqa: E402
 from app.schemas.policy import PolicyCreate, PolicyUpdate  # noqa: E402
+from app.schemas.rule_exclusion import (  # noqa: E402
+    RuleExclusionCreate,
+    RuleExclusionUpdate,
+)
 from app.schemas.rule_override import (  # noqa: E402
     RuleOverrideCreate,
     RuleOverrideUpdate,
@@ -226,6 +231,67 @@ def test_rule_override_update_valid() -> None:
 def test_rule_override_update_rule_id_must_be_positive() -> None:
     with pytest.raises(ValidationError, match="greater than 0"):
         RuleOverrideUpdate(rule_id=-1)
+
+
+# ---------------------------------------------------------------------------
+# RuleExclusion schemas
+# ---------------------------------------------------------------------------
+
+
+def test_rule_exclusion_create_valid() -> None:
+    exclusion = RuleExclusionCreate(
+        rule_id=942100,
+        target_type=TargetType.ARGS,
+        target_value="token",
+        scope_path="/api/login",
+        comment=None,
+    )
+    assert exclusion.rule_id == 942100
+    assert exclusion.scope_path == "/api/login"
+    assert exclusion.comment is None
+
+
+def test_rule_exclusion_create_valid_without_scope_path() -> None:
+    exclusion = RuleExclusionCreate(
+        rule_id=942100,
+        target_type=TargetType.ARGS,
+        target_value="token",
+    )
+    assert exclusion.scope_path is None
+
+
+def test_rule_exclusion_create_rule_id_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RuleExclusionCreate(
+            rule_id=0, target_type=TargetType.ARGS, target_value="token"
+        )
+
+
+def test_rule_exclusion_create_target_value_must_not_be_blank() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        RuleExclusionCreate(
+            rule_id=942100, target_type=TargetType.ARGS, target_value="  "
+        )
+
+
+def test_rule_exclusion_update_valid() -> None:
+    exclusion = RuleExclusionUpdate(
+        rule_id=941100,
+        target_type=TargetType.REQUEST_HEADERS,
+        comment=None,
+    )
+    assert exclusion.rule_id == 941100
+    assert exclusion.target_type == TargetType.REQUEST_HEADERS
+
+
+def test_rule_exclusion_update_rule_id_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than 0"):
+        RuleExclusionUpdate(rule_id=-1)
+
+
+def test_rule_exclusion_update_target_value_must_not_be_blank() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        RuleExclusionUpdate(target_value="   ")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a `RuleExclusion` model expressing path/target-scoped CRS exclusions (`SecRuleRemoveTargetById`-style), complementing the whole-rule `RuleOverride` enable/disable.
- Add `ExclusionService`, Pydantic schemas, and CRUD endpoints under `/policies/{policy_id}/exclusions`, following the existing `PolicyService`/router patterns.
- Nest `rule_exclusions` in `PolicyDetail` alongside `rule_overrides`.
- Add Alembic migration `a43bc7e65317` (head off `0bc86f680ecc`), verified with `alembic upgrade heads` + `alembic check` (no drift).

Out of scope (deferred to a follow-up): generating `SecRuleRemoveTargetById` config from exclusions, and frontend UI.

Closes #121

## Test plan
- [x] `uv run pytest --cov=app` — 426 passed
- [x] `uv run mypy app/` — no issues
- [x] `uv run ruff check app/` — no issues
- [x] `uv run alembic upgrade heads && uv run alembic check` — applies cleanly, no autogenerate drift
- [x] New unit tests for `RuleExclusionCreate`/`Update` validation
- [x] New integration tests covering CRUD happy paths, auth (admin/viewer), 404s, 422s, and policy-scoping
- [x] New cascade-delete test confirming exclusions are removed when their policy is deleted