### PR TITLE
feat(policies): add custom rule API

### DIFF
--- a/src/backend/alembic/versions/7da7bf17f2b8_create_custom_rules_table.py
+++ b/src/backend/alembic/versions/7da7bf17f2b8_create_custom_rules_table.py
@@ -1,0 +1,108 @@
+"""create custom_rules table
+
+Revision ID: 7da7bf17f2b8
+Revises: a43bc7e65317
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7da7bf17f2b8"
+down_revision: str | Sequence[str] | None = "a43bc7e65317"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "custom_rules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("policy_id", sa.Integer(), nullable=False),
+        sa.Column("rule_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "phase",
+            sa.Enum(
+                "request_headers",
+                "request_body",
+                "response_headers",
+                "response_body",
+                "logging",
+                name="rulephase",
+            ),
+            nullable=False,
+        ),
+        sa.Column("variables", sa.Text(), nullable=False),
+        sa.Column(
+            "operator",
+            sa.Enum(
+                "rx",
+                "streq",
+                "contains",
+                "begins_with",
+                "ends_with",
+                "eq",
+                "ge",
+                "gt",
+                "le",
+                "lt",
+                "pm",
+                "within",
+                "ip_match",
+                name="ruleoperator",
+            ),
+            nullable=False,
+        ),
+        sa.Column("operator_argument", sa.Text(), nullable=False),
+        sa.Column("actions", sa.Text(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "rule_id >= 9000000 AND rule_id <= 9099999",
+            name="ck_custom_rules_rule_id_range",
+        ),
+        sa.ForeignKeyConstraint(["policy_id"], ["policies.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "policy_id",
+            "rule_id",
+            name="uq_custom_rules_policy_id_rule_id",
+        ),
+    )
+    op.create_index(
+        op.f("ix_custom_rules_policy_id"),
+        "custom_rules",
+        ["policy_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_custom_rules_policy_id"), table_name="custom_rules")
+    op.drop_table("custom_rules")
+
+    # PostgreSQL creates enum types as separate DB objects — drop them explicitly.
+    # SQLite has no native enum type, so this block must be skipped there.
+    context = op.get_context()
+    if context.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS rulephase")
+        op.execute("DROP TYPE IF EXISTS ruleoperator")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -21,6 +21,7 @@ from app.rate_limit import limiter, rate_limit_exceeded_handler
 from app.routers import (
     auth,
     config,
+    custom_rules,
     logs,
     policies,
     rule_exclusions,
@@ -106,6 +107,7 @@ app.add_middleware(
 
 app.include_router(auth.router)
 app.include_router(config.router)
+app.include_router(custom_rules.router)
 app.include_router(logs.router)
 app.include_router(policies.router)
 app.include_router(rule_exclusions.router)

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ For autogenerate to work, EVERY model must be imported here.
 Without this, Alembic generates an empty migration (it does not see tables).
 """
 
+from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
 from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy, PolicyEnforcementMode
 from app.models.rule_exclusion import RuleExclusion, TargetType
@@ -33,4 +34,7 @@ __all__ = [
     "RuleAction",
     "RuleExclusion",
     "TargetType",
+    "CustomRule",
+    "RulePhase",
+    "RuleOperator",
 ]

