### PR TITLE
Render policy tuning in generated config

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -14,7 +14,10 @@ from sqlalchemy.orm import Session
 
 from app.config import settings, validate_runtime_settings
 from app.database import SessionLocal, get_db
+from app.models.custom_rule import CustomRule
 from app.models.policy import Policy
+from app.models.policy_binding import PolicyBinding
+from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
 from app.models.vhost import VHost
 from app.rate_limit import limiter, rate_limit_exceeded_handler
@@ -77,7 +80,17 @@ def _seed_runtime_config() -> None:
         vhosts = db.query(VHost).all()
         policies = db.query(Policy).all()
         rule_overrides = db.query(RuleOverride).all()
-        generated = generate(vhosts, policies, rule_overrides)
+        rule_exclusions = db.query(RuleExclusion).all()
+        custom_rules = db.query(CustomRule).all()
+        policy_bindings = db.query(PolicyBinding).all()
+        generated = generate(
+            vhosts,
+            policies,
+            rule_overrides,
+            rule_exclusions,
+            custom_rules,
+            policy_bindings,
+        )
         seed_runtime_config(generated)
     except Exception:
         logger.exception("Failed to seed runtime config on startup")

--- a/src/backend/app/routers/config.py
+++ b/src/backend/app/routers/config.py
@@ -8,7 +8,10 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import require_admin
+from app.models.custom_rule import CustomRule
 from app.models.policy import Policy
