### PR TITLE
fix(api): tighten CORS methods and headers

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -163,6 +163,18 @@ The login handler always runs `bcrypt.verify` against a precomputed dummy hash
 when the requested email does not exist, keeping response time consistent and
 preventing user-enumeration through timing.
 
+### CORS policy
+
+CORS is restricted to the methods and headers the panel actually uses:
+
+- `allow_methods`: `GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`
+- `allow_headers`: `Authorization`, `Content-Type`
+- `allow_credentials`: `true` (required for the HttpOnly refresh cookie)
+- `allow_origins`: driven by `settings.cors_origins` (env var `CORS_ORIGINS`, CSV or JSON
+  array); the built-in default lists only local dev origins
+  (`localhost`/`127.0.0.1` on ports 3000, 5173, 5174) and must be overridden with the
+  production panel origin(s) via environment configuration before deployment.
+
 ## Deployment
 
 ### Health and Readiness Probes

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -114,8 +114,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 app.include_router(auth.router)

--- a/src/backend/tests/integration/test_auth_router.py
+++ b/src/backend/tests/integration/test_auth_router.py
@@ -117,6 +117,52 @@ def test_me_preflight_allows_authorization_header(client: TestClient) -> None:
     assert "authorization" in resp.headers["access-control-allow-headers"].lower()
 
 
+def test_preflight_does_not_advertise_wildcard_methods(client: TestClient) -> None:
+    resp = client.options(
+        "/auth/login",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type",
+        },
+    )
+
+    allowed_methods = resp.headers["access-control-allow-methods"]
+    assert "*" not in allowed_methods
+    assert {m.strip() for m in allowed_methods.split(",")} == {
+        "GET",
+        "POST",
+        "PATCH",
+        "DELETE",
+        "OPTIONS",
+    }
+
+
+def test_preflight_does_not_advertise_wildcard_headers(client: TestClient) -> None:
+    resp = client.options(
+        "/auth/me",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+
+    allowed_headers = resp.headers["access-control-allow-headers"].lower()
+    assert "*" not in allowed_headers
+    # Starlette's CORSMiddleware always unions allow_headers with the
+    # CORS-safelisted headers (Accept, Accept-Language, Content-Language,
+    # Content-Type), so those appear even though we only configured
+    # Authorization and Content-Type explicitly.
+    assert {h.strip() for h in allowed_headers.split(",")} == {
+        "accept",
+        "accept-language",
+        "content-language",
+        "content-type",
+        "authorization",
+    }
+
+
 def test_refresh_valid_cookie_returns_new_access_token(
     client: TestClient, admin_user: User
 ) -> None:

--- a/src/frontend/src/lib/api-client.ts
+++ b/src/frontend/src/lib/api-client.ts
@@ -2,7 +2,7 @@
 export type ApiResponseType = "json" | "text" | "empty";
 
 export type ApiClientOptions = {
-  method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
   body?: BodyInit | Record<string, unknown> | null;
   token?: string | null;
   headers?: HeadersInit;


### PR DESCRIPTION
## Summary
- Replace wildcard `allow_methods`/`allow_headers` in the CORS middleware with the explicit set the panel actually uses (`GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS` / `Authorization`, `Content-Type`)
- `allow_origins` already comes from `settings.cors_origins` with a dev-only default — documented this instead of changing it
- Document the CORS policy in `README.architecture.md`

## Test plan
- [x] `uv run pytest --cov=app` — 500 passed
- [x] `uv run mypy app/` — no issues
- [x] `uv run ruff check app/` — all checks passed
- [x] Added tests asserting no `*` is advertised in CORS preflight responses for methods or headers

Closes #102