### PR TITLE
Fix #256: Dashboard: "Active policies" and "Protected vhosts" tiles count all records

### DIFF
--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchLogTotal } from "@/features/logs/api";
 import type { LogAction, LogSeverity } from "@/features/logs/types";
-import { listPolicies, listVHosts } from "@/features/vhosts/api";
+import { listVHosts } from "@/features/vhosts/api";
+import { listPolicies } from "@/features/policies/api";
 import { useAuth } from "@/hooks/use-auth";
 
 export type StatValue = {
@@ -60,11 +61,15 @@ export function useDashboardStats(): DashboardStatsState {
       };
 
     listVHosts(accessToken, controller.signal)
-      .then((list) => guard(setVHosts)(ok(list.length)))
+      .then((list) =>
+        guard(setVHosts)(
+          ok(list.filter((v) => v.is_active && v.policy_id != null).length),
+        ),
+      )
       .catch((e) => { if (!isAbortError(e)) guard(setVHosts)(failed()); });
 
     listPolicies(accessToken, controller.signal)
-      .then((list) => guard(setPolicies)(ok(list.length)))
+      .then((list) => guard(setPolicies)(ok(list.filter((p) => p.is_active).length)))
       .catch((e) => { if (!isAbortError(e)) guard(setPolicies)(failed()); });
 
     fetchLogTotal(accessToken, { action: "deny" as LogAction }, controller.signal)

--- a/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -4,11 +4,13 @@ import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
 import * as logsApi from "@/features/logs/api";
+import * as policiesApi from "@/features/policies/api";
 import * as vhostsApi from "@/features/vhosts/api";
 
 import { DashboardPage } from "./DashboardPage";
 
 vi.mock("@/features/logs/api");
+vi.mock("@/features/policies/api");
 vi.mock("@/features/vhosts/api");
 vi.mock("@/features/runtime/use-runtime-status", () => ({
   useRuntimeStatus: () => ({ data: null, isLoading: false, error: null, refresh: vi.fn() }),
@@ -33,8 +35,19 @@ function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContext
   };
 }
 
-const mockVHosts = [{ id: 1 }, { id: 2 }];
-const mockPolicies = [{ id: 1 }];
+// 2 protected vhosts (active + assigned), plus records that must be excluded:
+// one inactive, one active-but-unassigned.
+const mockVHosts = [
+  { id: 1, is_active: true, policy_id: 10 },
+  { id: 2, is_active: true, policy_id: 11 },
+  { id: 3, is_active: false, policy_id: 12 },
+  { id: 4, is_active: true, policy_id: null },
+];
+// 1 active policy, plus one inactive that must be excluded.
+const mockPolicies = [
+  { id: 10, is_active: true },
+  { id: 11, is_active: false },
+];
 
 function renderPage() {
   return render(
@@ -47,7 +60,7 @@ function renderPage() {
 describe("DashboardPage StatCards", () => {
   it("shows loading skeletons while all fetches are in-flight", () => {
     vi.mocked(vhostsApi.listVHosts).mockReturnValue(new Promise(() => undefined));
-    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(policiesApi.listPolicies).mockReturnValue(new Promise(() => undefined));
     vi.mocked(logsApi.fetchLogTotal).mockReturnValue(new Promise(() => undefined));
 
     renderPage();
@@ -57,7 +70,7 @@ describe("DashboardPage StatCards", () => {
 
   it("renders real counts after data loads", async () => {
     vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies as never);
+    vi.mocked(policiesApi.listPolicies).mockResolvedValue(mockPolicies as never);
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(42);
 
     renderPage();
@@ -72,7 +85,7 @@ describe("DashboardPage StatCards", () => {
 
   it("shows — only for the card whose endpoint fails, real counts for others", async () => {
     vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
-    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+    vi.mocked(policiesApi.listPolicies).mockRejectedValue(new Error("Network error"));
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(7);
 
     renderPage();
@@ -87,7 +100,7 @@ describe("DashboardPage StatCards", () => {
 
   it("shows — for all cards when all endpoints fail", async () => {
     vi.mocked(vhostsApi.listVHosts).mockRejectedValue(new Error("down"));
-    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("down"));
+    vi.mocked(policiesApi.listPolicies).mockRejectedValue(new Error("down"));
     vi.mocked(logsApi.fetchLogTotal).mockRejectedValue(new Error("down"));
 
     renderPage();


### PR DESCRIPTION
## Issue

  The Dashboard tiles displayed incorrect metrics:

  - **"Active policies"** counted all policies (including inactive ones).
  - **"Protected vhosts"** counted all vhosts (including inactive ones and those without an assigned
  policy).

  Root cause: `useDashboardStats` imported the trimmed-down `listPolicies` from `vhosts/api` (typed
  as `{ id, name }`), which dropped the `is_active` field actually returned by the API, and simply
  counted `list.length`.

  ## Fix (frontend only — the backend already returned the needed data)

  - Import `listPolicies` from `@/features/policies/api` (full `Policy` with `is_active`).
  - **Active policies** → `policies.filter(p => p.is_active)`.
  - **Protected vhosts** → `vhosts.filter(v => v.is_active && v.policy_id != null)`.

  ## Tests

  - Updated `DashboardPage.test.tsx` — the test data includes records that must be excluded (an
  inactive policy, an inactive vhost, a vhost without a policy), so the test actually verifies the
  filtering.

  ## Files

  - `src/frontend/src/features/dashboard/use-dashboard-stats.ts`
  - `src/frontend/src/pages/dashboard/DashboardPage.test.tsx`