--- a/src/backend/app/models/custom_rule.py
+++ b/src/backend/app/models/custom_rule.py
@@ -1,0 +1,151 @@
+"""CustomRule model for policy-scoped custom CRS rules in a WAF policy."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.policy import Policy
+
+# Rule IDs reserved for administrator-authored custom rules, kept clear of the
+# OWASP CRS range (CRS uses 900000-999999) so custom rules never collide.
+CUSTOM_RULE_ID_MIN = 9000000
+CUSTOM_RULE_ID_MAX = 9099999
+
+
+class RulePhase(enum.StrEnum):
+    """ModSecurity/Coraza processing phase a custom rule runs in.
+
+    Mirrors the five SecRule phases (request headers/body, response
+    headers/body, logging). The config generator maps these to the numeric
+    phases 1-5 expected by Coraza.
+    """
+
+    REQUEST_HEADERS = "request_headers"
+    REQUEST_BODY = "request_body"
+    RESPONSE_HEADERS = "response_headers"
+    RESPONSE_BODY = "response_body"
+    LOGGING = "logging"
+
+
+class RuleOperator(enum.StrEnum):
+    """Coraza operator used to match the rule's variables.
+
+    A focused MVP subset of operators supported by SecRule, for example
+    @rx for regular expressions or @streq for an exact string match.
+    """
+
+    RX = "rx"
+    STREQ = "streq"
+    CONTAINS = "contains"
+    BEGINS_WITH = "begins_with"
+    ENDS_WITH = "ends_with"
+    EQ = "eq"
+    GE = "ge"
+    GT = "gt"
+    LE = "le"
+    LT = "lt"
+    PM = "pm"
+    WITHIN = "within"
+    IP_MATCH = "ip_match"
+
+
+class CustomRule(Base):
+    """custom_rules table storing policy-specific administrator-authored rules.
+
+    Example:
+    - You add CustomRule(rule_id=9000001, phase=REQUEST_HEADERS,
+      variables="REQUEST_HEADERS:User-Agent", operator=RX,
+      operator_argument="(?i)curl", actions="deny,status:403")
+    - Guard Proxy can then generate config with
+      SecRule REQUEST_HEADERS:User-Agent "@rx (?i)curl"
+      "id:9000001,phase:1,deny,status:403"
+    """
+
+    __tablename__ = "custom_rules"
+    __table_args__ = (
+        CheckConstraint(
+            f"rule_id >= {CUSTOM_RULE_ID_MIN} AND rule_id <= {CUSTOM_RULE_ID_MAX}",
+            name="ck_custom_rules_rule_id_range",
+        ),
+        UniqueConstraint(
+            "policy_id",
+            "rule_id",
+            name="uq_custom_rules_policy_id_rule_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # Relationship to Policy: every custom rule belongs to one policy.
+    # ondelete="CASCADE" means custom rules are removed when the policy is deleted.
+    policy_id: Mapped[int] = mapped_column(
+        ForeignKey("policies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,  # We often query "which custom rules belong to policy X?"
+    )
+
+    # User-defined rule number, restricted to CUSTOM_RULE_ID_MIN-CUSTOM_RULE_ID_MAX
+    # so custom rules never collide with OWASP CRS rule IDs.
+    rule_id: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Which SecRule processing phase the rule runs in.
+    phase: Mapped[RulePhase] = mapped_column(Enum(RulePhase), nullable=False)
+
+    # CRS variables to inspect, for example "ARGS|REQUEST_HEADERS:User-Agent".
+    variables: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Operator used to match the variables, for example "rx" or "streq".
+    operator: Mapped[RuleOperator] = mapped_column(Enum(RuleOperator), nullable=False)
+
+    # The operator's pattern/value, for example the regex used with "@rx".
+    operator_argument: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Comma-separated SecRule actions, for example "deny,status:403,log".
+    actions: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Optional note explaining why the rule exists.
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Whether the rule is currently enabled. Inactive rules are kept but not
+    # rendered into generated config.
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    # ORM relationship back to Policy (the other side is policy.custom_rules).
+    policy: Mapped[Policy] = relationship(
+        "Policy",
+        back_populates="custom_rules",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CustomRule id={self.id} "
+            f"policy_id={self.policy_id} "
+            f"rule_id={self.rule_id} "
+            f"phase={self.phase} "
+            f"is_active={self.is_active}>"
+        )

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
 
 if TYPE_CHECKING:
+    from app.models.custom_rule import CustomRule
     from app.models.rule_exclusion import RuleExclusion
     from app.models.rule_override import RuleOverride
     from app.models.vhost import VHost
@@ -126,6 +127,15 @@ class Policy(Base):
     # cascade="all, delete-orphan" — remove rule_exclusions when deleting policy
     rule_exclusions: Mapped[list[RuleExclusion]] = relationship(
         "RuleExclusion",
+        back_populates="policy",
+        cascade="all, delete-orphan",
+    )
+
+    # ORM relationship for policy.custom_rules instead of manual JOINs.
+    # "CustomRule" is a string to avoid circular imports.
+    # cascade="all, delete-orphan" removes custom_rules when deleting policy.
+    custom_rules: Mapped[list[CustomRule]] = relationship(
+        "CustomRule",
         back_populates="policy",
         cascade="all, delete-orphan",
     )

--- a/src/backend/app/routers/custom_rules.py
+++ b/src/backend/app/routers/custom_rules.py
@@ -1,0 +1,176 @@
+"""Custom Rules API router for CRUD operations within a policy."""
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_current_user, require_admin
+from app.models.custom_rule import CustomRule
+from app.models.user import User
+from app.schemas.custom_rule import (
+    CustomRuleCreate,
+    CustomRuleResponse,
+    CustomRuleUpdate,
+)
+from app.services.custom_rule_service import (
+    CustomRuleDisallowedFieldError,
+    CustomRuleDuplicateRuleIdError,
+    CustomRuleFieldCannotBeNullError,
+    CustomRuleNotFoundError,
+    CustomRulePolicyNotFoundError,
+    CustomRuleService,
+)
+
+router = APIRouter(
+    prefix="/policies/{policy_id}/custom-rules", tags=["custom-rules"]
+)
+
+
+@router.post(
+    "",
+    response_model=CustomRuleResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_custom_rule(
+    policy_id: int,
+    body: CustomRuleCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> CustomRule:
+    """Create a custom rule for the given policy (admin only)."""
+    service = CustomRuleService(db)
+
+    try:
+        return service.create_custom_rule(
+            policy_id,
+            rule_id=body.rule_id,
+            phase=body.phase,
+            variables=body.variables,
+            operator=body.operator,
+            operator_argument=body.operator_argument,
+            actions=body.actions,
+            comment=body.comment,
+            is_active=body.is_active,
+        )
+    except CustomRulePolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except CustomRuleDuplicateRuleIdError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A custom rule with this ID already exists in this policy.",
+        ) from error
+
+
+@router.get("", response_model=list[CustomRuleResponse])
+def list_custom_rules(
+    policy_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[CustomRule]:
+    """Return all custom rules for the given policy."""
+    service = CustomRuleService(db)
+
+    try:
+        return service.list_custom_rules(policy_id)
+    except CustomRulePolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+
+
+@router.get("/{custom_rule_id}", response_model=CustomRuleResponse)
+def get_custom_rule(
+    policy_id: int,
+    custom_rule_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> CustomRule:
+    """Return a single custom rule scoped to the given policy."""
+    service = CustomRuleService(db)
+
+    try:
+        return service.get_custom_rule(policy_id, custom_rule_id)
+    except CustomRulePolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except CustomRuleNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom rule not found",
+        ) from error
+
+
+@router.patch("/{custom_rule_id}", response_model=CustomRuleResponse)
+def update_custom_rule(
+    policy_id: int,
+    custom_rule_id: int,
+    body: CustomRuleUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> CustomRule:
+    """Update selected fields of a custom rule (admin only)."""
+    service = CustomRuleService(db)
+
+    try:
+        return service.update_custom_rule(
+            policy_id,
+            custom_rule_id,
+            body.model_dump(exclude_unset=True),
+        )
+    except CustomRulePolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except CustomRuleNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom rule not found",
+        ) from error
+    except CustomRuleDuplicateRuleIdError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A custom rule with this ID already exists in this policy.",
+        ) from error
+    except CustomRuleDisallowedFieldError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+    except CustomRuleFieldCannotBeNullError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+
+
+@router.delete("/{custom_rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_custom_rule(
+    policy_id: int,
+    custom_rule_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> Response:
+    """Delete a custom rule from a policy (admin only)."""
+    service = CustomRuleService(db)
+
+    try:
+        service.delete_custom_rule(policy_id, custom_rule_id)
+    except CustomRulePolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except CustomRuleNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom rule not found",
+        ) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -1,6 +1,11 @@
 """Pydantic schemas used for request validation and API serialization."""
 
 from app.schemas.auth import AccessTokenResponse, LoginRequest, TokenData
+from app.schemas.custom_rule import (
+    CustomRuleCreate,
+    CustomRuleResponse,
+    CustomRuleUpdate,
+)
 from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
 from app.schemas.rule_exclusion import (
@@ -47,4 +52,8 @@ __all__ = [
     "RuleExclusionCreate",
     "RuleExclusionResponse",
     "RuleExclusionUpdate",
+    # Custom rules
+    "CustomRuleCreate",
+    "CustomRuleResponse",
+    "CustomRuleUpdate",
 ]

--- a/src/backend/app/schemas/custom_rule.py
+++ b/src/backend/app/schemas/custom_rule.py
@@ -1,0 +1,129 @@
+"""Pydantic schemas for WAF custom rules."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.models.custom_rule import (
+    CUSTOM_RULE_ID_MAX,
+    CUSTOM_RULE_ID_MIN,
+    RuleOperator,
+    RulePhase,
+)
+
+
+def _validate_rule_id_range(value: int) -> int:
+    """Require the rule ID to fall in the reserved custom rule range."""
+    if not (CUSTOM_RULE_ID_MIN <= value <= CUSTOM_RULE_ID_MAX):
+        raise ValueError(
+            f"Rule ID must be between {CUSTOM_RULE_ID_MIN} and {CUSTOM_RULE_ID_MAX}"
+        )
+    return value
+
+
+def _validate_not_blank(value: str, field_label: str) -> str:
+    """Require a string field to be non-empty."""
+    if not value.strip():
+        raise ValueError(f"{field_label} must not be blank")
+    return value
+
+
+class CustomRuleCreate(BaseModel):
+    """Request body for POST /policies/{id}/custom-rules."""
+
+    rule_id: int  # User-defined rule number, in the reserved custom rule range.
+    phase: RulePhase  # SecRule processing phase the rule runs in.
+    variables: str  # CRS variables to inspect, for example "ARGS".
+    operator: RuleOperator  # Operator used to match the variables.
+    operator_argument: str  # The operator's pattern/value, for example a regex.
+    actions: str  # Comma-separated SecRule actions, for example "deny,status:403".
+    comment: str | None = None
+    is_active: bool = True
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_in_range(cls, value: int) -> int:
+        """Require the rule ID to fall in the reserved custom rule range."""
+        return _validate_rule_id_range(value)
+
+    @field_validator("variables")
+    @classmethod
+    def variables_must_not_be_blank(cls, value: str) -> str:
+        """Require the variables field to be a non-empty string."""
+        return _validate_not_blank(value, "Variables")
+
+    @field_validator("operator_argument")
+    @classmethod
+    def operator_argument_must_not_be_blank(cls, value: str) -> str:
+        """Require the operator argument to be a non-empty string."""
+        return _validate_not_blank(value, "Operator argument")
+
+    @field_validator("actions")
+    @classmethod
+    def actions_must_not_be_blank(cls, value: str) -> str:
+        """Require the actions field to be a non-empty string."""
+        return _validate_not_blank(value, "Actions")
+
+
+class CustomRuleUpdate(BaseModel):
+    """Request body for PATCH /policies/{id}/custom-rules/{custom_rule_id}."""
+
+    rule_id: int | None = None
+    phase: RulePhase | None = None
+    variables: str | None = None
+    operator: RuleOperator | None = None
+    operator_argument: str | None = None
+    actions: str | None = None
+    comment: str | None = None
+    is_active: bool | None = None
+
+    @field_validator("rule_id")
+    @classmethod
+    def rule_id_in_range(cls, value: int | None) -> int | None:
+        """If rule_id is provided, it must fall in the reserved custom rule range."""
+        if value is None:
+            return None
+        return _validate_rule_id_range(value)
+
+    @field_validator("variables")
+    @classmethod
+    def variables_must_not_be_blank(cls, value: str | None) -> str | None:
+        """If variables is provided, it must be a non-empty string."""
+        if value is None:
+            return None
+        return _validate_not_blank(value, "Variables")
+
+    @field_validator("operator_argument")
+    @classmethod
+    def operator_argument_must_not_be_blank(cls, value: str | None) -> str | None:
+        """If operator_argument is provided, it must be a non-empty string."""
+        if value is None:
+            return None
+        return _validate_not_blank(value, "Operator argument")
+
+    @field_validator("actions")
+    @classmethod
+    def actions_must_not_be_blank(cls, value: str | None) -> str | None:
+        """If actions is provided, it must be a non-empty string."""
+        if value is None:
+            return None
+        return _validate_not_blank(value, "Actions")
+
+
+class CustomRuleResponse(BaseModel):
+    """Response body for GET /policies/{id}/custom-rules."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    policy_id: int
+    rule_id: int
+    phase: RulePhase
+    variables: str
+    operator: RuleOperator
+    operator_argument: str
+    actions: str
+    comment: str | None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.models.policy import PolicyEnforcementMode
+from app.schemas.custom_rule import CustomRuleResponse
 from app.schemas.rule_exclusion import RuleExclusionResponse
 from app.schemas.rule_override import RuleOverrideResponse
 
@@ -77,3 +78,4 @@ class PolicyDetail(PolicyResponse):
 
     rule_overrides: list[RuleOverrideResponse] = []
     rule_exclusions: list[RuleExclusionResponse] = []
+    custom_rules: list[CustomRuleResponse] = []

--- a/src/backend/app/services/custom_rule_service.py
+++ b/src/backend/app/services/custom_rule_service.py
@@ -1,0 +1,198 @@
+"""Custom rule service for WAF custom rule domain logic."""
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
+from app.models.policy import Policy
+
+NON_NULLABLE_PATCH_FIELDS = {
+    "rule_id",
+    "phase",
+    "variables",
+    "operator",
+    "operator_argument",
+    "actions",
+    "is_active",
+}
+
+# comment is intentionally included: it is nullable and may be set to None.
+PATCHABLE_FIELDS = {
+    "rule_id",
+    "phase",
+    "variables",
+    "operator",
+    "operator_argument",
+    "actions",
+    "comment",
+    "is_active",
+}
+
+_UNIQUE_CONSTRAINT = "uq_custom_rules_policy_id_rule_id"
+
+
+class CustomRuleError(Exception):
+    """Base class for custom rule domain errors."""
+
+
+class CustomRulePolicyNotFoundError(CustomRuleError):
+    """Raised when the policy a custom rule is scoped to does not exist."""
+
+
+class CustomRuleNotFoundError(CustomRuleError):
+    """Raised when a custom rule does not exist for the given policy."""
+
+
+class CustomRuleDuplicateRuleIdError(CustomRuleError):
+    """Raised when a policy already has a custom rule with the same rule_id."""
+
+
+class CustomRuleFieldCannotBeNullError(CustomRuleError):
+    """Raised when PATCH sets a non-nullable field to null."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be null")
+
+
+class CustomRuleDisallowedFieldError(CustomRuleError):
+    """Raised when PATCH contains a field that is not in the patchable allowlist."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be patched")
+
+
+class CustomRuleService:
+    """Encapsulates custom rule CRUD business rules.
+
+    In simple terms:
+    - the router should deal with HTTP and auth
+    - this service should deal with custom rule rules and database changes
+    """
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def create_custom_rule(
+        self,
+        policy_id: int,
+        *,
+        rule_id: int,
+        phase: RulePhase,
+        variables: str,
+        operator: RuleOperator,
+        operator_argument: str,
+        actions: str,
+        comment: str | None,
+        is_active: bool,
+    ) -> CustomRule:
+        """Create and persist a new custom rule for the given policy."""
+        self._get_policy_or_raise(policy_id)
+
+        custom_rule = CustomRule(
+            policy_id=policy_id,
+            rule_id=rule_id,
+            phase=phase,
+            variables=variables,
+            operator=operator,
+            operator_argument=operator_argument,
+            actions=actions,
+            comment=comment,
+            is_active=is_active,
+        )
+        self.db.add(custom_rule)
+        self._commit_or_raise_duplicate_rule_id()
+        self.db.refresh(custom_rule)
+        return custom_rule
+
+    def list_custom_rules(self, policy_id: int) -> list[CustomRule]:
+        """Return all custom rules for the given policy, ordered by ID."""
+        self._get_policy_or_raise(policy_id)
+        return (
+            self.db.query(CustomRule)
+            .filter(CustomRule.policy_id == policy_id)
+            .order_by(CustomRule.id.asc())
+            .all()
+        )
+
+    def get_custom_rule(self, policy_id: int, custom_rule_id: int) -> CustomRule:
+        """Return a single custom rule scoped to the given policy."""
+        self._get_policy_or_raise(policy_id)
+        return self._get_custom_rule_or_raise(policy_id, custom_rule_id)
+
+    def update_custom_rule(
+        self, policy_id: int, custom_rule_id: int, patch_data: dict[str, object]
+    ) -> CustomRule:
+        """Update selected fields of a custom rule."""
+        self._get_policy_or_raise(policy_id)
+        custom_rule = self._get_custom_rule_or_raise(policy_id, custom_rule_id)
+        self._validate_patch_data(patch_data)
+
+        for field, value in patch_data.items():
+            setattr(custom_rule, field, value)
+
+        self._commit_or_raise_duplicate_rule_id()
+        self.db.refresh(custom_rule)
+        return custom_rule
+
+    def delete_custom_rule(self, policy_id: int, custom_rule_id: int) -> None:
+        """Delete a custom rule from a policy."""
+        self._get_policy_or_raise(policy_id)
+        custom_rule = self._get_custom_rule_or_raise(policy_id, custom_rule_id)
+        self.db.delete(custom_rule)
+        self.db.commit()
+
+    def _get_policy_or_raise(self, policy_id: int) -> Policy:
+        """Return a policy by primary key or raise a domain error."""
+        policy = self.db.get(Policy, policy_id)
+        if policy is None:
+            raise CustomRulePolicyNotFoundError
+        return policy
+
+    def _get_custom_rule_or_raise(
+        self, policy_id: int, custom_rule_id: int
+    ) -> CustomRule:
+        """Return a custom rule scoped to a policy or raise a domain error."""
+        custom_rule = (
+            self.db.query(CustomRule)
+            .filter(
+                CustomRule.policy_id == policy_id,
+                CustomRule.id == custom_rule_id,
+            )
+            .first()
+        )
+        if custom_rule is None:
+            raise CustomRuleNotFoundError
+        return custom_rule
+
+    def _validate_patch_data(self, patch_data: dict[str, object]) -> None:
+        """Reject disallowed keys and nulls for non-nullable fields."""
+        for field in patch_data:
+            if field not in PATCHABLE_FIELDS:
+                raise CustomRuleDisallowedFieldError(field)
+        for field in NON_NULLABLE_PATCH_FIELDS:
+            if field in patch_data and patch_data[field] is None:
+                raise CustomRuleFieldCannotBeNullError(field)
+
+    def _commit_or_raise_duplicate_rule_id(self) -> None:
+        """Commit changes or convert duplicate rule IDs into a domain error."""
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if _is_custom_rule_unique_violation(error):
+                raise CustomRuleDuplicateRuleIdError from error
+            raise
+
+
+def _is_custom_rule_unique_violation(error: IntegrityError) -> bool:
+    """Check whether an IntegrityError comes from a duplicate custom rule ID."""
+    error_text = str(error.orig).lower()
+    # PostgreSQL includes the constraint name; SQLite includes column names instead.
+    return _UNIQUE_CONSTRAINT in error_text or (
+        "unique" in error_text
+        and "custom_rules" in error_text
+        and "rule_id" in error_text
+        and "policy_id" in error_text
+    )

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -115,6 +115,7 @@ class PolicyService:
             .options(
                 selectinload(Policy.rule_overrides),
                 selectinload(Policy.rule_exclusions),
+                selectinload(Policy.custom_rules),
             )
             .filter(Policy.id == policy_id)
             .first()

--- a/src/backend/tests/integration/test_custom_rules_router.py
+++ b/src/backend/tests/integration/test_custom_rules_router.py
@@ -1,0 +1,483 @@
+"""Integration tests for the custom rules router."""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+
+def _create_policy(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    name: str = "Policy for custom rules",
+) -> dict[str, Any]:
+    """Helper that creates a policy for custom rule tests."""
+    resp = client.post(
+        "/policies",
+        headers=headers,
+        json={
+            "name": name,
+            "description": "Policy used in custom rule tests",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _create_custom_rule(
+    client: TestClient,
+    headers: dict[str, str],
+    policy_id: int,
+    *,
+    rule_id: int = 9000001,
+    phase: str = "request_headers",
+    variables: str = "REQUEST_HEADERS:User-Agent",
+    operator: str = "rx",
+    operator_argument: str = "(?i)curl",
+    actions: str = "deny,status:403",
+    comment: str | None = "Block scripted clients",
+    is_active: bool = True,
+) -> dict[str, Any]:
+    """Helper that creates a custom rule for the given policy."""
+    resp = client.post(
+        f"/policies/{policy_id}/custom-rules",
+        headers=headers,
+        json={
+            "rule_id": rule_id,
+            "phase": phase,
+            "variables": variables,
+            "operator": operator,
+            "operator_argument": operator_argument,
+            "actions": actions,
+            "comment": comment,
+            "is_active": is_active,
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def test_create_custom_rule_admin_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can add a custom rule to an existing policy."""
+    policy = _create_policy(client, admin_token)
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "REQUEST_HEADERS:User-Agent",
+            "operator": "rx",
+            "operator_argument": "(?i)curl",
+            "actions": "deny,status:403",
+            "comment": "Block scripted clients",
+        },
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["policy_id"] == policy["id"]
+    assert body["rule_id"] == 9000001
+    assert body["phase"] == "request_headers"
+    assert body["variables"] == "REQUEST_HEADERS:User-Agent"
+    assert body["operator"] == "rx"
+    assert body["operator_argument"] == "(?i)curl"
+    assert body["actions"] == "deny,status:403"
+    assert body["comment"] == "Block scripted clients"
+    assert body["is_active"] is True
+
+
+def test_create_custom_rule_without_comment_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """comment is optional; omitting it creates a custom rule with no comment."""
+    policy = _create_policy(client, admin_token, name="No comment")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "REQUEST_HEADERS:User-Agent",
+            "operator": "rx",
+            "operator_argument": "(?i)curl",
+            "actions": "deny,status:403",
+        },
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["comment"] is None
+
+
+def test_create_custom_rule_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot create a custom rule."""
+    policy = _create_policy(client, admin_token, name="Viewer blocked")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=viewer_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "ARGS",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_create_custom_rule_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Creating a custom rule for a missing policy returns 404."""
+    resp = client.post(
+        "/policies/99999/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "ARGS",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_create_custom_rule_id_below_range_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """A rule_id below the reserved custom rule range is rejected."""
+    policy = _create_policy(client, admin_token, name="Below range")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 8999999,
+            "phase": "request_headers",
+            "variables": "ARGS",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 422
+
+
+def test_create_custom_rule_id_above_range_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """A rule_id above the reserved custom rule range is rejected."""
+    policy = _create_policy(client, admin_token, name="Above range")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9100000,
+            "phase": "request_headers",
+            "variables": "ARGS",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 422
+
+
+def test_create_custom_rule_blank_variables_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An empty variables field is rejected by schema validation."""
+    policy = _create_policy(client, admin_token, name="Blank variables")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "   ",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 422
+
+
+def test_create_custom_rule_duplicate_rule_id_returns_409(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """A policy cannot contain two custom rules with the same rule_id."""
+    policy = _create_policy(client, admin_token, name="Duplicate custom rule")
+    _create_custom_rule(client, admin_token, policy["id"], rule_id=9000001)
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "request_headers",
+            "variables": "ARGS",
+            "operator": "rx",
+            "operator_argument": ".*",
+            "actions": "deny",
+        },
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == (
+        "A custom rule with this ID already exists in this policy."
+    )
+
+
+def test_list_custom_rules_admin_and_viewer_return_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """Admins and viewers can list custom rules assigned to a policy."""
+    policy = _create_policy(client, admin_token, name="List policy")
+    _create_custom_rule(client, admin_token, policy["id"], rule_id=9000001)
+    _create_custom_rule(client, admin_token, policy["id"], rule_id=9000002)
+
+    admin_resp = client.get(
+        f"/policies/{policy['id']}/custom-rules", headers=admin_token
+    )
+    viewer_resp = client.get(
+        f"/policies/{policy['id']}/custom-rules", headers=viewer_token
+    )
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert [item["rule_id"] for item in admin_resp.json()] == [9000001, 9000002]
+    assert [item["rule_id"] for item in viewer_resp.json()] == [9000001, 9000002]
+
+
+def test_list_custom_rules_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Listing custom rules requires an existing policy."""
+    resp = client.get("/policies/99999/custom-rules", headers=admin_token)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_get_custom_rule_returns_200(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A single custom rule can be read by both admin and viewer."""
+    policy = _create_policy(client, admin_token, name="Detail policy")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    admin_resp = client.get(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+    )
+    viewer_resp = client.get(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert admin_resp.status_code == 200
+    assert viewer_resp.status_code == 200
+    assert admin_resp.json()["id"] == created["id"]
+    assert viewer_resp.json()["id"] == created["id"]
+
+
+def test_get_custom_rule_not_found_for_other_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """A custom rule from another policy cannot be read under the wrong policy ID."""
+    policy_one = _create_policy(client, admin_token, name="Policy one")
+    policy_two = _create_policy(client, admin_token, name="Policy two")
+    created = _create_custom_rule(client, admin_token, policy_one["id"])
+
+    resp = client.get(
+        f"/policies/{policy_two['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Custom rule not found"
+
+
+def test_patch_custom_rule_admin_partial_update(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH updates only the specified custom rule fields."""
+    policy = _create_policy(client, admin_token, name="Patch policy")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+        json={"is_active": False, "comment": "Temporarily disabled"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rule_id"] == 9000001
+    assert body["is_active"] is False
+    assert body["comment"] == "Temporarily disabled"
+
+
+def test_patch_custom_rule_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot edit a custom rule."""
+    policy = _create_policy(client, admin_token, name="Patch blocked")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=viewer_token,
+        json={"comment": "Should not apply"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_patch_custom_rule_missing_policy_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH requires an existing policy."""
+    resp = client.patch(
+        "/policies/99999/custom-rules/1",
+        headers=admin_token,
+        json={"comment": "irrelevant"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_patch_custom_rule_missing_custom_rule_returns_404(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """PATCH on a missing custom rule returns 404."""
+    policy = _create_policy(client, admin_token, name="Patch missing rule")
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/99999",
+        headers=admin_token,
+        json={"comment": "irrelevant"},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Custom rule not found"
+
+
+def test_patch_custom_rule_null_rule_id_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting rule_id to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null rule_id")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+        json={"rule_id": None},
+    )
+
+    assert resp.status_code == 422
+    assert "rule_id" in resp.json()["detail"]
+
+
+def test_patch_custom_rule_null_variables_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Explicitly setting variables to null in PATCH returns 422."""
+    policy = _create_policy(client, admin_token, name="Patch null variables")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+        json={"variables": None},
+    )
+
+    assert resp.status_code == 422
+    assert "variables" in resp.json()["detail"]
+
+
+def test_patch_custom_rule_duplicate_rule_id_returns_409(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Changing a custom rule to another rule's ID in the same policy is rejected."""
+    policy = _create_policy(client, admin_token, name="Patch duplicate rule_id")
+    _create_custom_rule(client, admin_token, policy["id"], rule_id=9000001)
+    second_rule = _create_custom_rule(
+        client, admin_token, policy["id"], rule_id=9000002
+    )
+
+    resp = client.patch(
+        f"/policies/{policy['id']}/custom-rules/{second_rule['id']}",
+        headers=admin_token,
+        json={"rule_id": 9000001},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == (
+        "A custom rule with this ID already exists in this policy."
+    )
+
+
+def test_delete_custom_rule_admin_returns_204(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """An admin can delete a custom rule and it can no longer be fetched."""
+    policy = _create_policy(client, admin_token, name="Delete policy")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    delete_resp = client.delete(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+    )
+    get_resp = client.get(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=admin_token,
+    )
+
+    assert delete_resp.status_code == 204
+    assert delete_resp.text == ""
+    assert get_resp.status_code == 404
+    assert get_resp.json()["detail"] == "Custom rule not found"
+
+
+def test_delete_custom_rule_viewer_forbidden(
+    client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
+) -> None:
+    """A viewer cannot delete a custom rule."""
+    policy = _create_policy(client, admin_token, name="Delete blocked")
+    created = _create_custom_rule(client, admin_token, policy["id"])
+
+    resp = client.delete(
+        f"/policies/{policy['id']}/custom-rules/{created['id']}",
+        headers=viewer_token,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
 from app.models.policy import Policy
 from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.vhost import VHost
@@ -99,6 +100,139 @@ def test_deleting_policy_cascades_to_rule_exclusions(db: Session) -> None:
     db.commit()
 
     assert db.get(RuleExclusion, exclusion_id) is None
+
+
+def test_deleting_policy_cascades_to_custom_rules(db: Session) -> None:
+    """Deleting a policy must remove its custom rules (ondelete=CASCADE)."""
+    policy = Policy(
+        name="cascade-custom-rules",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    db.add(policy)
+    db.flush()
+
+    custom_rule = CustomRule(
+        policy_id=policy.id,
+        rule_id=9000001,
+        phase=RulePhase.REQUEST_HEADERS,
+        variables="REQUEST_HEADERS:User-Agent",
+        operator=RuleOperator.RX,
+        operator_argument="(?i)curl",
+        actions="deny,status:403",
+    )
+    db.add(custom_rule)
+    db.flush()
+    custom_rule_id = custom_rule.id
+
+    db.delete(policy)
+    db.commit()
+
+    assert db.get(CustomRule, custom_rule_id) is None
+
+
+def test_custom_rule_id_below_reserved_range_raises_integrity_error(
+    db: Session,
+) -> None:
+    """DB must reject custom rule IDs outside the reserved custom range."""
+    policy = Policy(
+        name="invalid-custom-rule-id",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    db.add(policy)
+    db.flush()
+
+    db.add(
+        CustomRule(
+            policy_id=policy.id,
+            rule_id=8999999,
+            phase=RulePhase.REQUEST_HEADERS,
+            variables="ARGS",
+            operator=RuleOperator.RX,
+            operator_argument=".*",
+            actions="deny",
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match="ck_custom_rules_rule_id_range|CHECK constraint failed",
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_custom_rule_rule_id_must_be_unique_per_policy(db: Session) -> None:
+    """DB must reject duplicate custom rule IDs in the same policy."""
+    policy = Policy(
+        name="duplicate-custom-rule-id",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    db.add(policy)
+    db.flush()
+
+    for variables in ["ARGS:first", "ARGS:second"]:
+        db.add(
+            CustomRule(
+                policy_id=policy.id,
+                rule_id=9000001,
+                phase=RulePhase.REQUEST_HEADERS,
+                variables=variables,
+                operator=RuleOperator.RX,
+                operator_argument=".*",
+                actions="deny",
+            )
+        )
+
+    with pytest.raises(
+        IntegrityError,
+        match="uq_custom_rules_policy_id_rule_id|UNIQUE constraint failed",
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_custom_rule_rule_id_can_repeat_across_policies(db: Session) -> None:
+    """Different policies may reuse the same custom rule ID."""
+    policy_one = Policy(
+        name="policy-one-custom-rule-id",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    policy_two = Policy(
+        name="policy-two-custom-rule-id",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    db.add_all([policy_one, policy_two])
+    db.flush()
+
+    for policy in [policy_one, policy_two]:
+        db.add(
+            CustomRule(
+                policy_id=policy.id,
+                rule_id=9000001,
+                phase=RulePhase.REQUEST_HEADERS,
+                variables="ARGS",
+                operator=RuleOperator.RX,
+                operator_argument=".*",
+                actions="deny",
+            )
+        )
+
+    db.commit()
 
 
 def test_vhost_uppercase_domain_raises_integrity_error(db: Session) -> None:

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -12,9 +12,11 @@ from pydantic import ValidationError
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
+from app.models.custom_rule import RuleOperator, RulePhase  # noqa: E402
 from app.models.policy import PolicyEnforcementMode  # noqa: E402
 from app.models.rule_exclusion import TargetType  # noqa: E402
 from app.models.rule_override import RuleAction  # noqa: E402
+from app.schemas.custom_rule import CustomRuleCreate, CustomRuleUpdate  # noqa: E402
 from app.schemas.log import LogIngestRequest  # noqa: E402
 from app.schemas.policy import PolicyCreate, PolicyUpdate  # noqa: E402
 from app.schemas.rule_exclusion import (  # noqa: E402
@@ -295,6 +297,78 @@ def test_rule_exclusion_update_target_value_must_not_be_blank() -> None:
 
 
 # ---------------------------------------------------------------------------
+# CustomRule schemas
+# ---------------------------------------------------------------------------
+
+
+def test_custom_rule_create_valid() -> None:
+    rule = CustomRuleCreate(
+        rule_id=9000001,
+        phase=RulePhase.REQUEST_HEADERS,
+        variables="REQUEST_HEADERS:User-Agent",
+        operator=RuleOperator.RX,
+        operator_argument="(?i)curl",
+        actions="deny,status:403",
+    )
+
+    assert rule.rule_id == 9000001
+    assert rule.is_active is True
+
+
+def test_custom_rule_create_rule_id_below_range_invalid() -> None:
+    with pytest.raises(ValidationError, match="between 9000000 and 9099999"):
+        CustomRuleCreate(
+            rule_id=8999999,
+            phase=RulePhase.REQUEST_HEADERS,
+            variables="ARGS",
+            operator=RuleOperator.RX,
+            operator_argument=".*",
+            actions="deny",
+        )
+
+
+def test_custom_rule_create_rule_id_above_range_invalid() -> None:
+    with pytest.raises(ValidationError, match="between 9000000 and 9099999"):
+        CustomRuleCreate(
+            rule_id=9100000,
+            phase=RulePhase.REQUEST_HEADERS,
+            variables="ARGS",
+            operator=RuleOperator.RX,
+            operator_argument=".*",
+            actions="deny",
+        )
+
+
+def test_custom_rule_create_variables_must_not_be_blank() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        CustomRuleCreate(
+            rule_id=9000001,
+            phase=RulePhase.REQUEST_HEADERS,
+            variables="   ",
+            operator=RuleOperator.RX,
+            operator_argument=".*",
+            actions="deny",
+        )
+
+
+def test_custom_rule_update_valid() -> None:
+    rule = CustomRuleUpdate(
+        phase=RulePhase.REQUEST_BODY,
+        operator=RuleOperator.CONTAINS,
+        is_active=False,
+    )
+
+    assert rule.phase == RulePhase.REQUEST_BODY
+    assert rule.operator == RuleOperator.CONTAINS
+    assert rule.is_active is False
+
+
+def test_custom_rule_update_operator_argument_must_not_be_blank() -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        CustomRuleUpdate(operator_argument="   ")
+
+
+# ---------------------------------------------------------------------------
 # VHostCreate
 # ---------------------------------------------------------------------------
 
@@ -347,14 +421,18 @@ def test_vhost_create_backend_url_stripped() -> None:
 
 def test_vhost_create_domain_too_long_is_rejected() -> None:
     """A domain longer than 255 characters should raise ValidationError."""
-    with pytest.raises(ValidationError, match="String should have at most 255 characters"):
+    with pytest.raises(
+        ValidationError, match="String should have at most 255 characters"
+    ):
         VHostCreate(domain="a" * 256, backend_url="http://localhost:8080")
 
 
 def test_vhost_create_backend_url_too_long_is_rejected() -> None:
     """A backend_url longer than 512 characters should raise ValidationError."""
     long_url = "http://backend.internal/" + "a" * 512
-    with pytest.raises(ValidationError, match="String should have at most 512 characters"):
+    with pytest.raises(
+        ValidationError, match="String should have at most 512 characters"
+    ):
         VHostCreate(domain="example.com", backend_url=long_url)
 
 
@@ -367,14 +445,18 @@ def test_vhost_create_domain_at_max_length_is_accepted() -> None:
 
 def test_vhost_update_domain_too_long_is_rejected() -> None:
     """A domain update longer than 255 characters should raise ValidationError."""
-    with pytest.raises(ValidationError, match="String should have at most 255 characters"):
+    with pytest.raises(
+        ValidationError, match="String should have at most 255 characters"
+    ):
         VHostUpdate(domain="a" * 256)
 
 
 def test_vhost_update_backend_url_too_long_is_rejected() -> None:
     """A backend_url update longer than 512 characters should raise ValidationError."""
     long_url = "http://backend.internal/" + "a" * 512
-    with pytest.raises(ValidationError, match="String should have at most 512 characters"):
+    with pytest.raises(
+        ValidationError, match="String should have at most 512 characters"
+    ):
         VHostUpdate(backend_url=long_url)
 
 


### PR DESCRIPTION
## Summary

- add policy-scoped CustomRule model, schemas, service, and CRUD router
- add Alembic migration with custom rule ID range constraint and policy cascade
- include custom rules in policy detail responses and eager loading
- add schema, router, and DB constraint coverage

Closes #122
Related to #66

## Validation

- uv run pytest --cov=app
- uv run mypy app/
- uv run ruff check app/
- pnpm run type-check
- pnpm run lint
- LOG_INGEST_SHARED_SECRET=test-secret uv run alembic -c alembic.ini check
- Docker HAProxy validation using a temporary mount of configs/haproxy passed; direct host validation could not access /usr/local/etc/haproxy/coraza.cfg on this machine.