+from app.models.policy_binding import PolicyBinding
+from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
 from app.models.runtime_operation import (
     RuntimeOperation,
@@ -91,8 +94,18 @@ def apply_config(
         vhosts = db.query(VHost).all()
         policies = db.query(Policy).all()
         rule_overrides = db.query(RuleOverride).all()
+        rule_exclusions = db.query(RuleExclusion).all()
+        custom_rules = db.query(CustomRule).all()
+        policy_bindings = db.query(PolicyBinding).all()
 
-        generated = generate(vhosts, policies, rule_overrides)
+        generated = generate(
+            vhosts,
+            policies,
+            rule_overrides,
+            rule_exclusions,
+            custom_rules,
+            policy_bindings,
+        )
         result = _apply(generated)
         _record_runtime_operations(db, result)
 

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -73,7 +73,7 @@ def generate(
 
     certs = {}
     for vhost in active_vhosts:
-        if vhost.ssl_provider != "none" and vhost.ssl_cert and vhost.ssl_key:
+        if vhost.ssl_enabled and vhost.ssl_cert and vhost.ssl_key:
             certs[vhost.domain] = f"{vhost.ssl_cert}\n{vhost.ssl_key}"
 
     return GeneratedConfig(
@@ -258,29 +258,15 @@ def _control_rule_ids_for_scoped_exclusions(
     exclusions: list[RuleExclusion],
 ) -> dict[int, int]:
     assigned: dict[int, int] = {}
-    used_ids: set[int] = set()
-    fallback_index = 1
-    for exclusion in sorted(
-        (item for item in exclusions if item.scope_path is not None),
-        key=lambda item: (
-            item.id or 0,
-            item.rule_id,
-            item.target_type.value,
-            item.target_value,
-            item.scope_path or "",
-        ),
-    ):
-        if exclusion.id is not None:
-            control_rule_id = 9100000 + exclusion.id
-        else:
-            while 9100000 + fallback_index in used_ids:
-                fallback_index += 1
-            control_rule_id = 9100000 + fallback_index
-            fallback_index += 1
-        while control_rule_id in used_ids:
-            control_rule_id += 1
-        used_ids.add(control_rule_id)
-        assigned[id(exclusion)] = control_rule_id
+    for exclusion in exclusions:
+        if exclusion.scope_path is None:
+            continue
+        if exclusion.id is None:
+            raise ValueError(
+                "Path-scoped rule exclusion has no persisted id; "
+                "control rule ids require a persisted RuleExclusion"
+            )
+        assigned[id(exclusion)] = 9100000 + exclusion.id
     return assigned
 
 

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from app.models.custom_rule import CustomRule
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy_binding import PolicyBinding
+from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
 from app.models.vhost import VHost
 from app.services.config_renderer import (
     CrsPolicyRenderContext,
+    CustomRuleRenderContext,
     HaproxyBackend,
     HaproxyRenderContext,
     HaproxyRoute,
+    RuleExclusionRenderContext,
     RuleOverrideRenderContext,
     render_crs_setup,
     render_haproxy_cfg_multi,
@@ -34,20 +39,37 @@ def generate(
     vhosts: list[VHost],
     policies: list[Policy],
     rule_overrides: list[RuleOverride],
+    rule_exclusions: list[RuleExclusion] | None = None,
+    custom_rules: list[CustomRule] | None = None,
+    policy_bindings: list[PolicyBinding] | None = None,
 ) -> GeneratedConfig:
     """Generate all runtime config files from already loaded objects."""
+    rule_exclusions = rule_exclusions or []
+    custom_rules = custom_rules or []
+    policy_bindings = policy_bindings or []
     active_vhosts = sorted(
         (vhost for vhost in vhosts if vhost.is_active),
         key=lambda vhost: vhost.domain,
     )
     vhost_contexts = [_to_haproxy_context(vhost) for vhost in active_vhosts]
 
-    active_policy, active_overrides = _pick_active_policy(
-        active_vhosts, policies, rule_overrides
+    active_policy, active_overrides, active_exclusions, active_custom_rules = (
+        _pick_active_policy(
+            active_vhosts,
+            policies,
+            rule_overrides,
+            rule_exclusions,
+            custom_rules,
+            policy_bindings,
+        )
     )
     haproxy_cfg = render_haproxy_cfg_multi(vhost_contexts)
     crs_setup_conf = render_crs_setup(active_policy)
-    rule_overrides_conf = render_rule_overrides(active_overrides)
+    rule_overrides_conf = render_rule_overrides(
+        active_overrides,
+        active_exclusions,
+        active_custom_rules,
+    )
 
     certs = {}
     for vhost in active_vhosts:
@@ -66,21 +88,79 @@ def _pick_active_policy(
     active_vhosts: list[VHost],
     policies: list[Policy],
     rule_overrides: list[RuleOverride],
-) -> tuple[CrsPolicyRenderContext, tuple[RuleOverrideRenderContext, ...]]:
+    rule_exclusions: list[RuleExclusion] | None = None,
+    custom_rules: list[CustomRule] | None = None,
+    policy_bindings: list[PolicyBinding] | None = None,
+) -> tuple[
+    CrsPolicyRenderContext,
+    tuple[RuleOverrideRenderContext, ...],
+    tuple[RuleExclusionRenderContext, ...],
+    tuple[CustomRuleRenderContext, ...],
+]:
+    rule_exclusions = rule_exclusions or []
+    custom_rules = custom_rules or []
+    policy_bindings = policy_bindings or []
     policies_by_id = {policy.id: policy for policy in policies}
     overrides_by_policy_id: dict[int, list[RuleOverride]] = {}
     for override in rule_overrides:
         overrides_by_policy_id.setdefault(override.policy_id, []).append(override)
+    exclusions_by_policy_id: dict[int, list[RuleExclusion]] = {}
+    for exclusion in rule_exclusions:
+        exclusions_by_policy_id.setdefault(exclusion.policy_id, []).append(exclusion)
+    custom_rules_by_policy_id: dict[int, list[CustomRule]] = {}
+    for custom_rule in custom_rules:
+        custom_rules_by_policy_id.setdefault(custom_rule.policy_id, []).append(
+            custom_rule
+        )
+    bindings_by_vhost_id: dict[int, list[PolicyBinding]] = {}
+    for binding in policy_bindings:
+        bindings_by_vhost_id.setdefault(binding.vhost_id, []).append(binding)
 
+    effective_policy_ids: set[int] = set()
     for vhost in active_vhosts:
-        if vhost.policy_id is None:
+        if vhost.policy_id is not None:
+            _add_effective_policy_id(
+                effective_policy_ids,
+                policies_by_id,
+                vhost.policy_id,
+                f"Active vhost {vhost.domain!r}",
+            )
+        if vhost.id is None:
             continue
-        policy = policies_by_id.get(vhost.policy_id)
-        if policy is None or not policy.is_active:
-            continue
+        for binding in bindings_by_vhost_id.get(vhost.id, []):
+            _add_effective_policy_id(
+                effective_policy_ids,
+                policies_by_id,
+                binding.policy_id,
+                (
+                    f"Path binding {binding.path_prefix!r} on active vhost "
+                    f"{vhost.domain!r}"
+                ),
+            )
+
+    if len(effective_policy_ids) > 1:
+        policy_list = ", ".join(
+            str(policy_id) for policy_id in sorted(effective_policy_ids)
+        )
+        raise ValueError(
+            "Generated config supports one active CRS policy for MVP; "
+            f"found effective policies: {policy_list}"
+        )
+
+    effective_policy_id = next(iter(effective_policy_ids), None)
+    if effective_policy_id is not None:
+        policy = policies_by_id[effective_policy_id]
         return (
             _to_crs_policy_context(policy),
-            _to_rule_override_contexts(overrides_by_policy_id.get(policy.id, [])),
+            _to_rule_override_contexts(
+                overrides_by_policy_id.get(effective_policy_id, [])
+            ),
+            _to_rule_exclusion_contexts(
+                exclusions_by_policy_id.get(effective_policy_id, [])
+            ),
+            _to_custom_rule_contexts(
+                custom_rules_by_policy_id.get(effective_policy_id, [])
+            ),
         )
 
     return (
@@ -91,7 +171,25 @@ def _pick_active_policy(
             enforcement_mode=PolicyEnforcementMode.detect_only,
         ),
         (),
+        (),
+        (),
     )
+
+
+def _add_effective_policy_id(
+    effective_policy_ids: set[int],
+    policies_by_id: dict[int, Policy],
+    policy_id: int,
+    owner: str,
+) -> None:
+    policy = policies_by_id.get(policy_id)
+    if policy is None:
+        raise ValueError(f"{owner} references missing policy {policy_id}")
+    if not policy.is_active:
+        raise ValueError(f"{owner} references inactive policy {policy.id}")
+    if policy.id is None:
+        raise ValueError(f"{owner} references unpersisted policy")
+    effective_policy_ids.add(policy.id)
 
 
 def _to_haproxy_context(vhost: VHost) -> HaproxyRenderContext:
@@ -106,9 +204,9 @@ def _to_haproxy_context(vhost: VHost) -> HaproxyRenderContext:
     return HaproxyRenderContext(
         routes=(
             HaproxyRoute(
-        vhost_acl_name=f"host_{suffix}",
+                vhost_acl_name=f"host_{suffix}",
                 vhost_hosts=(vhost.domain,),
-                ssl_provider=vhost.ssl_provider,
+                ssl_provider=vhost.ssl_provider if vhost.ssl_enabled else "none",
                 backend=HaproxyBackend(
                     name=f"be_{suffix}",
                     server_name=f"srv_{suffix}",
@@ -140,11 +238,76 @@ def _to_rule_override_contexts(
     )
 
 
+def _to_rule_exclusion_contexts(
+    exclusions: list[RuleExclusion],
+) -> tuple[RuleExclusionRenderContext, ...]:
+    control_rule_ids = _control_rule_ids_for_scoped_exclusions(exclusions)
+    return tuple(
+        RuleExclusionRenderContext(
+            rule_id=exclusion.rule_id,
+            target_type=exclusion.target_type,
+            target_value=exclusion.target_value,
+            scope_path=exclusion.scope_path,
+            control_rule_id=control_rule_ids.get(id(exclusion)),
+        )
+        for exclusion in exclusions
+    )
+
+
+def _control_rule_ids_for_scoped_exclusions(
+    exclusions: list[RuleExclusion],
+) -> dict[int, int]:
+    assigned: dict[int, int] = {}
+    used_ids: set[int] = set()
+    fallback_index = 1
+    for exclusion in sorted(
+        (item for item in exclusions if item.scope_path is not None),
+        key=lambda item: (
+            item.id or 0,
+            item.rule_id,
+            item.target_type.value,
+            item.target_value,
+            item.scope_path or "",
+        ),
+    ):
+        if exclusion.id is not None:
+            control_rule_id = 9100000 + exclusion.id
+        else:
+            while 9100000 + fallback_index in used_ids:
+                fallback_index += 1
+            control_rule_id = 9100000 + fallback_index
+            fallback_index += 1
+        while control_rule_id in used_ids:
+            control_rule_id += 1
+        used_ids.add(control_rule_id)
+        assigned[id(exclusion)] = control_rule_id
+    return assigned
+
+
+def _to_custom_rule_contexts(
+    custom_rules: list[CustomRule],
+) -> tuple[CustomRuleRenderContext, ...]:
+    return tuple(
+        CustomRuleRenderContext(
+            rule_id=custom_rule.rule_id,
+            phase=custom_rule.phase,
+            variables=custom_rule.variables,
+            operator=custom_rule.operator,
+            operator_argument=custom_rule.operator_argument,
+            actions=custom_rule.actions,
+            is_active=custom_rule.is_active,
+        )
+        for custom_rule in custom_rules
+    )
+
+
 def _extract_backend_address(backend_url: str) -> str:
     parsed = urlparse(backend_url)
     
     if parsed.scheme:
         host = parsed.hostname
+        if host is None:
+            raise ValueError(f"Invalid backend URL {backend_url!r}: missing host")
         port = parsed.port
         if not port:
             port = 443 if parsed.scheme == "https" else 80

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -8,7 +8,9 @@ from dataclasses import dataclass
 
 from jinja2 import Environment, PackageLoader, StrictUndefined
 
+from app.models.custom_rule import RuleOperator, RulePhase
 from app.models.policy import PolicyEnforcementMode
+from app.models.rule_exclusion import TargetType
 from app.models.rule_override import RuleAction
 
 # HAProxy identifiers (ACL names, backend names, server names): letters, digits,
@@ -21,6 +23,40 @@ _HAPROXY_HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 # HAProxy backend address (host:port): same allowlist as host values.
 _HAPROXY_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
+_MODSEC_LINE_BREAK_RE = re.compile(r"[\r\n]")
+_MODSEC_TARGET_VALUE_RE = re.compile(r"^[A-Za-z0-9_.:/@-]+$")
+_MODSEC_VARIABLES_RE = re.compile(r"^[A-Za-z0-9_.:|@-]+$")
+
+_PHASE_BY_RULE_PHASE = {
+    RulePhase.REQUEST_HEADERS: 1,
+    RulePhase.REQUEST_BODY: 2,
+    RulePhase.RESPONSE_HEADERS: 3,
+    RulePhase.RESPONSE_BODY: 4,
+    RulePhase.LOGGING: 5,
+}
+
+_OPERATOR_BY_RULE_OPERATOR = {
+    RuleOperator.RX: "rx",
+    RuleOperator.STREQ: "streq",
+    RuleOperator.CONTAINS: "contains",
+    RuleOperator.BEGINS_WITH: "beginsWith",
+    RuleOperator.ENDS_WITH: "endsWith",
+    RuleOperator.EQ: "eq",
+    RuleOperator.GE: "ge",
+    RuleOperator.GT: "gt",
+    RuleOperator.LE: "le",
+    RuleOperator.LT: "lt",
+    RuleOperator.PM: "pm",
+    RuleOperator.WITHIN: "within",
+    RuleOperator.IP_MATCH: "ipMatch",
+}
+
+_TARGET_BY_TARGET_TYPE = {
+    TargetType.REQUEST_URI: "REQUEST_URI",
+    TargetType.ARGS: "ARGS",
+    TargetType.ARGS_NAMES: "ARGS_NAMES",
+    TargetType.REQUEST_HEADERS: "REQUEST_HEADERS",
+}
 
 
 def _validate_haproxy_identifier(value: str, field: str) -> None:
@@ -133,6 +169,101 @@ class RuleOverrideRenderContext:
     action: RuleAction
 
 
+@dataclass(frozen=True)
+class RuleExclusionRenderContext:
+    """Rule exclusion fields needed to render CRS target removals."""
+
+    rule_id: int
+    target_type: TargetType
+    target_value: str
+    scope_path: str | None = None
+    control_rule_id: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.rule_id <= 0:
+            raise ValueError("RuleExclusionRenderContext.rule_id must be positive")
+        _validate_modsec_target_value(
+            self.target_value,
+            "RuleExclusionRenderContext.target_value",
+        )
+        if self.scope_path is not None:
+            _validate_modsec_quoted_value(
+                self.scope_path,
+                "RuleExclusionRenderContext.scope_path",
+            )
+            if not self.scope_path.startswith("/"):
+                raise ValueError(
+                    "RuleExclusionRenderContext.scope_path must start with /"
+                )
+            if self.control_rule_id is None:
+                raise ValueError(
+                    "RuleExclusionRenderContext.control_rule_id is required for "
+                    "path-scoped exclusions"
+                )
+            if self.control_rule_id <= 0:
+                raise ValueError(
+                    "RuleExclusionRenderContext.control_rule_id must be positive"
+                )
+
+    @property
+    def target(self) -> str:
+        variable = _TARGET_BY_TARGET_TYPE[self.target_type]
+        if self.target_type == TargetType.REQUEST_URI:
+            return variable
+        return f"{variable}:{self.target_value}"
+
+    @property
+    def quoted_scope_path(self) -> str:
+        if self.scope_path is None:
+            raise ValueError("scope_path is required")
+        return _quote_modsec(self.scope_path)
+
+
+@dataclass(frozen=True)
+class CustomRuleRenderContext:
+    """Custom rule fields needed to render a Coraza SecRule."""
+
+    rule_id: int
+    phase: RulePhase
+    variables: str
+    operator: RuleOperator
+    operator_argument: str
+    actions: str
+    is_active: bool
+
+    def __post_init__(self) -> None:
+        if self.rule_id <= 0:
+            raise ValueError("CustomRuleRenderContext.rule_id must be positive")
+        _validate_modsec_variables(
+            self.variables,
+            "CustomRuleRenderContext.variables",
+        )
+        _validate_modsec_quoted_value(
+            self.operator_argument,
+            "CustomRuleRenderContext.operator_argument",
+        )
+        _validate_modsec_quoted_value(
+            self.actions,
+            "CustomRuleRenderContext.actions",
+        )
+
+    @property
+    def phase_number(self) -> int:
+        return _PHASE_BY_RULE_PHASE[self.phase]
+
+    @property
+    def operator_token(self) -> str:
+        return _OPERATOR_BY_RULE_OPERATOR[self.operator]
+
+    @property
+    def quoted_operator_argument(self) -> str:
+        return _quote_modsec(self.operator_argument)
+
+    @property
+    def quoted_actions(self) -> str:
+        return _quote_modsec(self.actions)
+
+
 _ENVIRONMENT = Environment(
     loader=PackageLoader("app", "templates"),
     autoescape=False,
@@ -186,11 +317,22 @@ def render_crs_setup(policy: CrsPolicyRenderContext) -> str:
     return template.render(policy=policy, sec_rule_engine=sec_rule_engine)
 
 
-def render_rule_overrides(overrides: tuple[RuleOverrideRenderContext, ...]) -> str:
-    """Render CRS rule removals for disabled policy overrides."""
+def render_rule_overrides(
+    overrides: tuple[RuleOverrideRenderContext, ...],
+    exclusions: tuple[RuleExclusionRenderContext, ...] = (),
+    custom_rules: tuple[CustomRuleRenderContext, ...] = (),
+) -> str:
+    """Render generated CRS tuning for the selected policy."""
     template = _ENVIRONMENT.get_template("rule-overrides.conf.j2")
     disabled_rule_overrides = _sorted_disabled_overrides(overrides)
-    return template.render(disabled_rule_overrides=disabled_rule_overrides)
+    global_exclusions, scoped_exclusions = _sorted_exclusions(exclusions)
+    active_custom_rules = _sorted_active_custom_rules(custom_rules)
+    return template.render(
+        disabled_rule_overrides=disabled_rule_overrides,
+        global_exclusions=global_exclusions,
+        scoped_exclusions=scoped_exclusions,
+        active_custom_rules=active_custom_rules,
+    )
 
 
 def _sorted_disabled_overrides(
@@ -202,9 +344,71 @@ def _sorted_disabled_overrides(
     )
 
 
+def _sorted_exclusions(
+    exclusions: tuple[RuleExclusionRenderContext, ...],
+) -> tuple[list[RuleExclusionRenderContext], list[RuleExclusionRenderContext]]:
+    sorted_exclusions = sorted(
+        exclusions,
+        key=lambda exclusion: (
+            exclusion.scope_path or "",
+            exclusion.rule_id,
+            exclusion.target_type.value,
+            exclusion.target_value,
+        ),
+    )
+    global_exclusions = [
+        exclusion for exclusion in sorted_exclusions if exclusion.scope_path is None
+    ]
+    scoped_exclusions = [
+        exclusion for exclusion in sorted_exclusions if exclusion.scope_path is not None
+    ]
+    return global_exclusions, scoped_exclusions
+
+
+def _sorted_active_custom_rules(
+    custom_rules: tuple[CustomRuleRenderContext, ...],
+) -> list[CustomRuleRenderContext]:
+    return sorted(
+        (rule for rule in custom_rules if rule.is_active),
+        key=lambda rule: rule.rule_id,
+    )
+
+
 def _ensure_unique(values: Iterable[str], field: str) -> None:
     seen: set[str] = set()
     for value in values:
         if value in seen:
             raise ValueError(f"{field} contains duplicate HAProxy identifier {value!r}")
         seen.add(value)
+
+
+def _validate_modsec_target_value(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must not be empty")
+    if not _MODSEC_TARGET_VALUE_RE.match(value):
+        raise ValueError(
+            f"{field} {value!r} contains characters unsafe for generated "
+            "Coraza target syntax"
+        )
+
+
+def _validate_modsec_variables(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must not be empty")
+    if not _MODSEC_VARIABLES_RE.match(value):
+        raise ValueError(
+            f"{field} {value!r} contains characters unsafe for generated "
+            "Coraza variable syntax"
+        )
+
+
+def _validate_modsec_quoted_value(value: str, field: str) -> None:
+    if not value:
+        raise ValueError(f"{field} must not be empty")
+    if _MODSEC_LINE_BREAK_RE.search(value):
+        raise ValueError(f"{field} must not contain line breaks")
+
+
+def _quote_modsec(value: str) -> str:
+    _validate_modsec_quoted_value(value, "quoted Coraza value")
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/backend/app/services/runtime_status_service.py
+++ b/src/backend/app/services/runtime_status_service.py
@@ -8,7 +8,10 @@ from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 
+from app.models.custom_rule import CustomRule
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy_binding import PolicyBinding
+from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
 from app.models.runtime_operation import (
     RuntimeOperation,
@@ -22,15 +25,13 @@ from app.schemas.runtime_status import (
     RuntimeOperationSnapshot,
     RuntimeStatusResponse,
 )
+from app.services.config_generator import generate
 from app.services.config_renderer import (
     CrsPolicyRenderContext,
     HaproxyBackend,
     HaproxyRenderContext,
     HaproxyRoute,
     RuleOverrideRenderContext,
-    render_crs_setup,
-    render_haproxy_cfg,
-    render_rule_overrides,
 )
 
 _FRONTEND_CONTRACT_VERSION = "1"
@@ -63,6 +64,13 @@ class RuntimeStatusService:
         rule_overrides = (
             self.db.query(RuleOverride).order_by(RuleOverride.id.asc()).all()
         )
+        rule_exclusions = (
+            self.db.query(RuleExclusion).order_by(RuleExclusion.id.asc()).all()
+        )
+        custom_rules = self.db.query(CustomRule).order_by(CustomRule.id.asc()).all()
+        policy_bindings = (
+            self.db.query(PolicyBinding).order_by(PolicyBinding.id.asc()).all()
+        )
         active_vhosts = [vhost for vhost in vhosts if vhost.is_active]
         # Compute before calling _pick_active_policy so they appear in the
         # response regardless of whether generation succeeds or fails.
@@ -71,15 +79,14 @@ class RuntimeStatusService:
         ] or None
 
         try:
-            active_policy, active_overrides = self._pick_active_policy(
-                active_vhosts=active_vhosts,
-                policies=policies,
-                rule_overrides=rule_overrides,
+            generated = generate(
+                vhosts,
+                policies,
+                rule_overrides,
+                rule_exclusions,
+                custom_rules,
+                policy_bindings,
             )
-            context = self._to_haproxy_context(active_vhosts)
-            haproxy_cfg = render_haproxy_cfg(context)
-            crs_setup_conf = render_crs_setup(active_policy)
-            rule_overrides_conf = render_rule_overrides(active_overrides)
         except Exception as error:  # pragma: no cover - defensive conversion
             return RuntimeGeneratedConfigStatus(
                 can_generate=False,
@@ -90,9 +97,9 @@ class RuntimeStatusService:
         return RuntimeGeneratedConfigStatus(
             can_generate=True,
             checksum=self._calculate_checksum(
-                haproxy_cfg,
-                crs_setup_conf,
-                rule_overrides_conf,
+                generated.haproxy_cfg,
+                generated.crs_setup_conf,
+                generated.rule_overrides_conf,
             ),
             generated_at=datetime.now(UTC),
             unbound_vhost_domains=unbound_vhost_domains,
@@ -241,7 +248,7 @@ class RuntimeStatusService:
         return HaproxyRoute(
             vhost_acl_name=f"host_{suffix}",
             vhost_hosts=(vhost.domain,),
-            ssl_provider=vhost.ssl_provider,
+            ssl_provider=vhost.ssl_provider if vhost.ssl_enabled else "none",
             backend=HaproxyBackend(
                 name=f"be_{suffix}",
                 server_name=f"srv_{suffix}",

--- a/src/backend/app/services/runtime_status_service.py
+++ b/src/backend/app/services/runtime_status_service.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime
-from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 
 from app.models.custom_rule import CustomRule
-from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy import Policy
 from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
@@ -26,13 +25,6 @@ from app.schemas.runtime_status import (
     RuntimeStatusResponse,
 )
 from app.services.config_generator import generate
-from app.services.config_renderer import (
-    CrsPolicyRenderContext,
-    HaproxyBackend,
-    HaproxyRenderContext,
-    HaproxyRoute,
-    RuleOverrideRenderContext,
-)
 
 _FRONTEND_CONTRACT_VERSION = "1"
 
@@ -148,143 +140,3 @@ class RuntimeStatusService:
         digest.update(rule_overrides_conf.encode("utf-8"))
         return digest.hexdigest()
 
-    @staticmethod
-    def _pick_active_policy(
-        *,
-        active_vhosts: list[VHost],
-        policies: list[Policy],
-        rule_overrides: list[RuleOverride],
-    ) -> tuple[CrsPolicyRenderContext, tuple[RuleOverrideRenderContext, ...]]:
-        policies_by_id = {policy.id: policy for policy in policies}
-        overrides_by_policy_id: dict[int, list[RuleOverride]] = {}
-        for override in rule_overrides:
-            overrides_by_policy_id.setdefault(override.policy_id, []).append(override)
-
-        effective_policy_ids: set[int] = set()
-        for vhost in active_vhosts:
-            if vhost.policy_id is None:
-                # Policy-less vhosts are served using the default CRS context.
-                # Do NOT add a sentinel 0 here — that caused "policy id 0" to
-                # appear in the multiple-policy error message when mixed with
-                # policy-bound vhosts.
-                continue
-
-            policy = policies_by_id.get(vhost.policy_id)
-            if policy is None:
-                raise ValueError(
-                    f"Active vhost {vhost.domain!r} references missing policy "
-                    f"{vhost.policy_id}"
-                )
-            if not policy.is_active:
-                raise ValueError(
-                    f"Active vhost {vhost.domain!r} references inactive policy "
-                    f"{policy.id}"
-                )
-            effective_policy_ids.add(policy.id)
-
-        if len(effective_policy_ids) > 1:
-            policy_list = ", ".join(
-                str(policy_id) for policy_id in sorted(effective_policy_ids)
-            )
-            raise ValueError(
-                "Generated config supports one active CRS policy for MVP; "
-                f"found effective policies: {policy_list}"
-            )
-
-        effective_policy_id = next(iter(effective_policy_ids), None)
-        if effective_policy_id is None:
-            # No policy-bound vhosts; use the default CRS context.
-            return (
-                CrsPolicyRenderContext(
-                    paranoia_level=1,
-                    inbound_anomaly_threshold=5,
-                    outbound_anomaly_threshold=4,
-                    enforcement_mode=PolicyEnforcementMode.detect_only,
-                ),
-                (),
-            )
-
-        policy = policies_by_id[effective_policy_id]
-        return (
-            RuntimeStatusService._to_crs_policy_context(policy),
-            RuntimeStatusService._to_rule_override_contexts(
-                overrides_by_policy_id.get(policy.id, [])
-            ),
-        )
-
-    @staticmethod
-    def _to_haproxy_context(active_vhosts: list[VHost]) -> HaproxyRenderContext:
-        if not active_vhosts:
-            return HaproxyRenderContext(
-                routes=(
-                    HaproxyRoute(
-                        vhost_acl_name="host_app",
-                        vhost_hosts=("app.local", "localhost", "127.0.0.1"),
-                        ssl_provider="none",
-                        backend=HaproxyBackend(
-                            name="be_app",
-                            server_name="app",
-                            address="backend:8000",
-                        ),
-                    ),
-                )
-            )
-
-        return HaproxyRenderContext(
-            routes=tuple(
-                RuntimeStatusService._to_haproxy_route(vhost)
-                for vhost in active_vhosts
-            )
-        )
-
-    @staticmethod
-    def _to_haproxy_route(vhost: VHost) -> HaproxyRoute:
-        if vhost.id is None:
-            raise ValueError(f"Active vhost {vhost.domain!r} has no persisted id")
-        suffix = f"vhost_{vhost.id}"
-        backend_address = RuntimeStatusService._extract_backend_address(
-            vhost.backend_url
-        )
-        return HaproxyRoute(
-            vhost_acl_name=f"host_{suffix}",
-            vhost_hosts=(vhost.domain,),
-            ssl_provider=vhost.ssl_provider if vhost.ssl_enabled else "none",
-            backend=HaproxyBackend(
-                name=f"be_{suffix}",
-                server_name=f"srv_{suffix}",
-                address=backend_address,
-            ),
-        )
-
-    @staticmethod
-    def _to_crs_policy_context(policy: Policy) -> CrsPolicyRenderContext:
-        return CrsPolicyRenderContext(
-            paranoia_level=policy.paranoia_level,
-            inbound_anomaly_threshold=policy.inbound_anomaly_threshold,
-            outbound_anomaly_threshold=policy.outbound_anomaly_threshold,
-            enforcement_mode=policy.enforcement_mode,
-        )
-
-    @staticmethod
-    def _to_rule_override_contexts(
-        overrides: list[RuleOverride],
-    ) -> tuple[RuleOverrideRenderContext, ...]:
-        return tuple(
-            RuleOverrideRenderContext(
-                rule_id=override.rule_id,
-                action=override.action,
-            )
-            for override in overrides
-        )
-
-    @staticmethod
-    def _extract_backend_address(backend_url: str) -> str:
-        parsed = urlparse(backend_url)
-        address = parsed.netloc if parsed.scheme else parsed.path
-        if not address:
-            raise ValueError(f"Invalid backend URL {backend_url!r}: missing host")
-        if "@" in address:
-            raise ValueError(
-                f"Invalid backend URL {backend_url!r}: userinfo is not supported"
-            )
-        return address

--- a/src/backend/app/services/scheduler.py
+++ b/src/backend/app/services/scheduler.py
@@ -43,15 +43,26 @@ def renew_certificates() -> None:
                     
                     # Need to trigger config generation to write the new certs to disk
                     # This relies on config apply logic.
+                    from app.models.custom_rule import CustomRule
                     from app.models.policy import Policy
+                    from app.models.policy_binding import PolicyBinding
+                    from app.models.rule_exclusion import RuleExclusion
                     from app.models.rule_override import RuleOverride
                     from app.services.config_apply import apply as apply_config
                     from app.services.config_generator import generate
                     try:
                         policies = db.query(Policy).all()
                         rule_overrides = db.query(RuleOverride).all()
+                        rule_exclusions = db.query(RuleExclusion).all()
+                        custom_rules = db.query(CustomRule).all()
+                        policy_bindings = db.query(PolicyBinding).all()
                         generated = generate(
-                            db.query(VHost).all(), policies, rule_overrides
+                            db.query(VHost).all(),
+                            policies,
+                            rule_overrides,
+                            rule_exclusions,
+                            custom_rules,
+                            policy_bindings,
                         )
                         apply_config(generated)
                     except Exception as e:

--- a/src/backend/app/templates/rule-overrides.conf.j2
+++ b/src/backend/app/templates/rule-overrides.conf.j2
@@ -1,7 +1,25 @@
-# Guard Proxy CRS rule overrides.
+# Guard Proxy generated CRS policy tuning.
 #
-# Rules are enabled by default through the CRS include. Disabled overrides remove
-# selected CRS rule IDs for the rendered policy.
+# Rules are enabled by default through the CRS include. This file applies the
+# selected policy's disabled rules, target exclusions, scoped exclusions, and
+# administrator-authored custom rules.
+
+# Disabled CRS rules.
 {% for override in disabled_rule_overrides %}
 SecRuleRemoveById {{ override.rule_id }}
+{% endfor %}
+
+# Global target exclusions.
+{% for exclusion in global_exclusions %}
+SecRuleRemoveTargetById {{ exclusion.rule_id }} {{ exclusion.target }}
+{% endfor %}
+
+# Path-scoped target exclusions.
+{% for exclusion in scoped_exclusions %}
+SecRule REQUEST_URI "@beginsWith {{ exclusion.quoted_scope_path }}" "id:{{ exclusion.control_rule_id }},phase:1,pass,nolog,ctl:ruleRemoveTargetById={{ exclusion.rule_id }};{{ exclusion.target }}"
+{% endfor %}
+
+# Custom rules.
+{% for rule in active_custom_rules %}
+SecRule {{ rule.variables }} "@{{ rule.operator_token }} {{ rule.quoted_operator_argument }}" "id:{{ rule.rule_id }},phase:{{ rule.phase_number }},{{ rule.quoted_actions }}"
 {% endfor %}

--- a/src/backend/tests/e2e/test_policy_apply.py
+++ b/src/backend/tests/e2e/test_policy_apply.py
@@ -23,6 +23,8 @@ ADMIN_PASSWORD = "policy-apply-password-123"
 HOST_HEADER = "app.local"
 SCANNER_USER_AGENT = "nuclei"
 SCANNER_RULE_ID = 913100
+EXCLUSION_RULE_ID = 942100
+CUSTOM_RULE_ID = 9000001
 HTTP_TIMEOUT_SECONDS = 5
 SERVICE_TIMEOUT_SECONDS = 180
 # Coraza's supervisor polls /runtime/current every second before restarting SPOA.
@@ -121,13 +123,53 @@ def test_policy_apply_rule_override_flips_runtime_waf_behavior(
             "policy_id": policy_id,
         },
     )
+    _api_json(
+        compose_stack,
+        "POST",
+        f"/policies/{policy_id}/exclusions",
+        token=token,
+        expected_status=201,
+        payload={
+            "rule_id": EXCLUSION_RULE_ID,
+            "target_type": "args",
+            "target_value": "token",
+            "scope_path": "/api/login",
+            "comment": "E2E proves exclusions reach generated config",
+        },
+    )
+    _api_json(
+        compose_stack,
+        "POST",
+        f"/policies/{policy_id}/custom-rules",
+        token=token,
+        expected_status=201,
+        payload={
+            "rule_id": CUSTOM_RULE_ID,
+            "phase": "request_headers",
+            "variables": "REQUEST_HEADERS:X-Guard-Proxy-E2E",
+            "operator": "streq",
+            "operator_argument": "deny-me",
+            "actions": "deny,status:403,log",
+            "comment": "E2E proves custom rules reach generated config",
+            "is_active": True,
+        },
+    )
 
     applied = _apply_config(compose_stack, token)
     assert "SecRuleEngine On" in applied["generated_config"]["crs_setup_conf"]
     assert f"SecRuleRemoveById {SCANNER_RULE_ID}" not in applied["generated_config"][
         "rule_overrides_conf"
     ]
+    assert (
+        f"ctl:ruleRemoveTargetById={EXCLUSION_RULE_ID};ARGS:token"
+        in applied["generated_config"]["rule_overrides_conf"]
+    )
+    assert (
+        f"id:{CUSTOM_RULE_ID},phase:1,deny,status:403,log"
+        in applied["generated_config"]["rule_overrides_conf"]
+    )
     _assert_coraza_runtime_override(compose_stack, should_exist=False)
+    _assert_coraza_runtime_tuning(compose_stack, should_exist=True)
     _wait_for_scanner_status(compose_stack, 403, "scanner request before override")
 
     override = _api_json(
@@ -353,6 +395,29 @@ def _assert_coraza_runtime_override(stack: ComposeStack, *, should_exist: bool) 
         assert expected in result.stdout
     else:
         assert expected not in result.stdout
+
+
+def _assert_coraza_runtime_tuning(stack: ComposeStack, *, should_exist: bool) -> None:
+    result = _run(
+        stack.command
+        + [
+            "exec",
+            "-T",
+            "coraza",
+            "cat",
+            "/runtime/current/rule-overrides.conf",
+        ],
+        env=stack.env,
+    )
+    expected = [
+        f"ctl:ruleRemoveTargetById={EXCLUSION_RULE_ID};ARGS:token",
+        f"id:{CUSTOM_RULE_ID},phase:1,deny,status:403,log",
+    ]
+    for line in expected:
+        if should_exist:
+            assert line in result.stdout
+        else:
+            assert line not in result.stdout
 
 
 def _api_json(

--- a/src/backend/tests/unit/test_config_generator.py
+++ b/src/backend/tests/unit/test_config_generator.py
@@ -1,10 +1,29 @@
+import shutil
+import subprocess
+from pathlib import Path
+
 import pytest
 
+from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy_binding import PolicyBinding
+from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.vhost import VHost
 from app.services.config_generator import generate
-from app.services.config_renderer import HaproxyBackend, HaproxyRenderContext, HaproxyRoute, render_haproxy_cfg_multi
+from app.services.config_renderer import (
+    HaproxyBackend,
+    HaproxyRenderContext,
+    HaproxyRoute,
+    render_haproxy_cfg_multi,
+)
+
+
+def _repo_root() -> Path:
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "configs/haproxy/coraza.cfg").is_file():
+            return candidate
+    raise RuntimeError("Could not locate repository root")
 
 
 def test_generate_empty_db() -> None:
@@ -15,7 +34,7 @@ def test_generate_empty_db() -> None:
     assert "backend coraza-spoa" in generated.haproxy_cfg
     assert "backend be_" not in generated.haproxy_cfg
     assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
-    assert generated.rule_overrides_conf.strip() == "# Guard Proxy CRS rule overrides.\n#\n# Rules are enabled by default through the CRS include. Disabled overrides remove\n# selected CRS rule IDs for the rendered policy."
+    assert "Guard Proxy generated CRS policy tuning" in generated.rule_overrides_conf
 
 
 def test_generate_one_vhost_no_policy() -> None:
@@ -36,6 +55,53 @@ def test_generate_one_vhost_no_policy() -> None:
     assert "use_backend be_vhost_1 if host_vhost_1" in generated.haproxy_cfg
     assert "server srv_vhost_1 backend:8000 check" in generated.haproxy_cfg
     assert "SecRuleEngine DetectionOnly" in generated.crs_setup_conf
+
+
+def test_generated_haproxy_cfg_validates_with_haproxy(tmp_path: Path) -> None:
+    haproxy = shutil.which("haproxy")
+    if haproxy is None:
+        pytest.skip("haproxy binary is not installed")
+    vhost = VHost(
+        id=1,
+        domain="app.local",
+        backend_url="http://backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+    generated = generate(vhosts=[vhost], policies=[], rule_overrides=[])
+    config_path = tmp_path / "haproxy.cfg"
+    repo_coraza_cfg = _repo_root() / "configs/haproxy/coraza.cfg"
+    config_path.write_text(
+        generated.haproxy_cfg.replace(
+            "/usr/local/etc/haproxy/coraza.cfg",
+            str(repo_coraza_cfg),
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [haproxy, "-c", "-f", str(config_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_generate_rejects_backend_url_with_scheme_but_no_host() -> None:
+    vhost = VHost(
+        id=1,
+        domain="broken.example.com",
+        backend_url="http://",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+
+    with pytest.raises(ValueError, match="missing host"):
+        generate(vhosts=[vhost], policies=[], rule_overrides=[])
 
 
 def test_generate_one_vhost_with_policy() -> None:
@@ -59,7 +125,10 @@ def test_generate_one_vhost_with_policy() -> None:
 
     generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[])
 
-    assert "acl host_vhost_5 hdr(host),field(1,:) -i api.example.com" in generated.haproxy_cfg
+    assert (
+        "acl host_vhost_5 hdr(host),field(1,:) -i api.example.com"
+        in generated.haproxy_cfg
+    )
     assert "use_backend be_vhost_5 if host_vhost_5" in generated.haproxy_cfg
     assert "SecRuleEngine On" in generated.crs_setup_conf
     assert "setvar:tx.blocking_paranoia_level=2" in generated.crs_setup_conf
@@ -93,6 +162,150 @@ def test_generate_one_vhost_with_policy_and_overrides() -> None:
     generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[override])
 
     assert "SecRuleRemoveById 942100" in generated.rule_overrides_conf
+
+
+def test_generate_one_vhost_with_policy_exclusion_and_custom_rule() -> None:
+    vhost = VHost(
+        id=1,
+        domain="api.example.com",
+        backend_url="http://api-backend:9000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=10,
+    )
+    policy = Policy(
+        id=10,
+        name="Strict",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+    )
+    exclusion = RuleExclusion(
+        id=42,
+        policy_id=10,
+        rule_id=942100,
+        target_type=TargetType.ARGS,
+        target_value="token",
+        scope_path="/api/login",
+    )
+    custom_rule = CustomRule(
+        id=100,
+        policy_id=10,
+        rule_id=9000001,
+        phase=RulePhase.REQUEST_HEADERS,
+        variables="REQUEST_HEADERS:User-Agent",
+        operator=RuleOperator.RX,
+        operator_argument="(?i)curl",
+        actions="deny,status:403,log",
+        is_active=True,
+    )
+
+    generated = generate(
+        vhosts=[vhost],
+        policies=[policy],
+        rule_overrides=[],
+        rule_exclusions=[exclusion],
+        custom_rules=[custom_rule],
+    )
+
+    assert (
+        'SecRule REQUEST_URI "@beginsWith /api/login" '
+        '"id:9100042,phase:1,pass,nolog,'
+        'ctl:ruleRemoveTargetById=942100;ARGS:token"'
+    ) in generated.rule_overrides_conf
+    assert (
+        'SecRule REQUEST_HEADERS:User-Agent "@rx (?i)curl" '
+        '"id:9000001,phase:1,deny,status:403,log"'
+    ) in generated.rule_overrides_conf
+
+
+def test_generate_uses_policy_from_path_binding() -> None:
+    vhost = VHost(
+        id=1,
+        domain="api.example.com",
+        backend_url="http://api-backend:9000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=None,
+    )
+    policy = Policy(
+        id=10,
+        name="Strict",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+    )
+    binding = PolicyBinding(
+        id=20,
+        vhost_id=1,
+        policy_id=10,
+        path_prefix="/api",
+        priority=10,
+    )
+    override = RuleOverride(
+        id=100,
+        policy_id=10,
+        rule_id=942100,
+        action=RuleAction.disable,
+    )
+
+    generated = generate(
+        vhosts=[vhost],
+        policies=[policy],
+        rule_overrides=[override],
+        policy_bindings=[binding],
+    )
+
+    assert "SecRuleEngine On" in generated.crs_setup_conf
+    assert "SecRuleRemoveById 942100" in generated.rule_overrides_conf
+
+
+def test_generate_rejects_multiple_effective_path_policies() -> None:
+    vhost = VHost(
+        id=1,
+        domain="api.example.com",
+        backend_url="http://api-backend:9000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=10,
+    )
+    first_policy = Policy(
+        id=10,
+        name="Strict",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+    )
+    second_policy = Policy(
+        id=11,
+        name="Monitor",
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.detect_only,
+        is_active=True,
+    )
+    binding = PolicyBinding(
+        id=20,
+        vhost_id=1,
+        policy_id=11,
+        path_prefix="/monitor",
+        priority=10,
+    )
+
+    with pytest.raises(ValueError, match="one active CRS policy"):
+        generate(
+            vhosts=[vhost],
+            policies=[first_policy, second_policy],
+            rule_overrides=[],
+            policy_bindings=[binding],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +351,10 @@ def test_generate_dot_dash_domain_siblings_do_not_collide() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_single_route_context(acl_name: str, backend_name: str) -> HaproxyRenderContext:
+def _make_single_route_context(
+    acl_name: str,
+    backend_name: str,
+) -> HaproxyRenderContext:
     return HaproxyRenderContext(
         routes=(
             HaproxyRoute(
@@ -155,7 +371,7 @@ def _make_single_route_context(acl_name: str, backend_name: str) -> HaproxyRende
     )
 
 
-def test_render_haproxy_cfg_multi_raises_on_duplicate_acl_name_across_contexts() -> None:
+def test_render_haproxy_cfg_multi_raises_on_duplicate_acl_name_across_contexts() -> None:  # noqa: E501
     ctx_a = _make_single_route_context("host_a", "be_a")
     ctx_b = _make_single_route_context("host_a", "be_b")  # duplicate ACL name
 
@@ -163,7 +379,7 @@ def test_render_haproxy_cfg_multi_raises_on_duplicate_acl_name_across_contexts()
         render_haproxy_cfg_multi([ctx_a, ctx_b])
 
 
-def test_render_haproxy_cfg_multi_raises_on_duplicate_backend_name_across_contexts() -> None:
+def test_render_haproxy_cfg_multi_raises_on_duplicate_backend_name_across_contexts() -> None:  # noqa: E501
     ctx_a = _make_single_route_context("host_a", "be_shared")
     ctx_b = _make_single_route_context("host_b", "be_shared")  # duplicate backend name
 

--- a/src/backend/tests/unit/test_config_renderer_rule_overrides.py
+++ b/src/backend/tests/unit/test_config_renderer_rule_overrides.py
@@ -20,10 +20,27 @@ def _overrides(
 def test_rule_overrides_template_renders_header_for_empty_policy() -> None:
     rendered = render_rule_overrides(_overrides([]))
 
-    assert "Guard Proxy generated CRS policy tuning" in rendered
-    assert "SecRuleRemoveById" not in rendered
-    assert "SecRuleRemoveTargetById" not in rendered
-    assert "SecRule REQUEST_URI" not in rendered
+    assert rendered == (
+        "# Guard Proxy generated CRS policy tuning.\n"
+        "#\n"
+        "# Rules are enabled by default through the CRS include. This file"
+        " applies the\n"
+        "# selected policy's disabled rules, target exclusions, scoped"
+        " exclusions, and\n"
+        "# administrator-authored custom rules.\n"
+        "\n"
+        "# Disabled CRS rules.\n"
+        "\n"
+        "\n"
+        "# Global target exclusions.\n"
+        "\n"
+        "\n"
+        "# Path-scoped target exclusions.\n"
+        "\n"
+        "\n"
+        "# Custom rules.\n"
+        "\n"
+    )
 
 
 def test_rule_overrides_template_renders_disabled_rules_sorted() -> None:

--- a/src/backend/tests/unit/test_config_renderer_rule_overrides.py
+++ b/src/backend/tests/unit/test_config_renderer_rule_overrides.py
@@ -1,5 +1,11 @@
+import pytest
+
+from app.models.custom_rule import RuleOperator, RulePhase
+from app.models.rule_exclusion import TargetType
 from app.models.rule_override import RuleAction
 from app.services.config_renderer import (
+    CustomRuleRenderContext,
+    RuleExclusionRenderContext,
     RuleOverrideRenderContext,
     render_rule_overrides,
 )
@@ -14,8 +20,10 @@ def _overrides(
 def test_rule_overrides_template_renders_header_for_empty_policy() -> None:
     rendered = render_rule_overrides(_overrides([]))
 
-    assert "Guard Proxy CRS rule overrides" in rendered
+    assert "Guard Proxy generated CRS policy tuning" in rendered
     assert "SecRuleRemoveById" not in rendered
+    assert "SecRuleRemoveTargetById" not in rendered
+    assert "SecRule REQUEST_URI" not in rendered
 
 
 def test_rule_overrides_template_renders_disabled_rules_sorted() -> None:
@@ -57,3 +65,119 @@ def test_rule_overrides_template_skips_enabled_rules() -> None:
 
     assert "SecRuleRemoveById 941100" not in rendered
     assert "SecRuleRemoveById 942100" in rendered
+
+
+def test_rule_overrides_template_renders_global_exclusions_sorted() -> None:
+    rendered = render_rule_overrides(
+        _overrides([]),
+        exclusions=(
+            RuleExclusionRenderContext(
+                rule_id=942100,
+                target_type=TargetType.REQUEST_HEADERS,
+                target_value="X-Api-Token",
+            ),
+            RuleExclusionRenderContext(
+                rule_id=941100,
+                target_type=TargetType.ARGS,
+                target_value="comment",
+            ),
+        ),
+    )
+
+    first = "SecRuleRemoveTargetById 941100 ARGS:comment"
+    second = "SecRuleRemoveTargetById 942100 REQUEST_HEADERS:X-Api-Token"
+    assert first in rendered
+    assert second in rendered
+    assert rendered.index(first) < rendered.index(second)
+
+
+def test_rule_overrides_template_renders_path_scoped_exclusion() -> None:
+    rendered = render_rule_overrides(
+        _overrides([]),
+        exclusions=(
+            RuleExclusionRenderContext(
+                rule_id=942100,
+                target_type=TargetType.ARGS,
+                target_value="token",
+                scope_path="/api/login",
+                control_rule_id=9100042,
+            ),
+        ),
+    )
+
+    assert (
+        'SecRule REQUEST_URI "@beginsWith /api/login" '
+        '"id:9100042,phase:1,pass,nolog,'
+        'ctl:ruleRemoveTargetById=942100;ARGS:token"'
+    ) in rendered
+
+
+def test_rule_overrides_template_requires_control_id_for_scoped_exclusion() -> None:
+    with pytest.raises(ValueError, match="control_rule_id is required"):
+        RuleExclusionRenderContext(
+            rule_id=942100,
+            target_type=TargetType.ARGS,
+            target_value="token",
+            scope_path="/api/login",
+        )
+
+
+def test_rule_overrides_template_renders_active_custom_rules_sorted() -> None:
+    rendered = render_rule_overrides(
+        _overrides([]),
+        custom_rules=(
+            CustomRuleRenderContext(
+                rule_id=9000002,
+                phase=RulePhase.REQUEST_BODY,
+                variables="ARGS:comment",
+                operator=RuleOperator.CONTAINS,
+                operator_argument="blocked",
+                actions="deny,status:403,log",
+                is_active=True,
+            ),
+            CustomRuleRenderContext(
+                rule_id=9000001,
+                phase=RulePhase.REQUEST_HEADERS,
+                variables="REQUEST_HEADERS:User-Agent",
+                operator=RuleOperator.RX,
+                operator_argument="(?i)curl",
+                actions="deny,status:403,log",
+                is_active=True,
+            ),
+            CustomRuleRenderContext(
+                rule_id=9000003,
+                phase=RulePhase.REQUEST_HEADERS,
+                variables="REQUEST_HEADERS:X-Test",
+                operator=RuleOperator.STREQ,
+                operator_argument="inactive",
+                actions="deny,status:403,log",
+                is_active=False,
+            ),
+        ),
+    )
+
+    first = (
+        'SecRule REQUEST_HEADERS:User-Agent "@rx (?i)curl" '
+        '"id:9000001,phase:1,deny,status:403,log"'
+    )
+    second = (
+        'SecRule ARGS:comment "@contains blocked" '
+        '"id:9000002,phase:2,deny,status:403,log"'
+    )
+    assert first in rendered
+    assert second in rendered
+    assert "9000003" not in rendered
+    assert rendered.index(first) < rendered.index(second)
+
+
+def test_custom_rule_context_rejects_line_break_in_operator_argument() -> None:
+    with pytest.raises(ValueError, match="line breaks"):
+        CustomRuleRenderContext(
+            rule_id=9000001,
+            phase=RulePhase.REQUEST_HEADERS,
+            variables="REQUEST_HEADERS:User-Agent",
+            operator=RuleOperator.RX,
+            operator_argument="curl\nSecRule ARGS",
+            actions="deny,status:403,log",
+            is_active=True,
+        )

--- a/src/backend/tests/unit/test_runtime_status_service.py
+++ b/src/backend/tests/unit/test_runtime_status_service.py
@@ -10,7 +10,7 @@ from app.models.runtime_operation import (
     RuntimeOperationType,
 )
 from app.models.vhost import VHost
-from app.services.config_renderer import render_haproxy_cfg
+from app.services.config_generator import generate
 from app.services.runtime_status_service import RuntimeStatusService
 
 
@@ -178,9 +178,8 @@ def test_haproxy_context_uses_vhost_id_identifiers_for_colliding_domains(
         backend_url="http://bar-backend:8000",
     )
 
-    rendered = render_haproxy_cfg(
-        RuntimeStatusService._to_haproxy_context([first, second])
-    )
+    generated = generate(vhosts=[first, second], policies=[], rule_overrides=[])
+    rendered = generated.haproxy_cfg
 
     assert f"acl host_vhost_{first.id} hdr(host),field(1,:) -i foo-bar.com" in rendered
     assert f"acl host_vhost_{second.id} hdr(host),field(1,:) -i foo.bar.com" in rendered
@@ -260,6 +259,7 @@ def test_generated_config_rejects_inactive_assigned_policy(db: Session) -> None:
 
 def test_active_policy_selection_rejects_missing_policy() -> None:
     vhost = VHost(
+        id=1,
         domain="app.example.com",
         backend_url="http://app-backend:8000",
         is_active=True,
@@ -268,11 +268,7 @@ def test_active_policy_selection_rejects_missing_policy() -> None:
     )
 
     try:
-        RuntimeStatusService._pick_active_policy(
-            active_vhosts=[vhost],
-            policies=[],
-            rule_overrides=[],
-        )
+        generate(vhosts=[vhost], policies=[], rule_overrides=[])
     except ValueError as error:
         assert "missing policy 999" in str(error)
     else:  # pragma: no cover - assertion guard


### PR DESCRIPTION
## Summary

- render generated CRS tuning for disabled overrides, target exclusions, path-scoped exclusions, and active custom rules
- pass exclusions, custom rules, and path policy bindings into config apply, startup seeding, scheduler apply, and runtime status generation
- add generator and renderer coverage, including rendered HAProxy config validation
- extend the policy-apply e2e flow to assert an exclusion and custom rule reach generated runtime config

Fixes #124

## Validation

- `cd src/backend && uv run pytest --cov=app`
- `cd src/backend && uv run mypy app/`
- `cd src/backend && uv run ruff check app/`
- `cd src/frontend && pnpm run type-check`
- `cd src/frontend && pnpm run lint`
