### PR TITLE
feat(vhosts): add path-scoped policy bindings

### DIFF
--- a/src/backend/alembic/versions/5e2d7c9a1b34_create_policy_bindings_table.py
+++ b/src/backend/alembic/versions/5e2d7c9a1b34_create_policy_bindings_table.py
@@ -1,0 +1,100 @@
+"""create policy_bindings table
+
+Revision ID: 5e2d7c9a1b34
+Revises: 7da7bf17f2b8
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5e2d7c9a1b34"
+down_revision: str | Sequence[str] | None = "7da7bf17f2b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "policy_bindings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("vhost_id", sa.Integer(), nullable=False),
+        sa.Column("policy_id", sa.Integer(), nullable=False),
+        sa.Column("path_prefix", sa.String(length=512), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "path_prefix LIKE '/%'",
+            name="ck_policy_bindings_path_prefix_starts_with_slash",
+        ),
+        sa.CheckConstraint(
+            "priority >= 0",
+            name="ck_policy_bindings_priority_non_negative",
+        ),
+        sa.ForeignKeyConstraint(["policy_id"], ["policies.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["vhost_id"], ["vhosts.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "vhost_id",
+            "path_prefix",
+            "priority",
+            name="uq_policy_bindings_vhost_path_priority",
+        ),
+    )
+    op.create_index(
+        op.f("ix_policy_bindings_policy_id"),
+        "policy_bindings",
+        ["policy_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_policy_bindings_vhost_id"),
+        "policy_bindings",
+        ["vhost_id"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        INSERT INTO policy_bindings (
+            vhost_id,
+            policy_id,
+            path_prefix,
+            priority,
+            comment
+        )
+        SELECT
+            id,
+            policy_id,
+            '/',
+            0,
+            'Migrated from vhost.policy_id'
+        FROM vhosts
+        WHERE policy_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_policy_bindings_vhost_id"), table_name="policy_bindings")
+    op.drop_index(op.f("ix_policy_bindings_policy_id"), table_name="policy_bindings")
+    op.drop_table("policy_bindings")

--- a/src/backend/app/models/__init__.py
+++ b/src/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ Without this, Alembic generates an empty migration (it does not see tables).
 from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
 from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.runtime_operation import (
@@ -23,6 +24,7 @@ __all__ = [
     "UserRole",
     "Policy",
     "PolicyEnforcementMode",
+    "PolicyBinding",
     "VHost",
     "Log",
     "LogAction",

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -23,6 +23,7 @@ from app.database import Base
 
 if TYPE_CHECKING:
     from app.models.custom_rule import CustomRule
+    from app.models.policy_binding import PolicyBinding
     from app.models.rule_exclusion import RuleExclusion
     from app.models.rule_override import RuleOverride
     from app.models.vhost import VHost
@@ -145,6 +146,12 @@ class Policy(Base):
     vhosts: Mapped[list[VHost]] = relationship(
         "VHost",
         back_populates="policy",
+    )
+
+    policy_bindings: Mapped[list[PolicyBinding]] = relationship(
+        "PolicyBinding",
+        back_populates="policy",
+        cascade="all, delete-orphan",
     )
 
     def __repr__(self) -> str:

--- a/src/backend/app/models/policy_binding.py
+++ b/src/backend/app/models/policy_binding.py
@@ -1,0 +1,87 @@
+"""PolicyBinding model for path-scoped policy assignments on vhosts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.policy import Policy
+    from app.models.vhost import VHost
+
+
+class PolicyBinding(Base):
+    """Path-scoped link between a vhost and a WAF policy."""
+
+    __tablename__ = "policy_bindings"
+    __table_args__ = (
+        CheckConstraint(
+            "path_prefix LIKE '/%'",
+            name="ck_policy_bindings_path_prefix_starts_with_slash",
+        ),
+        CheckConstraint(
+            "priority >= 0",
+            name="ck_policy_bindings_priority_non_negative",
+        ),
+        UniqueConstraint(
+            "vhost_id",
+            "path_prefix",
+            "priority",
+            name="uq_policy_bindings_vhost_path_priority",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    vhost_id: Mapped[int] = mapped_column(
+        ForeignKey("vhosts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    policy_id: Mapped[int] = mapped_column(
+        ForeignKey("policies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    path_prefix: Mapped[str] = mapped_column(String(512), nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    vhost: Mapped[VHost] = relationship(
+        "VHost",
+        back_populates="policy_bindings",
+    )
+    policy: Mapped[Policy] = relationship(
+        "Policy",
+        back_populates="policy_bindings",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PolicyBinding id={self.id} "
+            f"vhost_id={self.vhost_id} "
+            f"policy_id={self.policy_id} "
+            f"path_prefix={self.path_prefix!r} "
+            f"priority={self.priority}>"
+        )

--- a/src/backend/app/models/vhost.py
+++ b/src/backend/app/models/vhost.py
@@ -20,6 +20,7 @@ from app.database import Base
 
 if TYPE_CHECKING:
     from app.models.policy import Policy
+    from app.models.policy_binding import PolicyBinding
 
 
 class VHost(Base):
@@ -92,6 +93,13 @@ class VHost(Base):
         "Policy",
         foreign_keys=[policy_id],
         back_populates="vhosts",
+    )
+
+    policy_bindings: Mapped[list[PolicyBinding]] = relationship(
+        "PolicyBinding",
+        back_populates="vhost",
+        cascade="all, delete-orphan",
+        order_by="PolicyBinding.priority.asc(), PolicyBinding.id.asc()",
     )
 
     def __repr__(self) -> str:

--- a/src/backend/app/routers/vhosts.py
+++ b/src/backend/app/routers/vhosts.py
@@ -12,6 +12,7 @@ from app.schemas.policy_binding import PolicyBindingCreate, PolicyBindingRespons
 from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
 from app.services.vhost_service import (
     PolicyBindingAlreadyExistsError,
+    PolicyBindingDefaultManagedByVHostError,
     PolicyBindingFieldCannotBeNullError,
     PolicyBindingInvalidPathPrefixError,
     PolicyBindingInvalidPriorityError,
@@ -213,6 +214,11 @@ def create_policy_binding(
             status_code=status.HTTP_409_CONFLICT,
             detail="Policy binding already exists",
         ) from error
+    except PolicyBindingDefaultManagedByVHostError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(error),
+        ) from error
     except (
         PolicyBindingFieldCannotBeNullError,
         PolicyBindingInvalidPathPrefixError,
@@ -248,6 +254,11 @@ def delete_policy_binding(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Policy binding not found",
+        ) from error
+    except PolicyBindingDefaultManagedByVHostError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(error),
         ) from error
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/routers/vhosts.py
+++ b/src/backend/app/routers/vhosts.py
@@ -5,10 +5,17 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
+from app.models.policy_binding import PolicyBinding
 from app.models.user import User
 from app.models.vhost import VHost
+from app.schemas.policy_binding import PolicyBindingCreate, PolicyBindingResponse
 from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
 from app.services.vhost_service import (
+    PolicyBindingAlreadyExistsError,
+    PolicyBindingFieldCannotBeNullError,
+    PolicyBindingInvalidPathPrefixError,
+    PolicyBindingInvalidPriorityError,
+    PolicyBindingNotFoundError,
     VHostDomainAlreadyExistsError,
     VHostFieldCannotBeNullError,
     VHostNotFoundError,
@@ -143,6 +150,104 @@ def delete_vhost(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="VHost not found",
+        ) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/{vhost_id}/policy-bindings",
+    response_model=list[PolicyBindingResponse],
+)
+def list_policy_bindings(
+    vhost_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[PolicyBinding]:
+    """Return path-scoped policy bindings for a vhost."""
+    service = VHostService(db)
+
+    try:
+        return service.list_policy_bindings(vhost_id)
+    except VHostNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        ) from error
+
+
+@router.post(
+    "/{vhost_id}/policy-bindings",
+    response_model=PolicyBindingResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_policy_binding(
+    vhost_id: int,
+    body: PolicyBindingCreate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> PolicyBinding:
+    """Create a path-scoped policy binding for a vhost."""
+    service = VHostService(db)
+
+    try:
+        return service.create_policy_binding(
+            vhost_id,
+            policy_id=body.policy_id,
+            path_prefix=body.path_prefix,
+            priority=body.priority,
+            comment=body.comment,
+        )
+    except VHostNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        ) from error
+    except VHostPolicyNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found",
+        ) from error
+    except PolicyBindingAlreadyExistsError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Policy binding already exists",
+        ) from error
+    except (
+        PolicyBindingFieldCannotBeNullError,
+        PolicyBindingInvalidPathPrefixError,
+        PolicyBindingInvalidPriorityError,
+    ) as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
+        ) from error
+
+
+@router.delete(
+    "/{vhost_id}/policy-bindings/{binding_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_policy_binding(
+    vhost_id: int,
+    binding_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> Response:
+    """Delete a path-scoped policy binding from a vhost."""
+    service = VHostService(db)
+
+    try:
+        service.delete_policy_binding(vhost_id, binding_id)
+    except VHostNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="VHost not found",
+        ) from error
+    except PolicyBindingNotFoundError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy binding not found",
         ) from error
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -8,6 +8,7 @@ from app.schemas.custom_rule import (
 )
 from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
 from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
