### PR TITLE
feat(policies): add policy tuning UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ make clean   # stop containers and remove all volumes
 ## Documentation
 
 - [Architecture](README.architecture.md) — system architecture and data flow
+- [WAF Policy Tuning](README.waf-rules.md) — rule overrides, exclusions, and custom rules
 - [Development Commands](README.commands.md) — all dev commands, including user management
 - [Testing Strategy](README.testing.md) — testing approach and targets
 - [Evaluation Plan](docs/evaluation-plan.md) — thesis benchmark methodology and lab scenarios

--- a/README.waf-rules.md
+++ b/README.waf-rules.md
@@ -1,0 +1,466 @@
+# WAF Policy Tuning Guide
+
+> How to adjust OWASP CRS behaviour with rule overrides, target exclusions, and custom rules.
+
+Guard Proxy does not only deploy the OWASP Core Rule Set (CRS) out of the box — it also lets you **fine-tune** it. Every virtual host can be bound to a *policy*, and every policy can carry three kinds of tuning entries:
+
+1. **Rule overrides** — turn an entire CRS rule on or off.
+2. **Rule exclusions** — stop a CRS rule from inspecting one specific argument, header, or URI.
+3. **Custom rules** — write your own security rules on top of CRS.
+
+This guide explains what each entry does, what fields you must fill in, and what Guard Proxy writes into the generated Coraza configuration.
+
+---
+
+## Table of Contents
+
+- [Quick glossary](#quick-glossary)
+- [Rule overrides](#rule-overrides)
+- [Rule exclusions](#rule-exclusions)
+- [From log to exclusion — a worked example](#from-log-to-exclusion--a-worked-example)
+- [Custom rules](#custom-rules)
+- [API cheat-sheet](#api-cheat-sheet)
+- [What the generated config looks like](#what-the-generated-config-looks-like)
+- [Further reading](#further-reading)
+
+---
+
+## Quick glossary
+
+| Term | Meaning |
+|---|---|
+| **CRS** | OWASP Core Rule Set — a large collection of ready-made WAF rules (SQL-injection detection, XSS detection, etc.). |
+| **Rule** | A single numbered check inside CRS, e.g. `942100` looks for SQL-injection patterns. |
+| **Target** | The specific *place* a rule inspects: a query argument, a request header, the request URI, etc. |
+| **Phase** | The moment in the HTTP life-cycle when a rule runs. Guard Proxy currently supports custom rules in Phase 1 = request headers and Phase 2 = request body. |
+| **Action** | What Coraza does when a rule matches, e.g. `deny`, `pass`, `log`, `skipAfter`. |
+| **SecRule** | The ModSecurity/Coraza directive that defines a rule. |
+
+---
+
+## Rule overrides
+
+### What it does
+A rule override is the simplest form of tuning: you **completely enable or completely disable** a CRS rule for a given policy.
+
+**When to use it**
+- A CRS rule is constantly blocking legitimate traffic on your application and you have no time to investigate a narrower fix → *disable* it.
+- You previously disabled a rule and now want it back → *enable* it.
+
+**When *not* to use it**
+- The rule only misbehaves on one endpoint or for one request argument. In that case use a **rule exclusion** (see below) so you do not lose protection everywhere else.
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `rule_id` | Yes | CRS rule number, e.g. `941100` (XSS), `942100` (SQLi). |
+| `action` | Yes | `enable` or `disable`. |
+| `comment` | No | A free-text note for your team, e.g. "Disabled because of false positives on the legacy search endpoint". |
+
+### Example
+
+Disable rule `942100` inside policy `3`:
+
+```json
+POST /policies/3/rules
+{
+  "rule_id": 942100,
+  "action": "disable",
+  "comment": "False positives on search form"
+}
+```
+
+---
+
+## Rule exclusions
+
+### What it does
+Instead of turning a whole rule off, you tell the WAF: *"Rule X should stop looking at this one specific thing"*. In ModSecurity/Coraza terminology this is called removing a **target** from a rule.
+
+**When to use it**
+- Rule `942100` (SQLi) fires on a harmless `token` parameter sent by your mobile app to `/api/login`.
+- Rule `941100` (XSS) fires on a rich-text field `description` in your admin panel.
+- A third-party webhook sends a header `X-Signature` that looks suspicious to CRS but is actually expected.
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `rule_id` | Yes | CRS rule number you want to narrow down, e.g. `942100`. |
+| `target_type` | Yes | What kind of target you are excluding. See the table below. |
+| `target_value` | Yes | The concrete name of the target, e.g. `"token"`, `"X-Signature"`. |
+| `scope_path` | No | A URL path prefix (e.g. `/api/login`) where the exclusion is valid. If omitted the exclusion is **global** — it applies to every request handled by the policy. |
+| `comment` | No | A note explaining why the exclusion exists. |
+
+### Target types
+
+| `target_type` value | What it means | Example `target_value` |
+|---|---|---|
+| `args` | A query-string or body parameter | `"token"`, `"search"` |
+| `args_names` | The *name* of a parameter (rarely needed) | `"old_name"` |
+| `request_headers` | A request header | `"X-Signature"`, `"User-Agent"` |
+| `request_uri` | The full request URI | Leave empty / same as target type (excludes the whole URI from inspection for that rule) |
+
+### Examples
+
+**Global exclusion** — stop rule `942100` from checking the `token` argument on *every* endpoint:
+
+```json
+POST /policies/3/exclusions
+{
+  "rule_id": 942100,
+  "target_type": "args",
+  "target_value": "token",
+  "comment": "Mobile app sends long opaque tokens"
+}
+```
+
+**Path-scoped exclusion** — same as above, but only for `/api/login`:
+
+```json
+POST /policies/3/exclusions
+{
+  "rule_id": 942100,
+  "target_type": "args",
+  "target_value": "token",
+  "scope_path": "/api/login",
+  "comment": "Login endpoint only"
+}
+```
+
+**Header exclusion** — stop rule `920274` from inspecting the `X-Custom-Header` header:
+
+```json
+POST /policies/3/exclusions
+{
+  "rule_id": 920274,
+  "target_type": "request_headers",
+  "target_value": "X-Custom-Header",
+  "comment": "Third-party integration header"
+}
+```
+
+---
+
+## From log to exclusion — a worked example
+
+The hardest part of tuning a WAF is knowing **whether** a blocked request deserves an exclusion. Below are two step-by-step examples that show how to read a log and make the right decision.
+
+---
+
+### Example 1 — a rich-text field triggers XSS detection (create an exclusion)
+
+Your team reports: *"When our editors save blog posts that contain HTML, the WAF blocks them with 403."*
+
+You look at the log and see:
+
+| Field | Value |
+|---|---|
+| Method | `POST` |
+| Request URI | `/admin/posts` |
+| Rule ID | `941100` |
+| Rule message | `XSS Attack Detected via libinjection` |
+
+**Step 1 — What does the rule do?**  
+Rule `941100` detects cross-site scripting (XSS) patterns. It inspects request arguments and the request body.
+
+**Step 2 — Is this a false positive?**  
+Yes. An admin panel that intentionally accepts HTML from trusted editors is expected to contain `<script>`-like strings. The rule is doing its job, but the *context* (a trusted admin saving a post) makes it a false positive.
+
+**Step 3 — What exactly should be excluded?**  
+The rule fired on the `content` argument inside the POST body. You do not want to disable the whole rule — you only want to stop it from checking the `content` field on the admin endpoint.
+
+**Step 4 — Build the exclusion**
+
+| Exclusion field | Value | Reason |
+|---|---|---|
+| `rule_id` | `941100` | The rule that fired. |
+| `target_type` | `args` | The rule inspected a request argument. |
+| `target_value` | `"content"` | The argument name that contained the HTML. |
+| `scope_path` | `/admin/posts` | Only the post-editing endpoint needs this. |
+| `comment` | `Editors intentionally save HTML in posts` | So the next admin knows why this exists. |
+
+**JSON to send:**
+
+```json
+POST /policies/3/exclusions
+{
+  "rule_id": 941100,
+  "target_type": "args",
+  "target_value": "content",
+  "scope_path": "/admin/posts",
+  "comment": "Editors intentionally save HTML in posts"
+}
+```
+
+Then run `POST /config/apply` to regenerate the configuration.
+
+---
+
+### Example 2 — a mobile login token triggers SQLi detection (create an exclusion)
+
+Your mobile app users cannot log in. The logs show:
+
+| Field | Value |
+|---|---|
+| Method | `POST` |
+| Request URI | `/api/login` |
+| Rule ID | `942100` |
+| Rule message | `SQL Injection Attack Detected via libinjection` |
+
+The `token` parameter contains a long opaque JWT string that happens to contain a character sequence the SQLi rule treats as suspicious.
+
+**Step 1 — What does the rule do?**  
+Rule `942100` detects SQL-injection patterns in request arguments.
+
+**Step 2 — Is this a false positive?**  
+Yes. The `token` field is generated by your own authentication service. It is not user-supplied SQL.
+
+**Step 3 — What exactly should be excluded?**  
+The `token` argument on the login endpoint only.
+
+**Step 4 — Build the exclusion**
+
+| Exclusion field | Value | Reason |
+|---|---|---|
+| `rule_id` | `942100` | The rule that fired. |
+| `target_type` | `args` | The rule inspected a request argument. |
+| `target_value` | `"token"` | The argument name that triggered the rule. |
+| `scope_path` | `/api/login` | Only the login endpoint needs this. |
+| `comment` | `Mobile app JWT token contains SQL-like sequences` | Explains the business context. |
+
+**JSON to send:**
+
+```json
+POST /policies/3/exclusions
+{
+  "rule_id": 942100,
+  "target_type": "args",
+  "target_value": "token",
+  "scope_path": "/api/login",
+  "comment": "Mobile app JWT token contains SQL-like sequences"
+}
+```
+
+---
+
+### Example 3 — a scanner probing sensitive files (do NOT create an exclusion)
+
+You see a block in your logs:
+
+| Field | Value |
+|---|---|
+| Method | `GET` |
+| Request URI | `/.env` |
+| Rule ID | `930130` |
+| Rule message | `Restricted File Access Attempt` |
+
+**Step 1 — What does the rule do?**  
+Rule `930130` is part of the CRS file-access group. It blocks requests for sensitive files such as `.env`, `.git`, `.htaccess`, and backup files.
+
+**Step 2 — Is this a false positive?**  
+Ask yourself: *"Should a legitimate user ever request `/.env`?"*  
+The answer is **no**. `.env` contains secrets (database passwords, API keys). A request for it is almost always a malicious scanner or bot.
+
+**Step 3 — Decision**  
+Do **nothing**. The WAF worked exactly as intended. Creating an exclusion here would open a security hole.
+
+> **Golden rule:** If the blocked request looks like an attack, do not tune the rule — let it block.
+
+---
+
+### Quick checklist for every log
+
+1. **Find the Rule ID** and read its message. What is the rule trying to protect against?
+2. **Look at the Request URI, Method, and any arguments/headers.** Is this a normal, legitimate use of your application?
+3. **If it is an attack** → do nothing. Let the rule block.
+4. **If it is a false positive** → identify the **smallest possible target** (one argument, one header) and create a **rule exclusion** scoped to the specific path.
+5. **Only as a last resort** — if the rule is completely incompatible with your application and you cannot narrow it down — use a **rule override** to disable the entire rule.
+
+---
+
+## Custom rules
+
+### What it does
+Custom rules let you **write your own security checks** that do not exist in CRS. They are standard Coraza `SecRule` directives created through the admin panel instead of being hand-edited into a `.conf` file.
+
+**When to use it**
+- Block requests from a specific bot user-agent that CRS does not catch.
+- Reject requests that do not carry a mandatory internal header.
+- Add geo-IP or time-based restrictions tailored to your organisation.
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `rule_id` | Yes | A number **you choose** between `9000000` and `9099999`. This range is reserved for administrator-authored rules so it never collides with CRS rule IDs. |
+| `phase` | Yes | When the rule runs. Allowed values: `request_headers`, `request_body`. Response and logging phases are not available because Guard Proxy's current SPOA integration inspects requests only. |
+| `variables` | Yes | What Coraza should inspect, e.g. `REQUEST_HEADERS:User-Agent`, `ARGS`, `ARGS\|REQUEST_BODY`. |
+| `operator` | Yes | How to compare the variable against your pattern. See the operator table below. |
+| `operator_argument` | Yes | The pattern or value for the operator, e.g. a regex or a literal string. |
+| `actions` | Yes | Comma-separated Coraza actions, e.g. `deny,status:403,log` or `pass,skipAfter:END`. |
+| `comment` | No | A human-readable note. |
+| `is_active` | No (default `true`) | Inactive rules are kept in the database but are **not** written into the generated config. |
+
+### Operators
+
+| `operator` value | Coraza token | Meaning | Typical `operator_argument` |
+|---|---|---|---|
+| `rx` | `@rx` | Regular expression match | `(?i)badbot` |
+| `streq` | `@streq` | Exact string match | `admin` |
+| `contains` | `@contains` | Substring match | `internal` |
+| `begins_with` | `@beginsWith` | Starts with | `/api/v1` |
+| `ends_with` | `@endsWith` | Ends with | `.pdf` |
+| `eq` | `@eq` | Numeric equal | `0` |
+| `ge` | `@ge` | Greater than or equal | `18` |
+| `gt` | `@gt` | Greater than | `100` |
+| `le` | `@le` | Less than or equal | `5` |
+| `lt` | `@lt` | Less than | `10` |
+| `pm` | `@pm` | Phrase match (space-separated list) | `select drop delete` |
+| `within` | `@within` | Value must be in a list | `GET POST HEAD` |
+| `ip_match` | `@ipMatch` | IP or CIDR match | `192.168.1.0/24 10.0.0.5` |
+
+### Phase mapping
+
+| `phase` value | Coraza phase number | When it runs |
+|---|---|---|
+| `request_headers` | 1 | After the request headers are received |
+| `request_body` | 2 | After the request body is received |
+
+Coraza itself also has response and logging phases, but Guard Proxy does not run
+them today. HAProxy sends request metadata and body data to Coraza through SPOE,
+and the Coraza SPOA application is configured with `response_check: false`.
+If you need response inspection later, the proxy/SPOA data flow must be extended
+first; adding a phase 3, 4, or 5 custom rule in the current stack would not
+execute as an operator expects.
+
+### Examples
+
+**Block every request whose User-Agent contains `curl`:**
+
+```json
+POST /policies/3/custom-rules
+{
+  "rule_id": 9000001,
+  "phase": "request_headers",
+  "variables": "REQUEST_HEADERS:User-Agent",
+  "operator": "rx",
+  "operator_argument": "(?i)curl",
+  "actions": "deny,status:403,log",
+  "comment": "No curl-based scraping"
+}
+```
+
+**Require an internal header `X-Internal-Auth` on admin paths:**
+
+```json
+POST /policies/3/custom-rules
+{
+  "rule_id": 9000002,
+  "phase": "request_headers",
+  "variables": "REQUEST_HEADERS:X-Internal-Auth",
+  "operator": "rx",
+  "operator_argument": "^$",
+  "actions": "deny,status:403,msg:'Missing internal auth header'",
+  "comment": "All admin requests must carry the internal auth header"
+}
+```
+
+**Allow only specific HTTP methods:**
+
+```json
+POST /policies/3/custom-rules
+{
+  "rule_id": 9000003,
+  "phase": "request_headers",
+  "variables": "REQUEST_METHOD",
+  "operator": "within",
+  "operator_argument": "GET POST HEAD OPTIONS",
+  "actions": "deny,status:405,log",
+  "comment": "Reject unexpected HTTP verbs"
+}
+```
+
+---
+
+## API cheat-sheet
+
+All endpoints below require an `Authorization: Bearer <token>` header. `POST`, `PATCH`, and `DELETE` are restricted to admin users.
+
+| Action | Endpoint | Method |
+|---|---|---|
+| **Rule overrides** | | |
+| Create | `/policies/{id}/rules` | `POST` |
+| List | `/policies/{id}/rules` | `GET` |
+| Get one | `/policies/{id}/rules/{rule_override_id}` | `GET` |
+| Update | `/policies/{id}/rules/{rule_override_id}` | `PATCH` |
+| Delete | `/policies/{id}/rules/{rule_override_id}` | `DELETE` |
+| **Rule exclusions** | | |
+| Create | `/policies/{id}/exclusions` | `POST` |
+| List | `/policies/{id}/exclusions` | `GET` |
+| Get one | `/policies/{id}/exclusions/{rule_exclusion_id}` | `GET` |
+| Update | `/policies/{id}/exclusions/{rule_exclusion_id}` | `PATCH` |
+| Delete | `/policies/{id}/exclusions/{rule_exclusion_id}` | `DELETE` |
+| **Custom rules** | | |
+| Create | `/policies/{id}/custom-rules` | `POST` |
+| List | `/policies/{id}/custom-rules` | `GET` |
+| Get one | `/policies/{id}/custom-rules/{custom_rule_id}` | `GET` |
+| Update | `/policies/{id}/custom-rules/{custom_rule_id}` | `PATCH` |
+| Delete | `/policies/{id}/custom-rules/{custom_rule_id}` | `DELETE` |
+| **Deploy config** | | |
+| Generate & apply | `/config/apply` | `POST` |
+
+After you create, update, or delete any tuning entry you must call `POST /config/apply` to regenerate the WAF configuration and reload HAProxy + Coraza.
+
+---
+
+## What the generated config looks like
+
+Guard Proxy renders three files when you hit `POST /config/apply`. The tuning entries end up in `rule_overrides.conf`.
+
+### Rule overrides
+
+If you disabled rule `942100`:
+
+```apache
+SecRuleRemoveById 942100
+```
+
+### Rule exclusions
+
+A **global** exclusion (no `scope_path`) is emitted as:
+
+```apache
+SecRuleRemoveTargetById 942100 ARGS:token
+```
+
+A **path-scoped** exclusion (e.g. `/api/login`) becomes a small control rule:
+
+```apache
+SecRule REQUEST_URI "@beginsWith /api/login" \
+  "id:9990001,phase:1,pass,nolog,\
+   ctl:ruleRemoveTargetById=942100;ARGS:token"
+```
+
+The control rule matches the request URI and then tells Coraza to remove the target for that single request only.
+
+### Custom rules
+
+A custom rule is emitted exactly as a `SecRule` directive:
+
+```apache
+SecRule REQUEST_HEADERS:User-Agent "@rx (?i)curl" \
+  "id:9000001,phase:1,deny,status:403,log"
+```
+
+Inactive rules (`is_active: false`) are skipped entirely — they do not appear in the generated file.
+
+---
+
+## Further reading
+
+- [OWASP CRS Documentation](https://coreruleset.org/docs/) — how the rule set works, paranoia levels, anomaly scoring, and rule numbering.
+- [Coraza Reference](https://coraza.io/docs/seclang/) — SecRule syntax, variables, operators, actions, and phases.
+- [ModSecurity Handbook](https://www.feistyduck.com/books/modsecurity-handbook/) (book) — deep dive into the engine that Coraza is compatible with.
+- Guard Proxy [README.architecture.md](README.architecture.md) — how the generated config reaches HAProxy and Coraza.

--- a/docs/dokumentacja_kursowa.md
+++ b/docs/dokumentacja_kursowa.md
@@ -11,7 +11,9 @@ Glownym celem projektu jest zarzadzanie konfiguracja WAF z poziomu panelu:
 
 - tworzenie i edycja wirtualnych hostow,
 - tworzenie i edycja polityk WAF,
-- przypisywanie polityk do domen (soon),
+- domain policy assignment, including path-scoped bindings,
+- policy tuning through CRS rule overrides, rule target exclusions, and custom
+  rules in the reserved ID range,
 - stosowanie wygenerowanej konfiguracji HAProxy/Coraza,
 - odbieranie i przegladanie logow zdarzen WAF,
 - zabezpieczenie panelu przez logowanie i role uzytkownikow.
@@ -96,6 +98,17 @@ Najwazniejsze endpointy:
 | POST | `/policies/{policy_id}/rules` | Dodanie override'u reguly CRS |
 | PATCH | `/policies/{policy_id}/rules/{id}` | Edycja override'u reguly CRS |
 | DELETE | `/policies/{policy_id}/rules/{id}` | Usuniecie override'u reguly CRS |
+| GET | `/policies/{policy_id}/exclusions` | List CRS rule target exclusions |
+| POST | `/policies/{policy_id}/exclusions` | Add an exclusion (rule_id + target + optional scope_path) |
+| PATCH | `/policies/{policy_id}/exclusions/{id}` | Edit an exclusion |
+| DELETE | `/policies/{policy_id}/exclusions/{id}` | Delete an exclusion |
+| GET | `/policies/{policy_id}/custom-rules` | List custom rules for a policy |
+| POST | `/policies/{policy_id}/custom-rules` | Add a custom rule (rule_id in the 9000000-9099999 range) |
+| PATCH | `/policies/{policy_id}/custom-rules/{id}` | Edit a custom rule |
+| DELETE | `/policies/{policy_id}/custom-rules/{id}` | Delete a custom rule |
+| GET | `/vhosts/{vhost_id}/policy-bindings` | List path-scoped policy bindings for a vhost |
+| POST | `/vhosts/{vhost_id}/policy-bindings` | Add a policy binding for a path prefix |
+| DELETE | `/vhosts/{vhost_id}/policy-bindings/{id}` | Delete a policy binding |
 | GET | `/logs` | Lista logow WAF z filtrami i paginacja |
 | POST | `/logs/ingest` | Przyjmowanie logow z log shippera |
 | POST | `/config/apply` | Wygenerowanie i zastosowanie konfiguracji runtime |
@@ -175,13 +188,21 @@ Najwazniejsze tabele:
 | `vhosts` | Domeny obslugiwane przez HAProxy i ich backendy |
 | `policies` | Polityki WAF: poziom paranoi, progi anomalii, tryb pracy |
 | `rule_overrides` | Wlaczenia/wylaczenia konkretnych reguł OWASP CRS dla polityki |
+| `rule_exclusions` | CRS rule target exclusions, such as ARGS:token, optionally scoped by path |
+| `custom_rules` | Administrator-authored custom rules in the reserved ID range 9000000-9099999 |
+| `policy_bindings` | Path-prefix scoped policy bindings for vhosts |
 | `logs` | Zdarzenia WAF/proxy odebrane przez log shippera |
 | `runtime_operations` | Historia operacji zastosowania konfiguracji runtime |
 
 Glowne relacje:
 
-- `vhosts.policy_id` wskazuje na `policies.id`.
-- `rule_overrides.policy_id` wskazuje na `policies.id`.
+- `vhosts.policy_id` points to `policies.id` as the vhost default policy.
+- `rule_overrides.policy_id`, `rule_exclusions.policy_id`, and
+  `custom_rules.policy_id` point to `policies.id`; deleting a policy cascades
+  to the related records.
+- `policy_bindings.vhost_id` and `policy_bindings.policy_id` point to
+  `vhosts.id` and `policies.id`; deleting a vhost or policy cascades to its
+  bindings.
 - `vhosts.created_by` i `policies.created_by` wskazuja na `users.id`.
 - `logs.vhost_id` i `logs.policy_id` moga wskazywac na powiazany vhost i polityke.
 
@@ -236,6 +257,43 @@ erDiagram
         datetime created_at
     }
 
+    rule_exclusions {
+        int id PK
+        int policy_id FK
+        int rule_id
+        TargetType target_type
+        string target_value
+        string scope_path
+        string comment
+        datetime created_at
+    }
+
+    custom_rules {
+        int id PK
+        int policy_id FK
+        int rule_id
+        RulePhase phase
+        string variables
+        RuleOperator operator
+        string operator_argument
+        string actions
+        string comment
+        boolean is_active
+        datetime created_at
+        datetime updated_at
+    }
+
+    policy_bindings {
+        int id PK
+        int vhost_id FK
+        int policy_id FK
+        string path_prefix
+        int priority
+        string comment
+        datetime created_at
+        datetime updated_at
+    }
+
     logs {
         int id PK
         string producer_event_id UK
@@ -271,6 +329,10 @@ erDiagram
     users ||--o{ policies : "created_by"
     policies ||--o{ vhosts : "policy_id"
     policies ||--o{ rule_overrides : "policy_id"
+    policies ||--o{ rule_exclusions : "policy_id"
+    policies ||--o{ custom_rules : "policy_id"
+    vhosts ||--o{ policy_bindings : "vhost_id"
+    policies ||--o{ policy_bindings : "policy_id"
     vhosts ||--o{ logs : "vhost_id"
     policies ||--o{ logs : "policy_id"
 ```
@@ -285,8 +347,9 @@ Projekt spelnia podstawowe wymagania CRUD na centralnej bazie danych:
 
 - `vhosts`: create, read, update, delete,
 - `policies`: create, read, update, delete,
-- `rule_overrides`: create, read, update, delete,
-- `logs`: ingest oraz read z filtrami.
+- `rule_overrides`, `rule_exclusions`, `custom_rules`: create, read, update, delete,
+- `policy_bindings`: create, read, delete,
+- `logs`: ingest and filtered read.
 
 Operacje modyfikujace sa dostepne tylko dla uzytkownikow z rola `admin`.
 Uzytkownik `viewer` moze odczytywac dane, ale nie moze ich zmieniac.

--- a/src/backend/app/schemas/custom_rule.py
+++ b/src/backend/app/schemas/custom_rule.py
@@ -28,6 +28,15 @@ def _validate_not_blank(value: str, field_label: str) -> str:
     return value
 
 
+def _validate_request_phase(value: RulePhase) -> RulePhase:
+    """Allow only phases that run in Guard Proxy's request-only SPOA flow."""
+    if value not in {RulePhase.REQUEST_HEADERS, RulePhase.REQUEST_BODY}:
+        raise ValueError(
+            "Custom rules only support request_headers and request_body phases"
+        )
+    return value
+
+
 class CustomRuleCreate(BaseModel):
     """Request body for POST /policies/{id}/custom-rules."""
 
@@ -45,6 +54,12 @@ class CustomRuleCreate(BaseModel):
     def rule_id_in_range(cls, value: int) -> int:
         """Require the rule ID to fall in the reserved custom rule range."""
         return _validate_rule_id_range(value)
+
+    @field_validator("phase")
+    @classmethod
+    def phase_must_be_request_phase(cls, value: RulePhase) -> RulePhase:
+        """Reject response/logging phases because Guard Proxy inspects requests only."""
+        return _validate_request_phase(value)
 
     @field_validator("variables")
     @classmethod
@@ -84,6 +99,14 @@ class CustomRuleUpdate(BaseModel):
         if value is None:
             return None
         return _validate_rule_id_range(value)
+
+    @field_validator("phase")
+    @classmethod
+    def phase_must_be_request_phase(cls, value: RulePhase | None) -> RulePhase | None:
+        """Reject response/logging phases because Guard Proxy inspects requests only."""
+        if value is None:
+            return None
+        return _validate_request_phase(value)
 
     @field_validator("variables")
     @classmethod

--- a/src/backend/tests/integration/test_custom_rules_router.py
+++ b/src/backend/tests/integration/test_custom_rules_router.py
@@ -116,6 +116,29 @@ def test_create_custom_rule_without_comment_returns_201(
     assert resp.json()["comment"] is None
 
 
+def test_create_custom_rule_response_phase_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Response phases are rejected because the SPOA integration inspects requests only."""
+    policy = _create_policy(client, admin_token, name="Response phase rejected")
+
+    resp = client.post(
+        f"/policies/{policy['id']}/custom-rules",
+        headers=admin_token,
+        json={
+            "rule_id": 9000001,
+            "phase": "response_body",
+            "variables": "RESPONSE_BODY",
+            "operator": "rx",
+            "operator_argument": "secret",
+            "actions": "deny,status:403",
+        },
+    )
+
+    assert resp.status_code == 422
+    assert "request_headers" in str(resp.json()["detail"])
+
+
 def test_create_custom_rule_viewer_forbidden(
     client: TestClient, admin_token: dict[str, str], viewer_token: dict[str, str]
 ) -> None:

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -351,6 +351,18 @@ def test_custom_rule_create_variables_must_not_be_blank() -> None:
         )
 
 
+def test_custom_rule_create_response_phase_invalid() -> None:
+    with pytest.raises(ValidationError, match="only support request_headers"):
+        CustomRuleCreate(
+            rule_id=9000001,
+            phase=RulePhase.RESPONSE_BODY,
+            variables="RESPONSE_BODY",
+            operator=RuleOperator.RX,
+            operator_argument="secret",
+            actions="deny",
+        )
+
+
 def test_custom_rule_update_valid() -> None:
     rule = CustomRuleUpdate(
         phase=RulePhase.REQUEST_BODY,
@@ -361,6 +373,11 @@ def test_custom_rule_update_valid() -> None:
     assert rule.phase == RulePhase.REQUEST_BODY
     assert rule.operator == RuleOperator.CONTAINS
     assert rule.is_active is False
+
+
+def test_custom_rule_update_logging_phase_invalid() -> None:
+    with pytest.raises(ValidationError, match="only support request_headers"):
+        CustomRuleUpdate(phase=RulePhase.LOGGING)
 
 
 def test_custom_rule_update_operator_argument_must_not_be_blank() -> None:

--- a/src/frontend/src/features/policies/CustomRuleModals.tsx
+++ b/src/frontend/src/features/policies/CustomRuleModals.tsx
@@ -32,9 +32,6 @@ export type CustomRuleModalState =
 const PHASE_OPTIONS: { value: CustomRulePhase; label: string }[] = [
   { value: "request_headers", label: "Request headers" },
   { value: "request_body", label: "Request body" },
-  { value: "response_headers", label: "Response headers" },
-  { value: "response_body", label: "Response body" },
-  { value: "logging", label: "Logging" },
 ];
 
 const OPERATOR_OPTIONS: { value: CustomRuleOperator; label: string }[] = [

--- a/src/frontend/src/features/policies/CustomRuleModals.tsx
+++ b/src/frontend/src/features/policies/CustomRuleModals.tsx
@@ -1,0 +1,362 @@
+import { type FormEvent, useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import {
+  createCustomRule,
+  updateCustomRule,
+  deleteCustomRule,
+} from "@/features/policies/api";
+import type {
+  CustomRule,
+  CustomRuleCreate,
+  CustomRuleOperator,
+  CustomRulePhase,
+  CustomRuleUpdate,
+} from "@/features/policies/types";
+import { CUSTOM_RULE_ID_MAX, CUSTOM_RULE_ID_MIN } from "@/features/policies/types";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+export type CustomRuleModalState =
+  | null
+  | { type: "create"; policyId: number }
+  | { type: "edit"; policyId: number; rule: CustomRule }
+  | { type: "delete"; policyId: number; rule: CustomRule };
+
+const PHASE_OPTIONS: { value: CustomRulePhase; label: string }[] = [
+  { value: "request_headers", label: "Request headers" },
+  { value: "request_body", label: "Request body" },
+  { value: "response_headers", label: "Response headers" },
+  { value: "response_body", label: "Response body" },
+  { value: "logging", label: "Logging" },
+];
+
+const OPERATOR_OPTIONS: { value: CustomRuleOperator; label: string }[] = [
+  { value: "rx", label: "rx (regex)" },
+  { value: "streq", label: "streq" },
+  { value: "contains", label: "contains" },
+  { value: "begins_with", label: "begins_with" },
+  { value: "ends_with", label: "ends_with" },
+  { value: "eq", label: "eq" },
+  { value: "ge", label: "ge" },
+  { value: "gt", label: "gt" },
+  { value: "le", label: "le" },
+  { value: "lt", label: "lt" },
+  { value: "pm", label: "pm" },
+  { value: "within", label: "within" },
+  { value: "ip_match", label: "ip_match" },
+];
+
+type CustomRuleFormModalProps = {
+  mode: "create" | "edit";
+  policyId: number;
+  rule?: CustomRule;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function CustomRuleFormModal({
+  mode,
+  policyId,
+  rule,
+  onSuccess,
+  onClose,
+}: CustomRuleFormModalProps) {
+  const { accessToken } = useAuth();
+  const [ruleId, setRuleId] = useState(String(rule?.rule_id ?? ""));
+  const [phase, setPhase] = useState<CustomRulePhase>(
+    rule?.phase ?? "request_headers",
+  );
+  const [variables, setVariables] = useState(rule?.variables ?? "");
+  const [operator, setOperator] = useState<CustomRuleOperator>(rule?.operator ?? "rx");
+  const [operatorArgument, setOperatorArgument] = useState(
+    rule?.operator_argument ?? "",
+  );
+  const [actions, setActions] = useState(rule?.actions ?? "");
+  const [comment, setComment] = useState(rule?.comment ?? "");
+  const [isActive, setIsActive] = useState(rule?.is_active ?? true);
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    const parsedRuleId = Number(ruleId);
+    if (
+      !Number.isInteger(parsedRuleId) ||
+      parsedRuleId < CUSTOM_RULE_ID_MIN ||
+      parsedRuleId > CUSTOM_RULE_ID_MAX
+    ) {
+      setServerError(
+        `Rule ID must be between ${CUSTOM_RULE_ID_MIN} and ${CUSTOM_RULE_ID_MAX}`,
+      );
+      return;
+    }
+
+    if (!variables.trim() || !operatorArgument.trim() || !actions.trim()) {
+      setServerError("Variables, operator argument, and actions must not be blank");
+      return;
+    }
+
+    setSubmitting(true);
+    setServerError(null);
+
+    const body: CustomRuleCreate | CustomRuleUpdate = {
+      rule_id: parsedRuleId,
+      phase,
+      variables,
+      operator,
+      operator_argument: operatorArgument,
+      actions,
+      comment: comment || null,
+      is_active: isActive,
+    };
+
+    try {
+      if (mode === "edit" && rule) {
+        await updateCustomRule(accessToken, policyId, rule.id, body);
+      } else {
+        await createCustomRule(accessToken, policyId, body as CustomRuleCreate);
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={mode === "create" ? "Add custom rule" : "Edit custom rule"}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="custom-rule-form"
+            disabled={submitting}
+          >
+            {submitting ? "Saving..." : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id="custom-rule-form"
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-4"
+      >
+        {serverError && (
+          <Alert
+            variant="destructive"
+            aria-live="assertive"
+          >
+            {serverError}
+          </Alert>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-rule-id" className="text-foreground">
+            Rule ID
+          </Label>
+          <Input
+            id="custom-rule-rule-id"
+            type="number"
+            required
+            value={ruleId}
+            onChange={(e) => setRuleId(e.target.value)}
+            placeholder={String(CUSTOM_RULE_ID_MIN + 1)}
+          />
+          <p className="text-xs text-fg-subtle">
+            Must be between {CUSTOM_RULE_ID_MIN} and {CUSTOM_RULE_ID_MAX} to avoid
+            colliding with OWASP CRS rule IDs.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-phase" className="text-foreground">
+            Phase
+          </Label>
+          <Select
+            id="custom-rule-phase"
+            value={phase}
+            onChange={(e) => setPhase(e.target.value as CustomRulePhase)}
+          >
+            {PHASE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-variables" className="text-foreground">
+            Variables
+          </Label>
+          <Input
+            id="custom-rule-variables"
+            type="text"
+            required
+            value={variables}
+            onChange={(e) => setVariables(e.target.value)}
+            placeholder="ARGS|REQUEST_HEADERS:User-Agent"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-operator" className="text-foreground">
+            Operator
+          </Label>
+          <Select
+            id="custom-rule-operator"
+            value={operator}
+            onChange={(e) => setOperator(e.target.value as CustomRuleOperator)}
+          >
+            {OPERATOR_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-operator-argument" className="text-foreground">
+            Operator argument
+          </Label>
+          <Input
+            id="custom-rule-operator-argument"
+            type="text"
+            required
+            value={operatorArgument}
+            onChange={(e) => setOperatorArgument(e.target.value)}
+            placeholder="(?i)curl"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-actions" className="text-foreground">
+            Actions
+          </Label>
+          <Input
+            id="custom-rule-actions"
+            type="text"
+            required
+            value={actions}
+            onChange={(e) => setActions(e.target.value)}
+            placeholder="deny,status:403,log"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="custom-rule-comment" className="text-foreground">
+            Comment
+          </Label>
+          <Input
+            id="custom-rule-comment"
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Optional"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="custom-rule-is-active"
+            checked={isActive}
+            onChange={(e) => setIsActive(e.target.checked)}
+          />
+          <Label htmlFor="custom-rule-is-active" className="text-foreground">
+            Active
+          </Label>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+type DeleteCustomRuleDialogProps = {
+  policyId: number;
+  rule: CustomRule;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function DeleteCustomRuleDialog({
+  policyId,
+  rule,
+  onSuccess,
+  onClose,
+}: DeleteCustomRuleDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    try {
+      await deleteCustomRule(accessToken, policyId, rule.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete custom rule"
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            variant="destructive"
+          >
+            {submitting ? "Deleting..." : "Delete"}
+          </Button>
+        </>
+      }
+    >
+      {serverError && (
+        <Alert
+          variant="destructive"
+          aria-live="assertive"
+        >
+          {serverError}
+        </Alert>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete custom rule{" "}
+        <span className="font-semibold text-fg">{rule.rule_id}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/policies/RuleExclusionModals.tsx
+++ b/src/frontend/src/features/policies/RuleExclusionModals.tsx
@@ -1,0 +1,282 @@
+import { type FormEvent, useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import {
+  createRuleExclusion,
+  updateRuleExclusion,
+  deleteRuleExclusion,
+} from "@/features/policies/api";
+import type {
+  RuleExclusion,
+  RuleExclusionCreate,
+  RuleExclusionTargetType,
+  RuleExclusionUpdate,
+} from "@/features/policies/types";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+export type RuleExclusionModalState =
+  | null
+  | { type: "create"; policyId: number }
+  | { type: "edit"; policyId: number; exclusion: RuleExclusion }
+  | { type: "delete"; policyId: number; exclusion: RuleExclusion };
+
+const TARGET_TYPE_OPTIONS: { value: RuleExclusionTargetType; label: string }[] = [
+  { value: "request_uri", label: "Request URI" },
+  { value: "args", label: "Args" },
+  { value: "args_names", label: "Args names" },
+  { value: "request_headers", label: "Request headers" },
+];
+
+type RuleExclusionFormModalProps = {
+  mode: "create" | "edit";
+  policyId: number;
+  exclusion?: RuleExclusion;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function RuleExclusionFormModal({
+  mode,
+  policyId,
+  exclusion,
+  onSuccess,
+  onClose,
+}: RuleExclusionFormModalProps) {
+  const { accessToken } = useAuth();
+  const [ruleId, setRuleId] = useState(String(exclusion?.rule_id ?? ""));
+  const [targetType, setTargetType] = useState<RuleExclusionTargetType>(
+    exclusion?.target_type ?? "args",
+  );
+  const [targetValue, setTargetValue] = useState(exclusion?.target_value ?? "");
+  const [scopePath, setScopePath] = useState(exclusion?.scope_path ?? "");
+  const [comment, setComment] = useState(exclusion?.comment ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    const parsedRuleId = Number(ruleId);
+    if (!Number.isInteger(parsedRuleId) || parsedRuleId <= 0) {
+      setServerError("Rule ID must be greater than 0");
+      return;
+    }
+
+    if (!targetValue.trim()) {
+      setServerError("Target value must not be blank");
+      return;
+    }
+
+    setSubmitting(true);
+    setServerError(null);
+
+    const body: RuleExclusionCreate | RuleExclusionUpdate = {
+      rule_id: parsedRuleId,
+      target_type: targetType,
+      target_value: targetValue,
+      scope_path: scopePath || null,
+      comment: comment || null,
+    };
+
+    try {
+      if (mode === "edit" && exclusion) {
+        await updateRuleExclusion(accessToken, policyId, exclusion.id, body);
+      } else {
+        await createRuleExclusion(accessToken, policyId, body as RuleExclusionCreate);
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={mode === "create" ? "Add rule exclusion" : "Edit rule exclusion"}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="rule-exclusion-form"
+            disabled={submitting}
+          >
+            {submitting ? "Saving..." : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id="rule-exclusion-form"
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-4"
+      >
+        {serverError && (
+          <Alert
+            variant="destructive"
+            aria-live="assertive"
+          >
+            {serverError}
+          </Alert>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-exclusion-rule-id" className="text-foreground">
+            Rule ID
+          </Label>
+          <Input
+            id="rule-exclusion-rule-id"
+            type="number"
+            required
+            min={1}
+            value={ruleId}
+            onChange={(e) => setRuleId(e.target.value)}
+            placeholder="942100"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-exclusion-target-type" className="text-foreground">
+            Target type
+          </Label>
+          <Select
+            id="rule-exclusion-target-type"
+            value={targetType}
+            onChange={(e) => setTargetType(e.target.value as RuleExclusionTargetType)}
+          >
+            {TARGET_TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-exclusion-target-value" className="text-foreground">
+            Target value
+          </Label>
+          <Input
+            id="rule-exclusion-target-value"
+            type="text"
+            required
+            value={targetValue}
+            onChange={(e) => setTargetValue(e.target.value)}
+            placeholder="token"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-exclusion-scope-path" className="text-foreground">
+            Scope path
+          </Label>
+          <Input
+            id="rule-exclusion-scope-path"
+            type="text"
+            value={scopePath}
+            onChange={(e) => setScopePath(e.target.value)}
+            placeholder="Optional, e.g. /api/login"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-exclusion-comment" className="text-foreground">
+            Comment
+          </Label>
+          <Input
+            id="rule-exclusion-comment"
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Optional"
+          />
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+type DeleteRuleExclusionDialogProps = {
+  policyId: number;
+  exclusion: RuleExclusion;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function DeleteRuleExclusionDialog({
+  policyId,
+  exclusion,
+  onSuccess,
+  onClose,
+}: DeleteRuleExclusionDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    try {
+      await deleteRuleExclusion(accessToken, policyId, exclusion.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete rule exclusion"
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            variant="destructive"
+          >
+            {submitting ? "Deleting..." : "Delete"}
+          </Button>
+        </>
+      }
+    >
+      {serverError && (
+        <Alert
+          variant="destructive"
+          aria-live="assertive"
+        >
+          {serverError}
+        </Alert>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete the exclusion for rule{" "}
+        <span className="font-semibold text-fg">{exclusion.rule_id}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/policies/RuleOverrideModals.tsx
+++ b/src/frontend/src/features/policies/RuleOverrideModals.tsx
@@ -1,0 +1,235 @@
+import { type FormEvent, useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import {
+  createRuleOverride,
+  updateRuleOverride,
+  deleteRuleOverride,
+} from "@/features/policies/api";
+import type {
+  RuleOverride,
+  RuleOverrideCreate,
+  RuleOverrideUpdate,
+} from "@/features/policies/types";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+export type RuleOverrideModalState =
+  | null
+  | { type: "create"; policyId: number }
+  | { type: "edit"; policyId: number; override: RuleOverride }
+  | { type: "delete"; policyId: number; override: RuleOverride };
+
+type RuleOverrideFormModalProps = {
+  mode: "create" | "edit";
+  policyId: number;
+  override?: RuleOverride;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function RuleOverrideFormModal({
+  mode,
+  policyId,
+  override,
+  onSuccess,
+  onClose,
+}: RuleOverrideFormModalProps) {
+  const { accessToken } = useAuth();
+  const [ruleId, setRuleId] = useState(String(override?.rule_id ?? ""));
+  const [action, setAction] = useState<"enable" | "disable">(
+    override?.action ?? "disable",
+  );
+  const [comment, setComment] = useState(override?.comment ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!accessToken) return;
+
+    const parsedRuleId = Number(ruleId);
+    if (!Number.isInteger(parsedRuleId) || parsedRuleId <= 0) {
+      setServerError("Rule ID must be greater than 0");
+      return;
+    }
+
+    setSubmitting(true);
+    setServerError(null);
+
+    const body: RuleOverrideCreate | RuleOverrideUpdate = {
+      rule_id: parsedRuleId,
+      action,
+      comment: comment || null,
+    };
+
+    try {
+      if (mode === "edit" && override) {
+        await updateRuleOverride(accessToken, policyId, override.id, body);
+      } else {
+        await createRuleOverride(accessToken, policyId, body as RuleOverrideCreate);
+      }
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={mode === "create" ? "Add rule override" : "Edit rule override"}
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="rule-override-form"
+            disabled={submitting}
+          >
+            {submitting ? "Saving..." : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id="rule-override-form"
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-4"
+      >
+        {serverError && (
+          <Alert
+            variant="destructive"
+            aria-live="assertive"
+          >
+            {serverError}
+          </Alert>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-override-rule-id" className="text-foreground">
+            Rule ID
+          </Label>
+          <Input
+            id="rule-override-rule-id"
+            type="number"
+            required
+            min={1}
+            value={ruleId}
+            onChange={(e) => setRuleId(e.target.value)}
+            placeholder="942100"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-override-action" className="text-foreground">
+            Action
+          </Label>
+          <Select
+            id="rule-override-action"
+            value={action}
+            onChange={(e) => setAction(e.target.value as "enable" | "disable")}
+          >
+            <option value="enable">Enable</option>
+            <option value="disable">Disable</option>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="rule-override-comment" className="text-foreground">
+            Comment
+          </Label>
+          <Input
+            id="rule-override-comment"
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Optional"
+          />
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+type DeleteRuleOverrideDialogProps = {
+  policyId: number;
+  override: RuleOverride;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function DeleteRuleOverrideDialog({
+  policyId,
+  override,
+  onSuccess,
+  onClose,
+}: DeleteRuleOverrideDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleDelete() {
+    if (!accessToken) return;
+
+    setSubmitting(true);
+    setServerError(null);
+
+    try {
+      await deleteRuleOverride(accessToken, policyId, override.id);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete rule override"
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleDelete()}
+            variant="destructive"
+          >
+            {submitting ? "Deleting..." : "Delete"}
+          </Button>
+        </>
+      }
+    >
+      {serverError && (
+        <Alert
+          variant="destructive"
+          aria-live="assertive"
+        >
+          {serverError}
+        </Alert>
+      )}
+      <p className="text-sm text-fg">
+        Are you sure you want to delete the override for rule{" "}
+        <span className="font-semibold text-fg">{override.rule_id}</span>?
+        This action cannot be undone.
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/policies/api.ts
+++ b/src/frontend/src/features/policies/api.ts
@@ -1,10 +1,16 @@
 import { apiRequest } from "@/lib/api-client";
 
 import type {
+  CustomRule,
+  CustomRuleCreate,
+  CustomRuleUpdate,
   Policy,
   PolicyCreate,
   PolicyDetail,
   PolicyUpdate,
+  RuleExclusion,
+  RuleExclusionCreate,
+  RuleExclusionUpdate,
   RuleOverride,
   RuleOverrideCreate,
   RuleOverrideUpdate,
@@ -83,4 +89,112 @@ export function deleteRuleOverride(
     token,
     responseType: "empty",
   });
+}
+
+export function listRuleExclusions(
+  token: string,
+  policyId: number,
+  signal?: AbortSignal,
+) {
+  return apiRequest<RuleExclusion[]>(`/policies/${policyId}/exclusions`, {
+    token,
+    signal,
+  });
+}
+
+export function createRuleExclusion(
+  token: string,
+  policyId: number,
+  body: RuleExclusionCreate,
+) {
+  return apiRequest<RuleExclusion>(`/policies/${policyId}/exclusions`, {
+    method: "POST",
+    token,
+    body,
+  });
+}
+
+export function updateRuleExclusion(
+  token: string,
+  policyId: number,
+  ruleExclusionId: number,
+  body: RuleExclusionUpdate,
+) {
+  return apiRequest<RuleExclusion>(
+    `/policies/${policyId}/exclusions/${ruleExclusionId}`,
+    {
+      method: "PATCH",
+      token,
+      body,
+    },
+  );
+}
+
+export function deleteRuleExclusion(
+  token: string,
+  policyId: number,
+  ruleExclusionId: number,
+) {
+  return apiRequest<void>(
+    `/policies/${policyId}/exclusions/${ruleExclusionId}`,
+    {
+      method: "DELETE",
+      token,
+      responseType: "empty",
+    },
+  );
+}
+
+export function listCustomRules(
+  token: string,
+  policyId: number,
+  signal?: AbortSignal,
+) {
+  return apiRequest<CustomRule[]>(`/policies/${policyId}/custom-rules`, {
+    token,
+    signal,
+  });
+}
+
+export function createCustomRule(
+  token: string,
+  policyId: number,
+  body: CustomRuleCreate,
+) {
+  return apiRequest<CustomRule>(`/policies/${policyId}/custom-rules`, {
+    method: "POST",
+    token,
+    body,
+  });
+}
+
+export function updateCustomRule(
+  token: string,
+  policyId: number,
+  customRuleId: number,
+  body: CustomRuleUpdate,
+) {
+  return apiRequest<CustomRule>(
+    `/policies/${policyId}/custom-rules/${customRuleId}`,
+    {
+      method: "PATCH",
+      token,
+      body,
+    },
+  );
+}
+
+export function deleteCustomRule(
+  token: string,
+  policyId: number,
+  customRuleId: number,
+) {
+  return apiRequest<void>(
+    `/policies/${policyId}/custom-rules/${customRuleId}`,
+    {
+      method: "DELETE",
+      token,
+      responseType: "empty",
+    },
+  );
 }

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -33,8 +33,105 @@ export type RuleOverrideUpdate = {
   comment?: string | null;
 };
 
+export type RuleExclusionTargetType =
+  | "request_uri"
+  | "args"
+  | "args_names"
+  | "request_headers";
+
+export type RuleExclusion = {
+  id: number;
+  policy_id: number;
+  rule_id: number;
+  target_type: RuleExclusionTargetType;
+  target_value: string;
+  scope_path: string | null;
+  comment: string | null;
+  created_at: string;
+};
+
+export type RuleExclusionCreate = {
+  rule_id: number;
+  target_type: RuleExclusionTargetType;
+  target_value: string;
+  scope_path?: string | null;
+  comment?: string | null;
+};
+
+export type RuleExclusionUpdate = {
+  rule_id?: number;
+  target_type?: RuleExclusionTargetType;
+  target_value?: string;
+  scope_path?: string | null;
+  comment?: string | null;
+};
+
+export type CustomRulePhase =
+  | "request_headers"
+  | "request_body"
+  | "response_headers"
+  | "response_body"
+  | "logging";
+
+export type CustomRuleOperator =
+  | "rx"
+  | "streq"
+  | "contains"
+  | "begins_with"
+  | "ends_with"
+  | "eq"
+  | "ge"
+  | "gt"
+  | "le"
+  | "lt"
+  | "pm"
+  | "within"
+  | "ip_match";
+
+export const CUSTOM_RULE_ID_MIN = 9000000;
+export const CUSTOM_RULE_ID_MAX = 9099999;
+
+export type CustomRule = {
+  id: number;
+  policy_id: number;
+  rule_id: number;
+  phase: CustomRulePhase;
+  variables: string;
+  operator: CustomRuleOperator;
+  operator_argument: string;
+  actions: string;
+  comment: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CustomRuleCreate = {
+  rule_id: number;
+  phase: CustomRulePhase;
+  variables: string;
+  operator: CustomRuleOperator;
+  operator_argument: string;
+  actions: string;
+  comment?: string | null;
+  is_active?: boolean;
+};
+
+export type CustomRuleUpdate = {
+  rule_id?: number;
+  phase?: CustomRulePhase;
+  variables?: string;
+  operator?: CustomRuleOperator;
+  operator_argument?: string;
+  actions?: string;
+  comment?: string | null;
+  is_active?: boolean;
+};
+
 export type PolicyDetail = Policy & {
   rule_overrides: RuleOverride[];
+  rule_exclusions: RuleExclusion[];
+  custom_rules: CustomRule[];
 };
 
 export type PolicyCreate = {

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -68,10 +68,7 @@ export type RuleExclusionUpdate = {
 
 export type CustomRulePhase =
   | "request_headers"
-  | "request_body"
-  | "response_headers"
-  | "response_body"
-  | "logging";
+  | "request_body";
 
 export type CustomRuleOperator =
   | "rx"

--- a/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
@@ -1,0 +1,392 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as policiesApi from "@/features/policies/api";
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import type {
+  CustomRule,
+  PolicyDetail,
+  RuleExclusion,
+  RuleOverride,
+} from "@/features/policies/types";
+
+import { PolicyDetailPage } from "./PolicyDetailPage";
+
+vi.mock("@/features/policies/api");
+
+function makeAuthContext(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockOverride: RuleOverride = {
+  id: 10,
+  policy_id: 1,
+  rule_id: 942100,
+  action: "disable",
+  comment: "False positive on search",
+  created_at: "2026-01-03T00:00:00Z",
+};
+
+const mockExclusion: RuleExclusion = {
+  id: 20,
+  policy_id: 1,
+  rule_id: 941100,
+  target_type: "args",
+  target_value: "token",
+  scope_path: "/api/login",
+  comment: "Login token false positive",
+  created_at: "2026-01-04T00:00:00Z",
+};
+
+const mockCustomRule: CustomRule = {
+  id: 30,
+  policy_id: 1,
+  rule_id: 9000001,
+  phase: "request_headers",
+  variables: "REQUEST_HEADERS:User-Agent",
+  operator: "rx",
+  operator_argument: "(?i)curl",
+  actions: "deny,status:403,log",
+  comment: "Block curl",
+  is_active: true,
+  created_at: "2026-01-05T00:00:00Z",
+  updated_at: "2026-01-05T00:00:00Z",
+};
+
+const mockPolicy: PolicyDetail = {
+  id: 1,
+  name: "Default WAF",
+  description: "Default policy",
+  paranoia_level: 2,
+  inbound_anomaly_threshold: 5,
+  outbound_anomaly_threshold: 4,
+  enforcement_mode: "block",
+  is_active: true,
+  created_by: 1,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  rule_overrides: [mockOverride],
+  rule_exclusions: [mockExclusion],
+  custom_rules: [mockCustomRule],
+};
+
+function mockSuccessfulLoad(policy: PolicyDetail = mockPolicy) {
+  vi.mocked(policiesApi.getPolicy).mockResolvedValue(policy);
+}
+
+function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext(authOverrides)}>
+      <MemoryRouter initialEntries={["/policies/1"]}>
+        <Routes>
+          <Route path="/policies/:policyId" element={<PolicyDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+}
+
+describe("PolicyDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(policiesApi.createRuleOverride).mockResolvedValue(mockOverride);
+    vi.mocked(policiesApi.updateRuleOverride).mockResolvedValue(mockOverride);
+    vi.mocked(policiesApi.deleteRuleOverride).mockResolvedValue(undefined);
+    vi.mocked(policiesApi.createRuleExclusion).mockResolvedValue(mockExclusion);
+    vi.mocked(policiesApi.updateRuleExclusion).mockResolvedValue(mockExclusion);
+    vi.mocked(policiesApi.deleteRuleExclusion).mockResolvedValue(undefined);
+    vi.mocked(policiesApi.createCustomRule).mockResolvedValue(mockCustomRule);
+    vi.mocked(policiesApi.updateCustomRule).mockResolvedValue(mockCustomRule);
+    vi.mocked(policiesApi.deleteCustomRule).mockResolvedValue(undefined);
+  });
+
+  it("shows loading state initially", () => {
+    vi.mocked(policiesApi.getPolicy).mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+
+    expect(screen.getByText(/loading policy/i)).toBeInTheDocument();
+  });
+
+  it("renders policy settings, overrides, exclusions, and custom rules", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Default WAF" })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("942100")).toBeInTheDocument();
+    expect(screen.getByText("False positive on search")).toBeInTheDocument();
+    expect(screen.getByText("token")).toBeInTheDocument();
+    expect(screen.getByText("/api/login")).toBeInTheDocument();
+    expect(screen.getByText("9000001")).toBeInTheDocument();
+    expect(screen.getByText("REQUEST_HEADERS:User-Agent")).toBeInTheDocument();
+  });
+
+  it("shows error state and retries loading", async () => {
+    vi.mocked(policiesApi.getPolicy)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValue(mockPolicy);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load policy/i)).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Default WAF" })).toBeInTheDocument(),
+    );
+  });
+
+  it("lets admins add, edit, and delete rule overrides", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /add override/i }));
+    await userEvent.clear(screen.getByLabelText("Rule ID"));
+    await userEvent.type(screen.getByLabelText("Rule ID"), "941100");
+    await userEvent.selectOptions(screen.getByLabelText("Action"), "enable");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.createRuleOverride).toHaveBeenCalledWith("test-token", 1, {
+        rule_id: 941100,
+        action: "enable",
+        comment: null,
+      }),
+    );
+
+    const overrideRow = (await screen.findByText("942100")).closest("tr");
+    if (!overrideRow) throw new Error("override row not found");
+
+    await userEvent.click(within(overrideRow).getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByLabelText("Action"), "enable");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.updateRuleOverride).toHaveBeenCalledWith("test-token", 1, 10, {
+        rule_id: 942100,
+        action: "enable",
+        comment: "False positive on search",
+      }),
+    );
+
+    const refreshedOverrideRow = (await screen.findByText("942100")).closest("tr");
+    if (!refreshedOverrideRow) throw new Error("override row not found");
+
+    await userEvent.click(
+      within(refreshedOverrideRow).getByRole("button", { name: "Delete" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(policiesApi.deleteRuleOverride).toHaveBeenCalledWith("test-token", 1, 10),
+    );
+  });
+
+  it("lets admins add a rule exclusion", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /add exclusion/i }));
+    await userEvent.type(screen.getByLabelText("Rule ID"), "941200");
+    await userEvent.type(screen.getByLabelText("Target value"), "csrf_token");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.createRuleExclusion).toHaveBeenCalledWith("test-token", 1, {
+        rule_id: 941200,
+        target_type: "args",
+        target_value: "csrf_token",
+        scope_path: null,
+        comment: null,
+      }),
+    );
+  });
+
+  it("lets admins edit and delete rule exclusions", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    const exclusionRow = (await screen.findByText("token")).closest("tr");
+    if (!exclusionRow) throw new Error("exclusion row not found");
+
+    await userEvent.click(within(exclusionRow).getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByLabelText("Target type"), "request_headers");
+    await userEvent.clear(screen.getByLabelText("Target value"));
+    await userEvent.type(screen.getByLabelText("Target value"), "X-CSRF-Token");
+    await userEvent.clear(screen.getByLabelText("Scope path"));
+    await userEvent.type(screen.getByLabelText("Scope path"), "/api/session");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.updateRuleExclusion).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        20,
+        {
+          rule_id: 941100,
+          target_type: "request_headers",
+          target_value: "X-CSRF-Token",
+          scope_path: "/api/session",
+          comment: "Login token false positive",
+        },
+      ),
+    );
+
+    const refreshedExclusionRow = (await screen.findByText("token")).closest("tr");
+    if (!refreshedExclusionRow) throw new Error("exclusion row not found");
+
+    await userEvent.click(
+      within(refreshedExclusionRow).getByRole("button", { name: "Delete" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(policiesApi.deleteRuleExclusion).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        20,
+      ),
+    );
+  });
+
+  it("rejects an out-of-range custom rule ID before calling the API", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /add custom rule/i }));
+    await userEvent.type(screen.getByLabelText("Rule ID"), "123");
+    await userEvent.type(screen.getByLabelText("Variables"), "ARGS");
+    await userEvent.type(screen.getByLabelText("Operator argument"), "(?i)bad");
+    await userEvent.type(screen.getByLabelText("Actions"), "deny");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(/rule id must be between 9000000 and 9099999/i),
+    ).toBeInTheDocument();
+    expect(policiesApi.createCustomRule).not.toHaveBeenCalled();
+  });
+
+  it("lets admins add a custom rule", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /add custom rule/i }));
+    await userEvent.type(screen.getByLabelText("Rule ID"), "9000002");
+    await userEvent.type(screen.getByLabelText("Variables"), "ARGS");
+    await userEvent.type(screen.getByLabelText("Operator argument"), "(?i)bad");
+    await userEvent.type(screen.getByLabelText("Actions"), "deny,status:403");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.createCustomRule).toHaveBeenCalledWith("test-token", 1, {
+        rule_id: 9000002,
+        phase: "request_headers",
+        variables: "ARGS",
+        operator: "rx",
+        operator_argument: "(?i)bad",
+        actions: "deny,status:403",
+        comment: null,
+        is_active: true,
+      }),
+    );
+  });
+
+  it("lets admins edit and delete custom rules", async () => {
+    mockSuccessfulLoad();
+
+    renderPage();
+
+    const customRuleRow = (
+      await screen.findByText("REQUEST_HEADERS:User-Agent")
+    ).closest("tr");
+    if (!customRuleRow) throw new Error("custom rule row not found");
+
+    await userEvent.click(within(customRuleRow).getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByLabelText("Phase"), "request_body");
+    await userEvent.clear(screen.getByLabelText("Variables"));
+    await userEvent.type(screen.getByLabelText("Variables"), "ARGS");
+    await userEvent.clear(screen.getByLabelText("Actions"));
+    await userEvent.type(screen.getByLabelText("Actions"), "deny,status:403");
+    await userEvent.click(screen.getByRole("checkbox", { name: "Active" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(policiesApi.updateCustomRule).toHaveBeenCalledWith(
+        "test-token",
+        1,
+        30,
+        {
+          rule_id: 9000001,
+          phase: "request_body",
+          variables: "ARGS",
+          operator: "rx",
+          operator_argument: "(?i)curl",
+          actions: "deny,status:403",
+          comment: "Block curl",
+          is_active: false,
+        },
+      ),
+    );
+
+    const refreshedCustomRuleRow = (
+      await screen.findByText("REQUEST_HEADERS:User-Agent")
+    ).closest("tr");
+    if (!refreshedCustomRuleRow) throw new Error("custom rule row not found");
+
+    await userEvent.click(
+      within(refreshedCustomRuleRow).getByRole("button", { name: "Delete" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(policiesApi.deleteCustomRule).toHaveBeenCalledWith("test-token", 1, 30),
+    );
+  });
+
+  it("keeps viewer role read-only across all tuning sections", async () => {
+    mockSuccessfulLoad();
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(false), role: "viewer" });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Default WAF" })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /add override/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add exclusion/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add custom rule/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -10,16 +10,40 @@ import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { Button } from "@/components/ui/button";
 import { getPolicy } from "@/features/policies/api";
-import type { PolicyDetail, RuleOverride } from "@/features/policies/types";
+import {
+  CustomRuleFormModal,
+  DeleteCustomRuleDialog,
+  type CustomRuleModalState,
+} from "@/features/policies/CustomRuleModals";
+import {
+  DeleteRuleExclusionDialog,
+  RuleExclusionFormModal,
+  type RuleExclusionModalState,
+} from "@/features/policies/RuleExclusionModals";
+import {
+  DeleteRuleOverrideDialog,
+  RuleOverrideFormModal,
+  type RuleOverrideModalState,
+} from "@/features/policies/RuleOverrideModals";
+import type {
+  CustomRule,
+  PolicyDetail,
+  RuleExclusion,
+  RuleOverride,
+} from "@/features/policies/types";
 import { useAuth } from "@/hooks/use-auth";
 
 export function PolicyDetailPage() {
   const { policyId } = useParams();
-  const { accessToken } = useAuth();
+  const { accessToken, hasRole } = useAuth();
   const [policy, setPolicy] = useState<PolicyDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [overrideModal, setOverrideModal] = useState<RuleOverrideModalState>(null);
+  const [exclusionModal, setExclusionModal] = useState<RuleExclusionModalState>(null);
+  const [customRuleModal, setCustomRuleModal] = useState<CustomRuleModalState>(null);
   const refreshCountRef = useRef(0);
+  const isAdmin = hasRole("admin");
 
   const load = useCallback(() => {
     if (!accessToken || !policyId) return;
@@ -51,6 +75,21 @@ export function PolicyDetailPage() {
     return cleanup;
   }, [load]);
 
+  function closeOverrideModalAndRefresh() {
+    setOverrideModal(null);
+    load();
+  }
+
+  function closeExclusionModalAndRefresh() {
+    setExclusionModal(null);
+    load();
+  }
+
+  function closeCustomRuleModalAndRefresh() {
+    setCustomRuleModal(null);
+    load();
+  }
+
   const overrideColumns: DataTableColumn<RuleOverride>[] = [
     { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
     {
@@ -73,6 +112,166 @@ export function PolicyDetailPage() {
           <span className="text-muted-foreground">—</span>
         ),
     },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: RuleOverride) => (
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setOverrideModal({
+                      type: "edit",
+                      policyId: policy!.id,
+                      override: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setOverrideModal({
+                      type: "delete",
+                      policyId: policy!.id,
+                      override: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft"
+                >
+                  Delete
+                </button>
+              </div>
+            ),
+          } satisfies DataTableColumn<RuleOverride>,
+        ]
+      : []),
+  ];
+
+  const exclusionColumns: DataTableColumn<RuleExclusion>[] = [
+    { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
+    { key: "target_type", header: "Target type", cell: (row) => row.target_type },
+    { key: "target_value", header: "Target value", cell: (row) => row.target_value },
+    {
+      key: "scope_path",
+      header: "Scope path",
+      cell: (row) =>
+        row.scope_path ? (
+          <span>{row.scope_path}</span>
+        ) : (
+          <span className="text-muted-foreground">All paths</span>
+        ),
+    },
+    {
+      key: "comment",
+      header: "Comment",
+      cell: (row) =>
+        row.comment ? (
+          <span>{row.comment}</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: RuleExclusion) => (
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setExclusionModal({
+                      type: "edit",
+                      policyId: policy!.id,
+                      exclusion: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setExclusionModal({
+                      type: "delete",
+                      policyId: policy!.id,
+                      exclusion: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft"
+                >
+                  Delete
+                </button>
+              </div>
+            ),
+          } satisfies DataTableColumn<RuleExclusion>,
+        ]
+      : []),
+  ];
+
+  const customRuleColumns: DataTableColumn<CustomRule>[] = [
+    { key: "rule_id", header: "Rule ID", cell: (row) => String(row.rule_id) },
+    { key: "phase", header: "Phase", cell: (row) => row.phase },
+    { key: "variables", header: "Variables", cell: (row) => row.variables },
+    { key: "operator", header: "Operator", cell: (row) => row.operator },
+    {
+      key: "is_active",
+      header: "Status",
+      cell: (row) => (
+        <StatusBadge
+          label={row.is_active ? "Active" : "Inactive"}
+          tone={row.is_active ? "success" : "warning"}
+        />
+      ),
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: CustomRule) => (
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCustomRuleModal({
+                      type: "edit",
+                      policyId: policy!.id,
+                      rule: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-border bg-surface-hover px-3 py-1.5 text-xs font-semibold text-fg-muted transition hover:text-fg"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCustomRuleModal({
+                      type: "delete",
+                      policyId: policy!.id,
+                      rule: row,
+                    })
+                  }
+                  className="rounded-[var(--radius-sm)] border border-error/50 px-3 py-1.5 text-xs font-semibold text-error transition hover:border-error hover:bg-error-soft"
+                >
+                  Delete
+                </button>
+              </div>
+            ),
+          } satisfies DataTableColumn<CustomRule>,
+        ]
+      : []),
   ];
 
   return (
@@ -139,6 +338,17 @@ export function PolicyDetailPage() {
             title="Rule overrides"
             description="Individual CRS rules enabled or disabled for this policy."
             descriptionDisplay="tooltip"
+            actions={
+              isAdmin ? (
+                <button
+                  type="button"
+                  onClick={() => setOverrideModal({ type: "create", policyId: policy.id })}
+                  className="btn-primary px-4 py-2 text-sm"
+                >
+                  Add override
+                </button>
+              ) : undefined
+            }
           >
             <DataTable
               columns={overrideColumns}
@@ -148,6 +358,134 @@ export function PolicyDetailPage() {
               emptyDescription="All CRS rules follow the default paranoia level settings."
             />
           </SectionCard>
+
+          <SectionCard
+            title="Rule exclusions"
+            description="Targets narrowed out of CRS rule inspection for this policy."
+            descriptionDisplay="tooltip"
+            actions={
+              isAdmin ? (
+                <button
+                  type="button"
+                  onClick={() => setExclusionModal({ type: "create", policyId: policy.id })}
+                  className="btn-primary px-4 py-2 text-sm"
+                >
+                  Add exclusion
+                </button>
+              ) : undefined
+            }
+          >
+            <DataTable
+              columns={exclusionColumns}
+              rows={policy.rule_exclusions}
+              getRowKey={(row) => String(row.id)}
+              emptyTitle="No rule exclusions"
+              emptyDescription="No CRS rule targets are currently excluded for this policy."
+            />
+          </SectionCard>
+
+          <SectionCard
+            title="Custom rules"
+            description="Administrator-authored rules in the reserved 9000000–9099999 range."
+            descriptionDisplay="tooltip"
+            actions={
+              isAdmin ? (
+                <button
+                  type="button"
+                  onClick={() => setCustomRuleModal({ type: "create", policyId: policy.id })}
+                  className="btn-primary px-4 py-2 text-sm"
+                >
+                  Add custom rule
+                </button>
+              ) : undefined
+            }
+          >
+            <DataTable
+              columns={customRuleColumns}
+              rows={policy.custom_rules}
+              getRowKey={(row) => String(row.id)}
+              emptyTitle="No custom rules"
+              emptyDescription="No custom rules have been defined for this policy."
+            />
+          </SectionCard>
+
+          {overrideModal?.type === "create" && (
+            <RuleOverrideFormModal
+              mode="create"
+              policyId={overrideModal.policyId}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+          {overrideModal?.type === "edit" && (
+            <RuleOverrideFormModal
+              mode="edit"
+              policyId={overrideModal.policyId}
+              override={overrideModal.override}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+          {overrideModal?.type === "delete" && (
+            <DeleteRuleOverrideDialog
+              policyId={overrideModal.policyId}
+              override={overrideModal.override}
+              onSuccess={closeOverrideModalAndRefresh}
+              onClose={() => setOverrideModal(null)}
+            />
+          )}
+
+          {exclusionModal?.type === "create" && (
+            <RuleExclusionFormModal
+              mode="create"
+              policyId={exclusionModal.policyId}
+              onSuccess={closeExclusionModalAndRefresh}
+              onClose={() => setExclusionModal(null)}
+            />
+          )}
+          {exclusionModal?.type === "edit" && (
+            <RuleExclusionFormModal
+              mode="edit"
+              policyId={exclusionModal.policyId}
+              exclusion={exclusionModal.exclusion}
+              onSuccess={closeExclusionModalAndRefresh}
+              onClose={() => setExclusionModal(null)}
+            />
+          )}
+          {exclusionModal?.type === "delete" && (
+            <DeleteRuleExclusionDialog
+              policyId={exclusionModal.policyId}
+              exclusion={exclusionModal.exclusion}
+              onSuccess={closeExclusionModalAndRefresh}
+              onClose={() => setExclusionModal(null)}
+            />
+          )}
+
+          {customRuleModal?.type === "create" && (
+            <CustomRuleFormModal
+              mode="create"
+              policyId={customRuleModal.policyId}
+              onSuccess={closeCustomRuleModalAndRefresh}
+              onClose={() => setCustomRuleModal(null)}
+            />
+          )}
+          {customRuleModal?.type === "edit" && (
+            <CustomRuleFormModal
+              mode="edit"
+              policyId={customRuleModal.policyId}
+              rule={customRuleModal.rule}
+              onSuccess={closeCustomRuleModalAndRefresh}
+              onClose={() => setCustomRuleModal(null)}
+            />
+          )}
+          {customRuleModal?.type === "delete" && (
+            <DeleteCustomRuleDialog
+              policyId={customRuleModal.policyId}
+              rule={customRuleModal.rule}
+              onSuccess={closeCustomRuleModalAndRefresh}
+              onClose={() => setCustomRuleModal(null)}
+            />
+          )}
         </>
       ) : null}
     </section>

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -1,256 +1,30 @@
-import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import type { DataTableColumn } from "@/components/shared/DataTable";
 import { DataTable } from "@/components/shared/DataTable";
 import { ErrorState } from "@/components/shared/ErrorState";
 import { LoadingState } from "@/components/shared/LoadingState";
-import { Modal } from "@/components/shared/Modal";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
+import { listRuleOverrides } from "@/features/policies/api";
 import {
-  createRuleOverride,
-  deleteRuleOverride,
-  listRuleOverrides,
-  updateRuleOverride,
-} from "@/features/policies/api";
-import type {
-  RuleOverride,
-  RuleOverrideCreate,
-  RuleOverrideUpdate,
-} from "@/features/policies/types";
+  DeleteRuleOverrideDialog,
+  RuleOverrideFormModal,
+  type RuleOverrideModalState,
+} from "@/features/policies/RuleOverrideModals";
+import type { RuleOverride } from "@/features/policies/types";
 import { getVHost, listPolicies, updateVHost } from "@/features/vhosts/api";
 import type { Policy, VHostDetail } from "@/features/vhosts/types";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
-
-type OverrideModalState =
-  | null
-  | { type: "create"; policyId: number }
-  | { type: "edit"; policyId: number; override: RuleOverride }
-  | { type: "delete"; policyId: number; override: RuleOverride };
-
-type RuleOverrideFormModalProps = {
-  mode: "create" | "edit";
-  policyId: number;
-  override?: RuleOverride;
-  onSuccess: () => void;
-  onClose: () => void;
-};
 
 function formatDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
-}
-
-function RuleOverrideFormModal({
-  mode,
-  policyId,
-  override,
-  onSuccess,
-  onClose,
-}: RuleOverrideFormModalProps) {
-  const { accessToken } = useAuth();
-  const [ruleId, setRuleId] = useState(String(override?.rule_id ?? ""));
-  const [action, setAction] = useState<"enable" | "disable">(
-    override?.action ?? "disable",
-  );
-  const [comment, setComment] = useState(override?.comment ?? "");
-  const [submitting, setSubmitting] = useState(false);
-  const [serverError, setServerError] = useState<string | null>(null);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!accessToken) return;
-
-    const parsedRuleId = Number(ruleId);
-    if (!Number.isInteger(parsedRuleId) || parsedRuleId <= 0) {
-      setServerError("Rule ID must be greater than 0");
-      return;
-    }
-
-    setSubmitting(true);
-    setServerError(null);
-
-    const body: RuleOverrideCreate | RuleOverrideUpdate = {
-      rule_id: parsedRuleId,
-      action,
-      comment: comment || null,
-    };
-
-    try {
-      if (mode === "edit" && override) {
-        await updateRuleOverride(accessToken, policyId, override.id, body);
-      } else {
-        await createRuleOverride(accessToken, policyId, body as RuleOverrideCreate);
-      }
-      onSuccess();
-    } catch (err) {
-      setServerError(
-        err instanceof ApiError ? err.detail : "An unexpected error occurred",
-      );
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <Modal
-      title={mode === "create" ? "Add rule override" : "Edit rule override"}
-      onClose={onClose}
-      footer={
-        <>
-          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
-            Cancel
-          </button>
-          <button
-            type="submit"
-            form="rule-override-form"
-            disabled={submitting}
-            className="btn-primary px-4 py-2 text-sm"
-          >
-            {submitting ? "Saving..." : "Save"}
-          </button>
-        </>
-      }
-    >
-      <form
-        id="rule-override-form"
-        onSubmit={(e) => void handleSubmit(e)}
-        className="space-y-4"
-      >
-        {serverError && (
-          <div
-            role="alert"
-            aria-live="assertive"
-            className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
-          >
-            {serverError}
-          </div>
-        )}
-
-        <div className="space-y-1.5">
-          <label htmlFor="rule-override-rule-id" className="block text-sm font-medium text-fg-muted">
-            Rule ID
-          </label>
-          <input
-            id="rule-override-rule-id"
-            type="number"
-            required
-            min={1}
-            value={ruleId}
-            onChange={(e) => setRuleId(e.target.value)}
-            className="input-field"
-            placeholder="942100"
-          />
-        </div>
-
-        <div className="space-y-1.5">
-          <label htmlFor="rule-override-action" className="block text-sm font-medium text-fg-muted">
-            Action
-          </label>
-          <select
-            id="rule-override-action"
-            value={action}
-            onChange={(e) => setAction(e.target.value as "enable" | "disable")}
-            className="input-field"
-          >
-            <option value="enable">Enable</option>
-            <option value="disable">Disable</option>
-          </select>
-        </div>
-
-        <div className="space-y-1.5">
-          <label htmlFor="rule-override-comment" className="block text-sm font-medium text-fg-muted">
-            Comment
-          </label>
-          <input
-            id="rule-override-comment"
-            type="text"
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            className="input-field"
-            placeholder="Optional"
-          />
-        </div>
-      </form>
-    </Modal>
-  );
-}
-
-type DeleteRuleOverrideDialogProps = {
-  policyId: number;
-  override: RuleOverride;
-  onSuccess: () => void;
-  onClose: () => void;
-};
-
-function DeleteRuleOverrideDialog({
-  policyId,
-  override,
-  onSuccess,
-  onClose,
-}: DeleteRuleOverrideDialogProps) {
-  const { accessToken } = useAuth();
-  const [submitting, setSubmitting] = useState(false);
-  const [serverError, setServerError] = useState<string | null>(null);
-
-  async function handleDelete() {
-    if (!accessToken) return;
-
-    setSubmitting(true);
-    setServerError(null);
-
-    try {
-      await deleteRuleOverride(accessToken, policyId, override.id);
-      onSuccess();
-    } catch (err) {
-      setServerError(
-        err instanceof ApiError ? err.detail : "An unexpected error occurred",
-      );
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <Modal
-      title="Delete rule override"
-      onClose={onClose}
-      footer={
-        <>
-          <button type="button" onClick={onClose} className="btn-ghost px-4 py-2 text-sm">
-            Cancel
-          </button>
-          <button
-            type="button"
-            disabled={submitting}
-            onClick={() => void handleDelete()}
-            className="rounded-[var(--radius-md)] bg-error px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 disabled:opacity-50"
-          >
-            {submitting ? "Deleting..." : "Delete"}
-          </button>
-        </>
-      }
-    >
-      {serverError && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          className="rounded-[var(--radius-md)] bg-error-soft px-4 py-3 text-sm font-medium text-error"
-        >
-          {serverError}
-        </div>
-      )}
-      <p className="text-sm text-fg">
-        Are you sure you want to delete the override for rule{" "}
-        <span className="font-semibold text-fg">{override.rule_id}</span>?
-        This action cannot be undone.
-      </p>
-    </Modal>
-  );
 }
 
 export function VHostDetailPage() {
@@ -264,7 +38,7 @@ export function VHostDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [policyError, setPolicyError] = useState<string | null>(null);
   const [savingPolicy, setSavingPolicy] = useState(false);
-  const [overrideModal, setOverrideModal] = useState<OverrideModalState>(null);
+  const [overrideModal, setOverrideModal] = useState<RuleOverrideModalState>(null);
   const refreshCountRef = useRef(0);
   const isAdmin = hasRole("admin");
 


### PR DESCRIPTION
## Summary

- Add policy detail UI sections for rule overrides, rule exclusions, and custom rules.
- Add admin create/edit/delete modals and keep viewer users read-only.
- Reuse the rule override modal from the vhost detail page.
- Extend frontend policy API/types and add the WAF policy tuning guide.
- Limit custom rules to request phases because the current SPOA flow does not inspect responses.

## Validation

- `cd src/backend && uv run pytest --cov=app` - 498 passed, 1 deselected, 91% coverage
- `cd src/backend && uv run mypy app/`
- `cd src/backend && uv run ruff check app/`
- `cd src/frontend && pnpm test` - 95 Vitest tests and 3 Node tests passed
- `cd src/frontend && pnpm run type-check`
- `cd src/frontend && pnpm run lint`
- `cd src/frontend && pnpm run build`
- `haproxy -c -f configs/haproxy/haproxy.cfg` - fails locally because `/usr/local/etc/haproxy/coraza.cfg` is missing on the host

Closes #125
Closes #16
Closes #198
