### PR TITLE
feat(logs): add log retention policy and cleanup job

### DIFF
--- a/README.architecture.md
+++ b/README.architecture.md
@@ -106,6 +106,14 @@ machine-readable degraded reason header.
 5. FastAPI validates and normalizes payloads into the persisted `Log` model.
 6. `GET /logs` exposes stored events for the admin panel log viewer.
 
+### Log Retention
+`LOG_RETENTION_DAYS` (default `30`) controls how long `Log` rows are kept.
+A daily APScheduler job (`purge_old_logs` in
+`src/backend/app/services/scheduler.py`) deletes rows whose `event_at` is
+older than the threshold and logs the deleted count at `INFO`. Admins can
+also trigger an immediate cleanup via `POST /logs/cleanup`. Both paths share
+`purge_logs_older_than` in `src/backend/app/services/log_retention.py`.
+
 **Limitation — one log row per request, even when multiple rules fire.** A
 single Coraza transaction can trigger several CRS rules at once (e.g. an SQL
 injection probe matching `942100`, `942190`, `942270`, and `942360`

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -22,6 +22,9 @@ CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
 # SHIPPER_BACKOFF_MAX=30
 # SHIPPER_REQUEST_TIMEOUT=5
 
+# Number of days to keep log rows before the retention cleanup removes them.
+# LOG_RETENTION_DAYS=30
+
 # Local admin seed used by `make seed` and the benchmark lab.
 # Should be changed after initial deployment. 
 # ADMIN_EMAIL=admin@domain.com

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -76,6 +76,8 @@ class Settings(EnvFileSettings):
     haproxy_validation_timeout_seconds: int = 10
     haproxy_master_socket_path: str = "/var/run/haproxy/master.sock"
     haproxy_reload_timeout_seconds: int = 10
+    log_retention_days: int = 30
+
     @field_validator("database_url")
     @classmethod
     def database_url_must_not_be_empty(cls, value: str) -> str:
@@ -100,6 +102,13 @@ class Settings(EnvFileSettings):
     def timeout_settings_must_be_positive(cls, value: int) -> int:
         if value <= 0:
             raise ValueError("Runtime timeout settings must be greater than zero.")
+        return value
+
+    @field_validator("log_retention_days")
+    @classmethod
+    def log_retention_days_must_be_positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("LOG_RETENTION_DAYS must be greater than zero.")
         return value
 
     # JWT

--- a/src/backend/app/routers/logs.py
+++ b/src/backend/app/routers/logs.py
@@ -10,12 +10,18 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.config import settings
 from app.database import get_db
-from app.dependencies import get_current_user
+from app.dependencies import get_current_user, require_admin
 from app.models.log import Log, LogAction, LogSeverity
 from app.models.policy import Policy
 from app.models.user import User
 from app.models.vhost import VHost
-from app.schemas.log import LogIngestRequest, LogListResponse, LogResponse
+from app.schemas.log import (
+    LogCleanupResponse,
+    LogIngestRequest,
+    LogListResponse,
+    LogResponse,
+)
+from app.services.log_retention import purge_logs_older_than
 
 router = APIRouter(prefix="/logs", tags=["logs"])
 
@@ -188,6 +194,19 @@ def list_logs(
         total=total,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.post("/cleanup", response_model=LogCleanupResponse)
+def cleanup_logs(
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> LogCleanupResponse:
+    """Delete log events older than the configured retention threshold (admin only)."""
+    deleted = purge_logs_older_than(db, settings.log_retention_days)
+    return LogCleanupResponse(
+        deleted=deleted,
+        retention_days=settings.log_retention_days,
     )
 
 

--- a/src/backend/app/schemas/log.py
+++ b/src/backend/app/schemas/log.py
@@ -44,6 +44,13 @@ class LogListResponse(BaseModel):
     page_size: int
 
 
+class LogCleanupResponse(BaseModel):
+    """Result of a retention cleanup run returned by POST /logs/cleanup."""
+
+    deleted: int
+    retention_days: int
+
+
 class LogIngestRequest(BaseModel):
     """Payload accepted from a future runtime log producer."""
 

--- a/src/backend/app/services/log_retention.py
+++ b/src/backend/app/services/log_retention.py
@@ -1,0 +1,22 @@
+"""Log retention — delete persisted log events older than the configured threshold."""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models.log import Log
+
+
+def purge_logs_older_than(db: Session, retention_days: int) -> int:
+    """Delete log rows whose event_at is older than retention_days.
+
+    Returns the number of rows removed.
+    """
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=retention_days)
+    deleted = (
+        db.query(Log)
+        .filter(Log.event_at < cutoff)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    return deleted

--- a/src/backend/app/services/scheduler.py
+++ b/src/backend/app/services/scheduler.py
@@ -5,9 +5,11 @@ from datetime import UTC, datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore
 
+from app.config import settings
 from app.database import SessionLocal
 from app.models.vhost import VHost
 from app.services.certbot_service import CertbotError, CertbotService
+from app.services.log_retention import purge_logs_older_than
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +72,19 @@ def renew_certificates() -> None:
                 except CertbotError as e:
                     logger.error(f"Failed to renew certificate for {vhost.domain}: {e}")
 
+def purge_old_logs() -> None:
+    """Delete log events older than the configured retention threshold."""
+    with SessionLocal() as db:
+        deleted = purge_logs_older_than(db, settings.log_retention_days)
+        logger.info(
+            f"Log retention cleanup removed {deleted} rows older than "
+            f"{settings.log_retention_days} days"
+        )
+
 def start_scheduler() -> None:
     """Start the background scheduler."""
     scheduler.add_job(renew_certificates, 'interval', days=1, id='renew_certificates')
+    scheduler.add_job(purge_old_logs, 'interval', days=1, id='purge_old_logs')
     scheduler.start()
     logger.info("Background scheduler started")
 

--- a/src/backend/tests/integration/test_logs_router.py
+++ b/src/backend/tests/integration/test_logs_router.py
@@ -1,6 +1,6 @@
 """Integration tests for log ingestion and log listing APIs."""
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -851,3 +851,40 @@ def test_ingest_keeps_reported_paranoia_level_when_present(
     )
     assert resp.status_code == 201
     assert resp.json()["paranoia_level"] == 1
+
+
+def test_cleanup_logs_removes_only_rows_older_than_retention(
+    client: TestClient,
+    db: Session,
+    admin_token: dict[str, str],
+) -> None:
+    """Admin-triggered cleanup deletes only rows past the retention threshold."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    old_log = _create_log(db, event_at=now - timedelta(days=31))
+    recent_log = _create_log(db, event_at=now - timedelta(days=1))
+
+    resp = client.post("/logs/cleanup", headers=admin_token)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == 1
+    assert body["retention_days"] == 30
+
+    remaining_ids = {row.id for row in db.query(Log).all()}
+    assert old_log.id not in remaining_ids
+    assert recent_log.id in remaining_ids
+
+
+def test_cleanup_logs_requires_auth(client: TestClient) -> None:
+    """Cleanup is rejected without an Authorization header."""
+    resp = client.post("/logs/cleanup")
+    assert resp.status_code == 401
+
+
+def test_cleanup_logs_requires_admin_role(
+    client: TestClient,
+    viewer_token: dict[str, str],
+) -> None:
+    """Cleanup is rejected for an authenticated non-admin user."""
+    resp = client.post("/logs/cleanup", headers=viewer_token)
+    assert resp.status_code == 403

--- a/src/backend/tests/unit/test_log_retention.py
+++ b/src/backend/tests/unit/test_log_retention.py
@@ -1,0 +1,48 @@
+"""Unit tests for the log retention cleanup function."""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.models.log import Log, LogAction, LogSeverity
+from app.services.log_retention import purge_logs_older_than
+
+
+def _make_log(event_at: datetime) -> Log:
+    return Log(
+        event_at=event_at,
+        vhost="app.example.com",
+        action=LogAction.allow,
+        source_ip="203.0.113.10",
+        method="GET",
+        request_uri="/health",
+        status_code=200,
+        severity=LogSeverity.info,
+    )
+
+
+def test_purge_logs_older_than_removes_only_old_rows(db: Session) -> None:
+    now = datetime.now(UTC).replace(tzinfo=None)
+    old_log = _make_log(now - timedelta(days=31))
+    recent_log = _make_log(now - timedelta(days=1))
+    db.add_all([old_log, recent_log])
+    db.commit()
+
+    deleted = purge_logs_older_than(db, retention_days=30)
+
+    assert deleted == 1
+    remaining = db.query(Log).all()
+    assert len(remaining) == 1
+    assert remaining[0].id == recent_log.id
+
+
+def test_purge_logs_older_than_keeps_row_within_threshold(db: Session) -> None:
+    now = datetime.now(UTC).replace(tzinfo=None)
+    boundary_log = _make_log(now - timedelta(days=29, hours=23, minutes=59))
+    db.add(boundary_log)
+    db.commit()
+
+    deleted = purge_logs_older_than(db, retention_days=30)
+
+    assert deleted == 0
+    assert db.query(Log).count() == 1


### PR DESCRIPTION
## Summary
- Add `LOG_RETENTION_DAYS` setting (default 30, validated positive)
- Add `purge_logs_older_than` cleanup function that deletes log rows older than the threshold
- Expose `POST /logs/cleanup` (admin only) for on-demand cleanup
- Register a daily APScheduler job that runs the cleanup and logs the deleted count at INFO
- Document the mechanism in `README.architecture.md` and `.env.example`

## Test plan
- [x] Unit tests: cleanup removes only rows older than the threshold, keeps rows within it
- [x] Integration tests: `POST /logs/cleanup` deletes only old rows and returns the count; requires auth (401) and admin role (403)
- [x] `uv run pytest --cov=app` — 503 passed
- [x] `uv run mypy app/` — clean
- [x] `uv run ruff check app/` — clean

Closes #119