+from app.schemas.policy_binding import PolicyBindingCreate, PolicyBindingResponse
 from app.schemas.rule_exclusion import (
     RuleExclusionCreate,
     RuleExclusionResponse,
@@ -39,6 +40,8 @@ __all__ = [
     "PolicyUpdate",
     "PolicyResponse",
     "PolicyDetail",
+    "PolicyBindingCreate",
+    "PolicyBindingResponse",
     # VHosts
     "VHostCreate",
     "VHostUpdate",

--- a/src/backend/app/schemas/policy_binding.py
+++ b/src/backend/app/schemas/policy_binding.py
@@ -1,0 +1,54 @@
+"""Pydantic schemas for path-scoped vhost policy bindings."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class PolicyBindingCreate(BaseModel):
+    """Request body for POST /vhosts/{id}/policy-bindings."""
+
+    policy_id: int
+    path_prefix: str = Field(default="/", max_length=512)
+    priority: int = 0
+    comment: str | None = None
+
+    @field_validator("policy_id")
+    @classmethod
+    def policy_id_must_be_positive(cls, value: int) -> int:
+        """Require policy_id to point at a positive primary key."""
+        if value <= 0:
+            raise ValueError("Policy ID must be greater than 0")
+        return value
+
+    @field_validator("path_prefix")
+    @classmethod
+    def path_prefix_must_start_with_slash(cls, value: str) -> str:
+        """Normalize and validate a URL path prefix."""
+        value = value.strip()
+        if not value.startswith("/"):
+            raise ValueError("Path prefix must start with /")
+        return value
+
+    @field_validator("priority")
+    @classmethod
+    def priority_must_be_non_negative(cls, value: int) -> int:
+        """Require deterministic non-negative route priority."""
+        if value < 0:
+            raise ValueError("Priority must be greater than or equal to 0")
+        return value
+
+
+class PolicyBindingResponse(BaseModel):
+    """Response body for path-scoped policy bindings."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    vhost_id: int
+    policy_id: int
+    path_prefix: str
+    priority: int
+    comment: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/src/backend/app/schemas/vhost.py
+++ b/src/backend/app/schemas/vhost.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.schemas.policy import PolicyResponse
+from app.schemas.policy_binding import PolicyBindingResponse
 
 
 class VHostCreate(BaseModel):
@@ -122,6 +123,7 @@ class VHostResponse(BaseModel):
     ssl_expires_at: datetime | None = None
     is_active: bool
     policy_id: int | None
+    policy_bindings: list[PolicyBindingResponse] = Field(default_factory=list)
     created_by: int | None
     created_at: datetime
     updated_at: datetime

--- a/src/backend/app/services/vhost_service.py
+++ b/src/backend/app/services/vhost_service.py
@@ -56,6 +56,15 @@ class PolicyBindingAlreadyExistsError(VHostError):
     """Raised when a policy binding conflicts with an existing binding."""
 
 
+class PolicyBindingDefaultManagedByVHostError(VHostError):
+    """Raised when callers try to manage the legacy default binding directly."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Default root policy binding is managed through vhost.policy_id"
+        )
+
+
 class PolicyBindingFieldCannotBeNullError(VHostError):
     """Raised when a required policy binding field is null."""
 
@@ -252,6 +261,8 @@ class VHostService:
             path_prefix=path_prefix,
             priority=priority,
         )
+        if self._is_default_policy_binding(path_prefix, priority):
+            raise PolicyBindingDefaultManagedByVHostError()
 
         binding = PolicyBinding(
             vhost_id=vhost_id,
@@ -277,6 +288,8 @@ class VHostService:
         """Delete a policy binding scoped to a vhost."""
         self._get_vhost_or_raise(vhost_id)
         binding = self._get_policy_binding_or_raise(vhost_id, binding_id)
+        if self._is_default_policy_binding(binding.path_prefix, binding.priority):
+            raise PolicyBindingDefaultManagedByVHostError()
         self.db.delete(binding)
         self.db.commit()
 
@@ -389,6 +402,11 @@ class VHostService:
                 and ("path_prefix" in error_text or "vhost_id" in error_text)
             )
         )
+
+    @staticmethod
+    def _is_default_policy_binding(path_prefix: str, priority: int) -> bool:
+        """Return whether a binding is the legacy vhost.policy_id mirror."""
+        return path_prefix == "/" and priority == 0
 
     @staticmethod
     def _parse_cert_expiration(cert_pem: str) -> datetime | None:

--- a/src/backend/app/services/vhost_service.py
+++ b/src/backend/app/services/vhost_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from app.models.policy import Policy
+from app.models.policy_binding import PolicyBinding
 from app.models.vhost import VHost
 from app.services.certbot_service import CertbotError, CertbotService
 
@@ -45,6 +46,36 @@ class VHostFieldCannotBeNullError(VHostError):
 
 class VHostPolicyNotFoundError(VHostError):
     """Raised when a referenced policy does not exist."""
+
+
+class PolicyBindingNotFoundError(VHostError):
+    """Raised when a policy binding does not exist for the given vhost."""
+
+
+class PolicyBindingAlreadyExistsError(VHostError):
+    """Raised when a policy binding conflicts with an existing binding."""
+
+
+class PolicyBindingFieldCannotBeNullError(VHostError):
+    """Raised when a required policy binding field is null."""
+
+    def __init__(self, field_name: str) -> None:
+        self.field_name = field_name
+        super().__init__(f"Field '{field_name}' cannot be null")
+
+
+class PolicyBindingInvalidPathPrefixError(VHostError):
+    """Raised when a policy binding path prefix is invalid."""
+
+    def __init__(self) -> None:
+        super().__init__("Path prefix must start with /")
+
+
+class PolicyBindingInvalidPriorityError(VHostError):
+    """Raised when a policy binding priority is invalid."""
+
+    def __init__(self) -> None:
+        super().__init__("Priority must be greater than or equal to 0")
 
 
 class VHostService:
@@ -102,6 +133,9 @@ class VHostService:
         self.db.add(vhost)
 
         try:
+            self.db.flush()
+            if policy_id is not None:
+                self._sync_default_policy_binding(vhost, policy_id)
             self.db.commit()
         except IntegrityError as error:
             self.db.rollback()
@@ -114,13 +148,21 @@ class VHostService:
 
     def list_vhosts(self) -> list[VHost]:
         """Return all vhosts sorted by ID."""
-        return self.db.query(VHost).order_by(VHost.id.asc()).all()
+        return (
+            self.db.query(VHost)
+            .options(selectinload(VHost.policy_bindings))
+            .order_by(VHost.id.asc())
+            .all()
+        )
 
     def get_vhost(self, vhost_id: int) -> VHost:
         """Return one vhost with related policy loaded."""
         vhost = (
             self.db.query(VHost)
-            .options(selectinload(VHost.policy))
+            .options(
+                selectinload(VHost.policy),
+                selectinload(VHost.policy_bindings),
+            )
             .filter(VHost.id == vhost_id)
             .first()
         )
@@ -163,6 +205,8 @@ class VHostService:
 
         for field, value in patch_data.items():
             setattr(vhost, field, value)
+        if "policy_id" in patch_data:
+            self._sync_default_policy_binding(vhost, patch_data["policy_id"])
 
         try:
             self.db.commit()
@@ -181,6 +225,61 @@ class VHostService:
         self.db.delete(vhost)
         self.db.commit()
 
+    def list_policy_bindings(self, vhost_id: int) -> list[PolicyBinding]:
+        """Return all policy bindings for a vhost ordered by priority and ID."""
+        self._get_vhost_or_raise(vhost_id)
+        return (
+            self.db.query(PolicyBinding)
+            .filter(PolicyBinding.vhost_id == vhost_id)
+            .order_by(PolicyBinding.priority.asc(), PolicyBinding.id.asc())
+            .all()
+        )
+
+    def create_policy_binding(
+        self,
+        vhost_id: int,
+        *,
+        policy_id: int,
+        path_prefix: str,
+        priority: int,
+        comment: str | None,
+    ) -> PolicyBinding:
+        """Create and persist a path-scoped policy binding for a vhost."""
+        self._get_vhost_or_raise(vhost_id)
+        self._ensure_policy_exists(policy_id)
+        self._validate_policy_binding_fields(
+            policy_id=policy_id,
+            path_prefix=path_prefix,
+            priority=priority,
+        )
+
+        binding = PolicyBinding(
+            vhost_id=vhost_id,
+            policy_id=policy_id,
+            path_prefix=path_prefix,
+            priority=priority,
+            comment=comment,
+        )
+        self.db.add(binding)
+
+        try:
+            self.db.commit()
+        except IntegrityError as error:
+            self.db.rollback()
+            if self._is_policy_binding_unique_violation(error):
+                raise PolicyBindingAlreadyExistsError from error
+            raise
+
+        self.db.refresh(binding)
+        return binding
+
+    def delete_policy_binding(self, vhost_id: int, binding_id: int) -> None:
+        """Delete a policy binding scoped to a vhost."""
+        self._get_vhost_or_raise(vhost_id)
+        binding = self._get_policy_binding_or_raise(vhost_id, binding_id)
+        self.db.delete(binding)
+        self.db.commit()
+
     def _get_vhost_or_raise(self, vhost_id: int) -> VHost:
         """Return a vhost by primary key or raise a domain error."""
         vhost = self.db.get(VHost, vhost_id)
@@ -193,17 +292,103 @@ class VHostService:
         if policy_id is not None and self.db.get(Policy, policy_id) is None:
             raise VHostPolicyNotFoundError
 
+    def _get_policy_binding_or_raise(
+        self, vhost_id: int, binding_id: int
+    ) -> PolicyBinding:
+        """Return a binding scoped to a vhost or raise a domain error."""
+        binding = (
+            self.db.query(PolicyBinding)
+            .filter(
+                PolicyBinding.vhost_id == vhost_id,
+                PolicyBinding.id == binding_id,
+            )
+            .first()
+        )
+        if binding is None:
+            raise PolicyBindingNotFoundError
+        return binding
+
     def _validate_patch_data(self, patch_data: dict[str, object]) -> None:
         """Reject nulls for fields that must always keep a real value."""
         for field in NON_NULLABLE_PATCH_FIELDS:
             if field in patch_data and patch_data[field] is None:
                 raise VHostFieldCannotBeNullError(field)
 
+    def _sync_default_policy_binding(
+        self, vhost: VHost, policy_id: object
+    ) -> None:
+        """Mirror legacy vhost.policy_id into the default root path binding."""
+        default_binding = (
+            self.db.query(PolicyBinding)
+            .filter(
+                PolicyBinding.vhost_id == vhost.id,
+                PolicyBinding.path_prefix == "/",
+                PolicyBinding.priority == 0,
+            )
+            .first()
+        )
+
+        if policy_id is None:
+            if default_binding is not None:
+                self.db.delete(default_binding)
+            return
+
+        if not isinstance(policy_id, int):
+            raise PolicyBindingFieldCannotBeNullError("policy_id")
+
+        if default_binding is None:
+            self.db.add(
+                PolicyBinding(
+                    vhost_id=vhost.id,
+                    policy_id=policy_id,
+                    path_prefix="/",
+                    priority=0,
+                    comment="Default binding mirrored from vhost.policy_id",
+                )
+            )
+            return
+
+        default_binding.policy_id = policy_id
+        if default_binding.comment is None:
+            default_binding.comment = "Default binding mirrored from vhost.policy_id"
+
+    def _validate_policy_binding_fields(
+        self,
+        *,
+        policy_id: object,
+        path_prefix: object,
+        priority: object,
+    ) -> None:
+        """Validate required policy binding fields before database writes."""
+        if policy_id is None:
+            raise PolicyBindingFieldCannotBeNullError("policy_id")
+        if path_prefix is None:
+            raise PolicyBindingFieldCannotBeNullError("path_prefix")
+        if priority is None:
+            raise PolicyBindingFieldCannotBeNullError("priority")
+        if not isinstance(path_prefix, str) or not path_prefix.startswith("/"):
+            raise PolicyBindingInvalidPathPrefixError
+        if not isinstance(priority, int) or priority < 0:
+            raise PolicyBindingInvalidPriorityError
+
     @staticmethod
     def _is_vhost_domain_unique_violation(error: IntegrityError) -> bool:
         """Detect whether IntegrityError comes from duplicate vhost domain."""
         error_text = str(error.orig).lower()
         return "unique" in error_text and "domain" in error_text
+
+    @staticmethod
+    def _is_policy_binding_unique_violation(error: IntegrityError) -> bool:
+        """Detect whether IntegrityError comes from duplicate policy binding."""
+        error_text = str(error.orig).lower()
+        return (
+            "uq_policy_bindings_vhost_path_priority" in error_text
+            or (
+                "unique" in error_text
+                and "policy_bindings" in error_text
+                and ("path_prefix" in error_text or "vhost_id" in error_text)
+            )
+        )
 
     @staticmethod
     def _parse_cert_expiration(cert_pem: str) -> datetime | None:

--- a/src/backend/tests/integration/test_db_constraints.py
+++ b/src/backend/tests/integration/test_db_constraints.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
 from app.models.policy import Policy
+from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.vhost import VHost
 
@@ -131,6 +132,183 @@ def test_deleting_policy_cascades_to_custom_rules(db: Session) -> None:
     db.commit()
 
     assert db.get(CustomRule, custom_rule_id) is None
+
+
+def test_deleting_policy_cascades_to_policy_bindings(db: Session) -> None:
+    """Deleting a policy must remove path-scoped policy bindings."""
+    policy = Policy(
+        name="cascade-policy-bindings",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    vhost = VHost(
+        domain="cascade-policy-bindings.example.com",
+        backend_url="http://backend:8000",
+        is_active=True,
+    )
+    db.add_all([policy, vhost])
+    db.flush()
+
+    binding = PolicyBinding(
+        vhost_id=vhost.id,
+        policy_id=policy.id,
+        path_prefix="/",
+        priority=0,
+    )
+    db.add(binding)
+    db.flush()
+    binding_id = binding.id
+
+    db.delete(policy)
+    db.commit()
+
+    assert db.get(PolicyBinding, binding_id) is None
+
+
+def test_deleting_vhost_cascades_to_policy_bindings(db: Session) -> None:
+    """Deleting a vhost must remove its path-scoped policy bindings."""
+    policy = Policy(
+        name="cascade-vhost-policy-bindings",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    vhost = VHost(
+        domain="cascade-vhost-policy-bindings.example.com",
+        backend_url="http://backend:8000",
+        is_active=True,
+    )
+    db.add_all([policy, vhost])
+    db.flush()
+
+    binding = PolicyBinding(
+        vhost_id=vhost.id,
+        policy_id=policy.id,
+        path_prefix="/",
+        priority=0,
+    )
+    db.add(binding)
+    db.flush()
+    binding_id = binding.id
+
+    db.delete(vhost)
+    db.commit()
+
+    assert db.get(PolicyBinding, binding_id) is None
+
+
+def test_policy_binding_path_prefix_must_start_with_slash(
+    db: Session,
+) -> None:
+    """DB must reject path prefixes that are not URL paths."""
+    policy = Policy(
+        name="invalid-binding-path",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    vhost = VHost(
+        domain="invalid-binding-path.example.com",
+        backend_url="http://backend:8000",
+        is_active=True,
+    )
+    db.add_all([policy, vhost])
+    db.flush()
+
+    db.add(
+        PolicyBinding(
+            vhost_id=vhost.id,
+            policy_id=policy.id,
+            path_prefix="api",
+            priority=0,
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match=(
+            "ck_policy_bindings_path_prefix_starts_with_slash"
+            "|CHECK constraint failed"
+        ),
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_policy_binding_priority_must_be_non_negative(db: Session) -> None:
+    """DB must reject negative policy binding priorities."""
+    policy = Policy(
+        name="invalid-binding-priority",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    vhost = VHost(
+        domain="invalid-binding-priority.example.com",
+        backend_url="http://backend:8000",
+        is_active=True,
+    )
+    db.add_all([policy, vhost])
+    db.flush()
+
+    db.add(
+        PolicyBinding(
+            vhost_id=vhost.id,
+            policy_id=policy.id,
+            path_prefix="/api",
+            priority=-1,
+        )
+    )
+
+    with pytest.raises(
+        IntegrityError,
+        match="ck_policy_bindings_priority_non_negative|CHECK constraint failed",
+    ):
+        db.commit()
+    db.rollback()
+
+
+def test_policy_binding_path_priority_must_be_unique_per_vhost(
+    db: Session,
+) -> None:
+    """DB must reject duplicate path and priority bindings for a vhost."""
+    policy = Policy(
+        name="duplicate-binding-policy",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        is_active=True,
+    )
+    vhost = VHost(
+        domain="duplicate-binding.example.com",
+        backend_url="http://backend:8000",
+        is_active=True,
+    )
+    db.add_all([policy, vhost])
+    db.flush()
+
+    for comment in ["first", "second"]:
+        db.add(
+            PolicyBinding(
+                vhost_id=vhost.id,
+                policy_id=policy.id,
+                path_prefix="/api",
+                priority=1,
+                comment=comment,
+            )
+        )
+
+    with pytest.raises(
+        IntegrityError,
+        match="uq_policy_bindings_vhost_path_priority|UNIQUE constraint failed",
+    ):
+        db.commit()
+    db.rollback()
 
 
 def test_custom_rule_id_below_reserved_range_raises_integrity_error(

--- a/src/backend/tests/integration/test_vhosts_router.py
+++ b/src/backend/tests/integration/test_vhosts_router.py
@@ -552,6 +552,30 @@ def test_create_policy_binding_duplicate_returns_409(
     assert second.json()["detail"] == "Policy binding already exists"
 
 
+def test_create_policy_binding_default_root_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """The default root binding is managed through PATCH /vhosts/{id}."""
+    policy = _create_policy(client, admin_token, name="Root binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="root-binding-create.example.com",
+    )
+
+    resp = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": policy["id"], "path_prefix": "/", "priority": 0},
+    )
+    assert resp.status_code == 409
+    assert (
+        resp.json()["detail"]
+        == "Default root policy binding is managed through vhost.policy_id"
+    )
+
+
 def test_delete_policy_binding_admin_returns_204(
     client: TestClient,
     admin_token: dict[str, str],
@@ -582,6 +606,38 @@ def test_delete_policy_binding_admin_returns_204(
     )
     assert list_resp.status_code == 200
     assert list_resp.json() == []
+
+
+def test_delete_policy_binding_default_root_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Deleting the default root binding directly would desync vhost.policy_id."""
+    policy = _create_policy(client, admin_token, name="Root delete binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="root-binding-delete.example.com",
+        policy_id=policy["id"],
+    )
+    root_binding = created["policy_bindings"][0]
+
+    resp = client.delete(
+        f"/vhosts/{created['id']}/policy-bindings/{root_binding['id']}",
+        headers=admin_token,
+    )
+    assert resp.status_code == 409
+    assert (
+        resp.json()["detail"]
+        == "Default root policy binding is managed through vhost.policy_id"
+    )
+
+    detail_resp = client.get(f"/vhosts/{created['id']}", headers=admin_token)
+    assert detail_resp.status_code == 200
+    detail = detail_resp.json()
+    assert detail["policy_id"] == policy["id"]
+    assert len(detail["policy_bindings"]) == 1
+    assert detail["policy_bindings"][0]["id"] == root_binding["id"]
 
 
 def test_delete_policy_binding_viewer_forbidden(

--- a/src/backend/tests/integration/test_vhosts_router.py
+++ b/src/backend/tests/integration/test_vhosts_router.py
@@ -93,6 +93,9 @@ def test_create_vhost_admin_returns_201(
     assert body["is_active"] is True
     assert body["policy_id"] == policy["id"]
     assert body["created_by"] == admin_user.id
+    assert len(body["policy_bindings"]) == 1
+    assert body["policy_bindings"][0]["policy_id"] == policy["id"]
+    assert body["policy_bindings"][0]["path_prefix"] == "/"
 
 
 def test_create_vhost_viewer_forbidden(
@@ -217,6 +220,8 @@ def test_get_vhost_returns_detail_with_policy(
     assert body["domain"] == "detail.example.com"
     assert body["policy"]["id"] == policy["id"]
     assert body["policy"]["name"] == "Nested policy"
+    assert len(body["policy_bindings"]) == 1
+    assert body["policy_bindings"][0]["policy_id"] == policy["id"]
 
 
 def test_get_vhost_not_found_returns_404(
@@ -317,6 +322,34 @@ def test_patch_vhost_with_missing_policy_returns_404(
     assert resp.json()["detail"] == "Policy not found"
 
 
+def test_patch_vhost_policy_id_updates_default_binding(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """PATCH policy_id keeps the legacy root binding synchronized."""
+    first_policy = _create_policy(client, admin_token, name="First binding policy")
+    second_policy = _create_policy(client, admin_token, name="Second binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="sync-binding.example.com",
+        policy_id=first_policy["id"],
+    )
+
+    resp = client.patch(
+        f"/vhosts/{created['id']}",
+        headers=admin_token,
+        json={"policy_id": second_policy["id"]},
+    )
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["policy_id"] == second_policy["id"]
+    assert len(body["policy_bindings"]) == 1
+    assert body["policy_bindings"][0]["policy_id"] == second_policy["id"]
+    assert body["policy_bindings"][0]["path_prefix"] == "/"
+
+
 def test_patch_vhost_domain_null_returns_422(
     client: TestClient,
     admin_token: dict[str, str],
@@ -346,6 +379,235 @@ def test_patch_vhost_backend_url_without_protocol_returns_422(
         json={"backend_url": "backend.internal:443"},
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /vhosts/{vhost_id}/policy-bindings
+# ---------------------------------------------------------------------------
+
+
+def test_list_policy_bindings_returns_default_binding(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Authenticated users can list a vhost's path-scoped policy bindings."""
+    policy = _create_policy(client, admin_token, name="Listed binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="list-bindings.example.com",
+        policy_id=policy["id"],
+    )
+
+    resp = client.get(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=viewer_token,
+    )
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["vhost_id"] == created["id"]
+    assert body[0]["policy_id"] == policy["id"]
+    assert body[0]["path_prefix"] == "/"
+    assert body[0]["priority"] == 0
+
+
+def test_create_policy_binding_admin_returns_201(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Admin can add a path-scoped policy binding to a vhost."""
+    policy = _create_policy(client, admin_token, name="API binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="create-binding.example.com",
+    )
+
+    resp = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={
+            "policy_id": policy["id"],
+            "path_prefix": "/api",
+            "priority": 10,
+            "comment": "API routes",
+        },
+    )
+    assert resp.status_code == 201
+
+    body = resp.json()
+    assert body["vhost_id"] == created["id"]
+    assert body["policy_id"] == policy["id"]
+    assert body["path_prefix"] == "/api"
+    assert body["priority"] == 10
+    assert body["comment"] == "API routes"
+
+
+def test_create_policy_binding_viewer_forbidden(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer cannot create policy bindings."""
+    policy = _create_policy(client, admin_token, name="Forbidden binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="forbidden-binding.example.com",
+    )
+
+    resp = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=viewer_token,
+        json={"policy_id": policy["id"], "path_prefix": "/api", "priority": 1},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_create_policy_binding_missing_vhost_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Creating a binding for an unknown vhost returns 404."""
+    policy = _create_policy(client, admin_token, name="Missing vhost binding policy")
+
+    resp = client.post(
+        "/vhosts/99999/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": policy["id"], "path_prefix": "/api", "priority": 1},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "VHost not found"
+
+
+def test_create_policy_binding_missing_policy_returns_404(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Creating a binding with an unknown policy returns 404."""
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="missing-policy-binding.example.com",
+    )
+
+    resp = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": 99999, "path_prefix": "/api", "priority": 1},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Policy not found"
+
+
+def test_create_policy_binding_invalid_path_returns_422(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Path prefixes must start with a slash."""
+    policy = _create_policy(client, admin_token, name="Invalid path binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="invalid-path-binding.example.com",
+    )
+
+    resp = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": policy["id"], "path_prefix": "api", "priority": 1},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_policy_binding_duplicate_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """A vhost cannot have duplicate bindings for the same path and priority."""
+    policy = _create_policy(client, admin_token, name="Duplicate binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="duplicate-binding.example.com",
+    )
+    payload = {"policy_id": policy["id"], "path_prefix": "/api", "priority": 1}
+    first = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json=payload,
+    )
+    assert first.status_code == 201
+
+    second = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json=payload,
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"] == "Policy binding already exists"
+
+
+def test_delete_policy_binding_admin_returns_204(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Admin can delete a policy binding."""
+    policy = _create_policy(client, admin_token, name="Delete binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="delete-binding.example.com",
+    )
+    binding = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": policy["id"], "path_prefix": "/api", "priority": 1},
+    ).json()
+
+    resp = client.delete(
+        f"/vhosts/{created['id']}/policy-bindings/{binding['id']}",
+        headers=admin_token,
+    )
+    assert resp.status_code == 204
+    assert resp.text == ""
+
+    list_resp = client.get(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+    )
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []
+
+
+def test_delete_policy_binding_viewer_forbidden(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    """Viewer cannot delete policy bindings."""
+    policy = _create_policy(client, admin_token, name="No delete binding policy")
+    created = _create_vhost(
+        client,
+        admin_token,
+        domain="no-delete-binding.example.com",
+    )
+    binding = client.post(
+        f"/vhosts/{created['id']}/policy-bindings",
+        headers=admin_token,
+        json={"policy_id": policy["id"], "path_prefix": "/api", "priority": 1},
+    ).json()
+
+    resp = client.delete(
+        f"/vhosts/{created['id']}/policy-bindings/{binding['id']}",
+        headers=viewer_token,
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -8,9 +8,14 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models.policy import Policy
+from app.models.policy_binding import PolicyBinding
 from app.models.user import User
 from app.models.vhost import VHost
 from app.services.vhost_service import (
+    PolicyBindingAlreadyExistsError,
+    PolicyBindingInvalidPathPrefixError,
+    PolicyBindingInvalidPriorityError,
+    PolicyBindingNotFoundError,
     VHostDomainAlreadyExistsError,
     VHostFieldCannotBeNullError,
     VHostNotFoundError,
@@ -84,6 +89,10 @@ def test_create_vhost_with_existing_policy_succeeds(
     )
 
     assert vhost.policy_id == policy.id
+    assert len(vhost.policy_bindings) == 1
+    assert vhost.policy_bindings[0].policy_id == policy.id
+    assert vhost.policy_bindings[0].path_prefix == "/"
+    assert vhost.policy_bindings[0].priority == 0
 
 
 def test_create_vhost_with_missing_policy_raises_error(
@@ -257,6 +266,54 @@ def test_update_vhost_with_missing_policy_raises_error(
         service.update_vhost(created.id, {"policy_id": 99999})
 
 
+def test_update_vhost_policy_id_syncs_default_binding(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    first_policy = _create_policy_for_test(db, name="First", created_by=admin_user.id)
+    second_policy = _create_policy_for_test(db, name="Second", created_by=admin_user.id)
+    created = service.create_vhost(
+        domain="sync-policy.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=first_policy.id,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_vhost(created.id, {"policy_id": second_policy.id})
+
+    bindings = service.list_policy_bindings(updated.id)
+    assert updated.policy_id == second_policy.id
+    assert len(bindings) == 1
+    assert bindings[0].policy_id == second_policy.id
+    assert bindings[0].path_prefix == "/"
+
+
+def test_update_vhost_policy_id_null_removes_default_binding(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    created = service.create_vhost(
+        domain="clear-policy.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=policy.id,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_vhost(created.id, {"policy_id": None})
+
+    assert updated.policy_id is None
+    assert service.list_policy_bindings(updated.id) == []
+
+
 def test_update_vhost_duplicate_domain_raises_error(
     db: Session,
     admin_user: User,
@@ -310,3 +367,202 @@ def test_delete_vhost_missing_raises_not_found(db: Session) -> None:
 
     with pytest.raises(VHostNotFoundError):
         service.delete_vhost(99999)
+
+
+def test_create_policy_binding_persists_values(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    binding = service.create_policy_binding(
+        vhost.id,
+        policy_id=policy.id,
+        path_prefix="/api",
+        priority=10,
+        comment="API policy",
+    )
+
+    assert binding.id > 0
+    assert binding.vhost_id == vhost.id
+    assert binding.policy_id == policy.id
+    assert binding.path_prefix == "/api"
+    assert binding.priority == 10
+    assert binding.comment == "API policy"
+
+
+def test_list_policy_bindings_returns_priority_order(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="ordered-bindings.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    second = service.create_policy_binding(
+        vhost.id,
+        policy_id=policy.id,
+        path_prefix="/api",
+        priority=20,
+        comment=None,
+    )
+    first = service.create_policy_binding(
+        vhost.id,
+        policy_id=policy.id,
+        path_prefix="/admin",
+        priority=10,
+        comment=None,
+    )
+
+    bindings = service.list_policy_bindings(vhost.id)
+
+    assert [binding.id for binding in bindings] == [first.id, second.id]
+
+
+def test_create_policy_binding_duplicate_path_priority_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="duplicate-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    service.create_policy_binding(
+        vhost.id,
+        policy_id=policy.id,
+        path_prefix="/api",
+        priority=1,
+        comment=None,
+    )
+
+    with pytest.raises(PolicyBindingAlreadyExistsError):
+        service.create_policy_binding(
+            vhost.id,
+            policy_id=policy.id,
+            path_prefix="/api",
+            priority=1,
+            comment=None,
+        )
+
+
+def test_create_policy_binding_invalid_path_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="invalid-path-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyBindingInvalidPathPrefixError):
+        service.create_policy_binding(
+            vhost.id,
+            policy_id=policy.id,
+            path_prefix="api",
+            priority=1,
+            comment=None,
+        )
+
+
+def test_create_policy_binding_invalid_priority_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="invalid-priority-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyBindingInvalidPriorityError):
+        service.create_policy_binding(
+            vhost.id,
+            policy_id=policy.id,
+            path_prefix="/api",
+            priority=-1,
+            comment=None,
+        )
+
+
+def test_delete_policy_binding_removes_existing_binding(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="delete-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    binding = service.create_policy_binding(
+        vhost.id,
+        policy_id=policy.id,
+        path_prefix="/api",
+        priority=1,
+        comment=None,
+    )
+
+    service.delete_policy_binding(vhost.id, binding.id)
+
+    assert db.get(PolicyBinding, binding.id) is None
+
+
+def test_delete_policy_binding_missing_raises_not_found(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    vhost = service.create_vhost(
+        domain="missing-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyBindingNotFoundError):
+        service.delete_policy_binding(vhost.id, 99999)

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -13,6 +13,7 @@ from app.models.user import User
 from app.models.vhost import VHost
 from app.services.vhost_service import (
     PolicyBindingAlreadyExistsError,
+    PolicyBindingDefaultManagedByVHostError,
     PolicyBindingInvalidPathPrefixError,
     PolicyBindingInvalidPriorityError,
     PolicyBindingNotFoundError,
@@ -469,6 +470,32 @@ def test_create_policy_binding_duplicate_path_priority_raises_error(
         )
 
 
+def test_create_policy_binding_rejects_default_root_binding(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="direct-root-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyBindingDefaultManagedByVHostError):
+        service.create_policy_binding(
+            vhost.id,
+            policy_id=policy.id,
+            path_prefix="/",
+            priority=0,
+            comment=None,
+        )
+
+
 def test_create_policy_binding_invalid_path_raises_error(
     db: Session,
     admin_user: User,
@@ -547,6 +574,31 @@ def test_delete_policy_binding_removes_existing_binding(
     service.delete_policy_binding(vhost.id, binding.id)
 
     assert db.get(PolicyBinding, binding.id) is None
+
+
+def test_delete_policy_binding_rejects_default_root_binding(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = VHostService(db)
+    policy = _create_policy_for_test(db, created_by=admin_user.id)
+    vhost = service.create_vhost(
+        domain="delete-root-binding.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=policy.id,
+        created_by=admin_user.id,
+    )
+    binding = service.list_policy_bindings(vhost.id)[0]
+
+    with pytest.raises(PolicyBindingDefaultManagedByVHostError):
+        service.delete_policy_binding(vhost.id, binding.id)
+
+    refreshed = service.get_vhost(vhost.id)
+    assert refreshed.policy_id == policy.id
+    assert len(service.list_policy_bindings(vhost.id)) == 1
 
 
 def test_delete_policy_binding_missing_raises_not_found(


### PR DESCRIPTION
## Summary

- add a `PolicyBinding` model and migration for path-scoped vhost policy assignments
- expose list, create, and delete API support under `/vhosts/{vhost_id}/policy-bindings`
- include bindings in vhost responses and keep the legacy `VHost.policy_id` mirrored to a default `/` binding for compatibility
- backfill existing policy-backed vhosts into default policy bindings during migration

## Validation

- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- fresh SQLite Alembic upgrade to heads
- Docker-mounted HAProxy config validation with `/usr/local/etc/haproxy` layout

Closes #123
