### PR TITLE
feat(api): paginate vhosts and policies

### DIFF
--- a/benchmarks/lab/set-policy.sh
+++ b/benchmarks/lab/set-policy.sh
@@ -100,7 +100,12 @@ policy_lookup="$(POLICIES="${policies_response}" POLICY_NAME="${TARGET_POLICY_NA
 import json, os, sys
 data = json.loads(os.environ["POLICIES"])
 name = os.environ["POLICY_NAME"]
-items = data if isinstance(data, list) else [data]
+if isinstance(data, dict) and "items" in data:
+    items = data["items"]
+elif isinstance(data, list):
+    items = data
+else:
+    items = [data]
 for item in items:
     if item["name"] == name:
         print(item["id"], item.get("paranoia_level", "?"))
@@ -119,7 +124,8 @@ set_vhost_policy() {
   vhost_id="$(VHOSTS="${vhosts_response}" DOMAIN="${domain}" python3 - <<'PY'
 import json, os, sys
 data = json.loads(os.environ["VHOSTS"]); domain = os.environ["DOMAIN"]
-for item in data:
+items = data["items"] if isinstance(data, dict) and "items" in data else data
+for item in items:
     if item["domain"] == domain:
         print(item["id"]); sys.exit(0)
 sys.exit(f"vhost {domain!r} not found. Run `make lab-up` (setup-lab.sh) first.")

--- a/benchmarks/lab/setup-lab.sh
+++ b/benchmarks/lab/setup-lab.sh
@@ -118,7 +118,12 @@ ensure_policy() {
 import json, sys, os
 data = json.loads(os.environ["POLICY_RESPONSE"])
 name = os.environ["POLICY_NAME"]
-items = data if isinstance(data, list) else [data]
+if isinstance(data, dict) and "items" in data:
+    items = data["items"]
+elif isinstance(data, list):
+    items = data
+else:
+    items = [data]
 for item in items:
     if item["name"] == name:
         print(item["id"]); sys.exit(0)
@@ -139,7 +144,8 @@ ensure_vhost() {
   vhost_id="$(VHOSTS="${vhosts_response}" DOMAIN="${domain}" python3 - <<'PY'
 import json, os
 data = json.loads(os.environ["VHOSTS"]); domain = os.environ["DOMAIN"]
-for item in data:
+items = data["items"] if isinstance(data, dict) and "items" in data else data
+for item in items:
     if item["domain"] == domain:
         print(item["id"]); exit(0)
 exit(f"vhost {domain!r} not found")

--- a/docs/dokumentacja_kursowa.md
+++ b/docs/dokumentacja_kursowa.md
@@ -84,12 +84,12 @@ Najwazniejsze endpointy:
 | POST | `/auth/refresh` | Odnowienie access tokena z refresh cookie |
 | POST | `/auth/logout` | Wylogowanie |
 | GET | `/auth/me` | Dane aktualnie zalogowanego uzytkownika |
-| GET | `/vhosts` | Lista wirtualnych hostow |
+| GET | `/vhosts` | Paginated virtual host list. Query params: `page`, `per_page`, `q` (domain search). Response: `{ items, total, page, per_page }`. |
 | POST | `/vhosts` | Utworzenie wirtualnego hosta |
 | GET | `/vhosts/{id}` | Szczegoly wirtualnego hosta |
 | PATCH | `/vhosts/{id}` | Edycja wirtualnego hosta |
 | DELETE | `/vhosts/{id}` | Usuniecie wirtualnego hosta |
-| GET | `/policies` | Lista polityk WAF |
+| GET | `/policies` | Paginated WAF policy list. Query params: `page`, `per_page`, `q` (name search). Response: `{ items, total, page, per_page }`. |
 | POST | `/policies` | Utworzenie polityki WAF |
 | GET | `/policies/{id}` | Szczegoly polityki WAF |
 | PATCH | `/policies/{id}` | Edycja polityki WAF |

--- a/src/backend/app/routers/policies.py
+++ b/src/backend/app/routers/policies.py
@@ -1,17 +1,24 @@
 """Policies API router — WAF policy CRUD."""
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
 from app.models.policy import Policy
 from app.models.user import User
-from app.schemas.policy import PolicyCreate, PolicyDetail, PolicyResponse, PolicyUpdate
+from app.schemas.policy import (
+    PolicyCreate,
+    PolicyDetail,
+    PolicyListResponse,
+    PolicyResponse,
+    PolicyUpdate,
+)
 from app.services.policy_service import (
     PolicyDatabaseConstraintError,
     PolicyDisallowedFieldError,
     PolicyFieldCannotBeNullError,
+    PolicyInUseError,
     PolicyNameAlreadyExistsError,
     PolicyNotFoundError,
     PolicyService,
@@ -51,14 +58,18 @@ def create_policy(
         ) from error
 
 
-@router.get("", response_model=list[PolicyResponse])
+@router.get("", response_model=PolicyListResponse)
 def list_policies(
+    page: int = Query(default=1, ge=1, le=10_000),
+    per_page: int = Query(default=50, ge=1, le=500),
+    q: str | None = Query(default=None, min_length=1, max_length=255),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
-) -> list[Policy]:
-    """Returns list of WAF policies (admin and viewer)."""
+) -> PolicyListResponse:
+    """Returns a paginated list of WAF policies, optionally filtered by name."""
     service = PolicyService(db)
-    return service.list_policies()
+    items, total = service.list_policies(page=page, per_page=per_page, q=q)
+    return PolicyListResponse(items=items, total=total, page=page, per_page=per_page)
 
 
 @router.get("/{policy_id}", response_model=PolicyDetail)
@@ -134,6 +145,11 @@ def delete_policy(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Policy not found",
+        ) from error
+    except PolicyInUseError as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Policy is assigned to a virtual host",
         ) from error
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/backend/app/routers/vhosts.py
+++ b/src/backend/app/routers/vhosts.py
@@ -1,6 +1,6 @@
 """VHosts API router — virtual host CRUD."""
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
@@ -9,7 +9,13 @@ from app.models.policy_binding import PolicyBinding
 from app.models.user import User
 from app.models.vhost import VHost
 from app.schemas.policy_binding import PolicyBindingCreate, PolicyBindingResponse
-from app.schemas.vhost import VHostCreate, VHostDetail, VHostResponse, VHostUpdate
+from app.schemas.vhost import (
+    VHostCreate,
+    VHostDetail,
+    VHostListResponse,
+    VHostResponse,
+    VHostUpdate,
+)
 from app.services.vhost_service import (
     PolicyBindingAlreadyExistsError,
     PolicyBindingDefaultManagedByVHostError,
@@ -67,14 +73,18 @@ def create_vhost(
         ) from error
 
 
-@router.get("", response_model=list[VHostResponse])
+@router.get("", response_model=VHostListResponse)
 def list_vhosts(
+    page: int = Query(default=1, ge=1, le=10_000),
+    per_page: int = Query(default=50, ge=1, le=500),
+    q: str | None = Query(default=None, min_length=1, max_length=255),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
-) -> list[VHost]:
-    """Returns list of vhosts (admin and viewer)."""
+) -> VHostListResponse:
+    """Returns a paginated list of vhosts, optionally filtered by domain."""
     service = VHostService(db)
-    return service.list_vhosts()
+    items, total = service.list_vhosts(page=page, per_page=per_page, q=q)
+    return VHostListResponse(items=items, total=total, page=page, per_page=per_page)
 
 
 @router.get("/{vhost_id}", response_model=VHostDetail)

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -79,3 +79,12 @@ class PolicyDetail(PolicyResponse):
     rule_overrides: list[RuleOverrideResponse] = []
     rule_exclusions: list[RuleExclusionResponse] = []
     custom_rules: list[CustomRuleResponse] = []
+
+
+class PolicyListResponse(BaseModel):
+    """Paginated response returned by GET /policies."""
+
+    items: list[PolicyResponse]
+    total: int
+    page: int
+    per_page: int

--- a/src/backend/app/schemas/vhost.py
+++ b/src/backend/app/schemas/vhost.py
@@ -137,3 +137,12 @@ class VHostDetail(VHostResponse):
     """
 
     policy: PolicyResponse | None = None
+
+
+class VHostListResponse(BaseModel):
+    """Paginated response returned by GET /vhosts."""
+
+    items: list[VHostResponse]
+    total: int
+    page: int
+    per_page: int

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -4,6 +4,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy_binding import PolicyBinding
+from app.models.vhost import VHost
 
 NON_NULLABLE_PATCH_FIELDS = {
     "name",
@@ -58,6 +60,10 @@ class PolicyDatabaseConstraintError(PolicyError):
     """Raised when an IntegrityError occurs for a reason other than a duplicate name."""
 
 
+class PolicyInUseError(PolicyError):
+    """Raised when a policy is still assigned to a vhost or path binding."""
+
+
 class PolicyService:
     """Encapsulates policy CRUD business rules.
 
@@ -104,9 +110,28 @@ class PolicyService:
         self.db.refresh(policy)
         return policy
 
-    def list_policies(self) -> list[Policy]:
-        """Return all policies sorted by ID."""
-        return self.db.query(Policy).order_by(Policy.id.asc()).all()
+    def list_policies(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 50,
+        q: str | None = None,
+    ) -> tuple[list[Policy], int]:
+        """Return a page of policies sorted by ID, optionally filtered by name."""
+        query = self.db.query(Policy)
+
+        search = q.strip() if q is not None else None
+        if search:
+            query = query.filter(Policy.name.ilike(f"%{search}%"))
+
+        total = query.count()
+        items = (
+            query.order_by(Policy.id.asc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+            .all()
+        )
+        return items, total
 
     def get_policy(self, policy_id: int) -> Policy:
         """Return one policy with related rule overrides and exclusions loaded."""
@@ -146,8 +171,26 @@ class PolicyService:
     def delete_policy(self, policy_id: int) -> None:
         """Delete a policy if it exists."""
         policy = self._get_policy_or_raise(policy_id)
+        if self._policy_is_assigned(policy_id):
+            raise PolicyInUseError
         self.db.delete(policy)
         self.db.commit()
+
+    def _policy_is_assigned(self, policy_id: int) -> bool:
+        """Return whether any vhost or path binding currently uses the policy."""
+        vhost_exists = (
+            self.db.query(VHost.id).filter(VHost.policy_id == policy_id).first()
+            is not None
+        )
+        if vhost_exists:
+            return True
+
+        return (
+            self.db.query(PolicyBinding.id)
+            .filter(PolicyBinding.policy_id == policy_id)
+            .first()
+            is not None
+        )
 
     def _get_policy_or_raise(self, policy_id: int) -> Policy:
         """Return a policy by primary key or raise a domain error."""

--- a/src/backend/app/services/vhost_service.py
+++ b/src/backend/app/services/vhost_service.py
@@ -155,14 +155,28 @@ class VHostService:
         self.db.refresh(vhost)
         return vhost
 
-    def list_vhosts(self) -> list[VHost]:
-        """Return all vhosts sorted by ID."""
-        return (
-            self.db.query(VHost)
-            .options(selectinload(VHost.policy_bindings))
-            .order_by(VHost.id.asc())
+    def list_vhosts(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 50,
+        q: str | None = None,
+    ) -> tuple[list[VHost], int]:
+        """Return a page of vhosts sorted by ID, optionally filtered by domain."""
+        query = self.db.query(VHost).options(selectinload(VHost.policy_bindings))
+
+        search = q.strip() if q is not None else None
+        if search:
+            query = query.filter(VHost.domain.ilike(f"%{search}%"))
+
+        total = query.count()
+        items = (
+            query.order_by(VHost.id.asc())
+            .offset((page - 1) * per_page)
+            .limit(per_page)
             .all()
         )
+        return items, total
 
     def get_vhost(self, vhost_id: int) -> VHost:
         """Return one vhost with related policy loaded."""

--- a/src/backend/tests/integration/test_policies_router.py
+++ b/src/backend/tests/integration/test_policies_router.py
@@ -133,7 +133,7 @@ def test_create_policy_invalid_paranoia_level_returns_422(
 def test_list_policies_admin_returns_200(
     client: TestClient, admin_token: dict[str, str]
 ) -> None:
-    """Admin może pobrać listę polityk."""
+    """Admin can list policies with pagination metadata."""
     _create_policy(client, admin_token, name="P1")
     _create_policy(client, admin_token, name="P2")
 
@@ -141,10 +141,10 @@ def test_list_policies_admin_returns_200(
     assert resp.status_code == 200
 
     body = resp.json()
-    assert isinstance(body, list)
-    assert len(body) == 2
-    assert body[0]["name"] == "P1"
-    assert body[1]["name"] == "P2"
+    assert body["total"] == 2
+    assert body["page"] == 1
+    assert body["per_page"] == 50
+    assert [item["name"] for item in body["items"]] == ["P1", "P2"]
 
 
 def test_list_policies_viewer_returns_200(
@@ -155,13 +155,45 @@ def test_list_policies_viewer_returns_200(
 
     resp = client.get("/policies", headers=viewer_token)
     assert resp.status_code == 200
-    assert len(resp.json()) == 1
+    assert len(resp.json()["items"]) == 1
 
 
 def test_list_policies_requires_auth(client: TestClient) -> None:
     """Brak tokena -> 401."""
     resp = client.get("/policies")
     assert resp.status_code == 401
+
+
+def test_list_policies_paginates_with_page_and_per_page(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """page/per_page parameters return a slice of results."""
+    for index in range(3):
+        _create_policy(client, admin_token, name=f"Policy {index}")
+
+    resp = client.get("/policies?page=2&per_page=2", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["total"] == 3
+    assert body["page"] == 2
+    assert body["per_page"] == 2
+    assert [item["name"] for item in body["items"]] == ["Policy 2"]
+
+
+def test_list_policies_filters_by_q(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """q filters policies by a name substring."""
+    _create_policy(client, admin_token, name="Strict Web App")
+    _create_policy(client, admin_token, name="Relaxed API")
+
+    resp = client.get("/policies?q=web", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["total"] == 1
+    assert [item["name"] for item in body["items"]] == ["Strict Web App"]
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +373,29 @@ def test_delete_policy_admin_returns_204(
 
     get_resp = client.get(f"/policies/{created['id']}", headers=admin_token)
     assert get_resp.status_code == 404
+
+
+def test_delete_policy_assigned_to_vhost_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """Assigned policies cannot be deleted."""
+    created = _create_policy(client, admin_token, name="Assigned policy")
+    vhost_resp = client.post(
+        "/vhosts",
+        headers=admin_token,
+        json={
+            "domain": "assigned.example.com",
+            "backend_url": "http://localhost:8080",
+            "policy_id": created["id"],
+        },
+    )
+    assert vhost_resp.status_code == 201
+
+    resp = client.delete(f"/policies/{created['id']}", headers=admin_token)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Policy is assigned to a virtual host"
 
 
 def test_delete_policy_viewer_forbidden(

--- a/src/backend/tests/integration/test_vhosts_router.py
+++ b/src/backend/tests/integration/test_vhosts_router.py
@@ -161,7 +161,7 @@ def test_list_vhosts_admin_returns_200(
     client: TestClient,
     admin_token: dict[str, str],
 ) -> None:
-    """Admin może pobrać listę vhostów."""
+    """Admin can list vhosts with pagination metadata."""
     _create_vhost(client, admin_token, domain="a.example.com")
     _create_vhost(client, admin_token, domain="b.example.com")
 
@@ -169,10 +169,13 @@ def test_list_vhosts_admin_returns_200(
     assert resp.status_code == 200
 
     body = resp.json()
-    assert isinstance(body, list)
-    assert len(body) == 2
-    assert body[0]["domain"] == "a.example.com"
-    assert body[1]["domain"] == "b.example.com"
+    assert body["total"] == 2
+    assert body["page"] == 1
+    assert body["per_page"] == 50
+    assert [item["domain"] for item in body["items"]] == [
+        "a.example.com",
+        "b.example.com",
+    ]
 
 
 def test_list_vhosts_viewer_returns_200(
@@ -185,13 +188,47 @@ def test_list_vhosts_viewer_returns_200(
 
     resp = client.get("/vhosts", headers=viewer_token)
     assert resp.status_code == 200
-    assert len(resp.json()) == 1
+    assert len(resp.json()["items"]) == 1
 
 
 def test_list_vhosts_requires_auth(client: TestClient) -> None:
     """Brak tokena -> 401."""
     resp = client.get("/vhosts")
     assert resp.status_code == 401
+
+
+def test_list_vhosts_paginates_with_page_and_per_page(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """page/per_page parameters return a slice of results."""
+    for index in range(3):
+        _create_vhost(client, admin_token, domain=f"host{index}.example.com")
+
+    resp = client.get("/vhosts?page=2&per_page=2", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["total"] == 3
+    assert body["page"] == 2
+    assert body["per_page"] == 2
+    assert [item["domain"] for item in body["items"]] == ["host2.example.com"]
+
+
+def test_list_vhosts_filters_by_q(
+    client: TestClient,
+    admin_token: dict[str, str],
+) -> None:
+    """q filters vhosts by a domain substring."""
+    _create_vhost(client, admin_token, domain="app.example.com")
+    _create_vhost(client, admin_token, domain="api.other.com")
+
+    resp = client.get("/vhosts?q=example", headers=admin_token)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["total"] == 1
+    assert [item["domain"] for item in body["items"]] == ["app.example.com"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/test_policy_service.py
+++ b/src/backend/tests/unit/test_policy_service.py
@@ -15,10 +15,13 @@ from sqlalchemy.orm import Session
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
 from app.models.policy import Policy, PolicyEnforcementMode  # noqa: E402
+from app.models.policy_binding import PolicyBinding  # noqa: E402
 from app.models.user import User  # noqa: E402
+from app.models.vhost import VHost  # noqa: E402
 from app.services.policy_service import (  # noqa: E402
     PolicyDisallowedFieldError,
     PolicyFieldCannotBeNullError,
+    PolicyInUseError,
     PolicyNameAlreadyExistsError,
     PolicyNotFoundError,
     PolicyService,
@@ -103,10 +106,59 @@ def test_list_policies_returns_items_sorted_by_id(
         created_by=admin_user.id,
     )
 
-    policies = service.list_policies()
+    policies, total = service.list_policies()
 
+    assert total == 2
     assert [policy.id for policy in policies] == [first.id, second.id]
     assert [policy.name for policy in policies] == ["Alpha", "Beta"]
+
+
+def test_list_policies_paginates_results(db: Session, admin_user: User) -> None:
+    service = PolicyService(db)
+    for index in range(3):
+        service.create_policy(
+            name=f"Policy {index}",
+            description=None,
+            paranoia_level=1,
+            inbound_anomaly_threshold=5,
+            outbound_anomaly_threshold=5,
+            enforcement_mode=PolicyEnforcementMode.block,
+            created_by=admin_user.id,
+        )
+
+    first_page, total = service.list_policies(page=1, per_page=2)
+    second_page, _ = service.list_policies(page=2, per_page=2)
+
+    assert total == 3
+    assert [policy.name for policy in first_page] == ["Policy 0", "Policy 1"]
+    assert [policy.name for policy in second_page] == ["Policy 2"]
+
+
+def test_list_policies_filters_by_name_substring(db: Session, admin_user: User) -> None:
+    service = PolicyService(db)
+    service.create_policy(
+        name="Strict Web App",
+        description=None,
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+    service.create_policy(
+        name="Relaxed API",
+        description=None,
+        paranoia_level=1,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    policies, total = service.list_policies(q="web")
+
+    assert total == 1
+    assert [policy.name for policy in policies] == ["Strict Web App"]
 
 
 def test_get_policy_returns_existing_policy(db: Session, admin_user: User) -> None:
@@ -228,6 +280,80 @@ def test_delete_policy_removes_existing_policy(db: Session, admin_user: User) ->
     service.delete_policy(created.id)
 
     assert db.get(Policy, created.id) is None
+
+
+def test_delete_policy_assigned_to_vhost_raises_in_use(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Assigned default",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+    db.add(
+        VHost(
+            domain="assigned.example.com",
+            backend_url="http://localhost:8080",
+            ssl_enabled=False,
+            ssl_provider="none",
+            is_active=True,
+            policy_id=created.id,
+            created_by=admin_user.id,
+        ),
+    )
+    db.commit()
+
+    with pytest.raises(PolicyInUseError):
+        service.delete_policy(created.id)
+
+    assert db.get(Policy, created.id) is not None
+
+
+def test_delete_policy_assigned_to_path_binding_raises_in_use(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Assigned binding",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+    vhost = VHost(
+        domain="binding.example.com",
+        backend_url="http://localhost:8080",
+        ssl_enabled=False,
+        ssl_provider="none",
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    db.add(vhost)
+    db.flush()
+    db.add(
+        PolicyBinding(
+            vhost_id=vhost.id,
+            policy_id=created.id,
+            path_prefix="/api",
+            priority=1,
+        ),
+    )
+    db.commit()
+
+    with pytest.raises(PolicyInUseError):
+        service.delete_policy(created.id)
+
+    assert db.get(Policy, created.id) is not None
 
 
 def test_delete_policy_missing_raises_not_found(db: Session) -> None:

--- a/src/backend/tests/unit/test_vhost_service.py
+++ b/src/backend/tests/unit/test_vhost_service.py
@@ -165,10 +165,62 @@ def test_list_vhosts_returns_items_sorted_by_id(
         created_by=admin_user.id,
     )
 
-    vhosts = service.list_vhosts()
+    vhosts, total = service.list_vhosts()
 
+    assert total == 2
     assert [vhost.id for vhost in vhosts] == [first.id, second.id]
     assert [vhost.domain for vhost in vhosts] == ["a.example.com", "b.example.com"]
+
+
+def test_list_vhosts_paginates_results(db: Session, admin_user: User) -> None:
+    service = VHostService(db)
+    for index in range(3):
+        service.create_vhost(
+            domain=f"host{index}.example.com",
+            backend_url="http://localhost:8080",
+            description=None,
+            ssl_enabled=False,
+            is_active=True,
+            policy_id=None,
+            created_by=admin_user.id,
+        )
+
+    first_page, total = service.list_vhosts(page=1, per_page=2)
+    second_page, _ = service.list_vhosts(page=2, per_page=2)
+
+    assert total == 3
+    assert [vhost.domain for vhost in first_page] == [
+        "host0.example.com",
+        "host1.example.com",
+    ]
+    assert [vhost.domain for vhost in second_page] == ["host2.example.com"]
+
+
+def test_list_vhosts_filters_by_domain_substring(db: Session, admin_user: User) -> None:
+    service = VHostService(db)
+    service.create_vhost(
+        domain="app.example.com",
+        backend_url="http://localhost:8080",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+    service.create_vhost(
+        domain="api.other.com",
+        backend_url="http://localhost:8081",
+        description=None,
+        ssl_enabled=False,
+        is_active=True,
+        policy_id=None,
+        created_by=admin_user.id,
+    )
+
+    vhosts, total = service.list_vhosts(q="example")
+
+    assert total == 1
+    assert [vhost.domain for vhost in vhosts] == ["app.example.com"]
 
 
 def test_get_vhost_returns_existing_vhost(db: Session, admin_user: User) -> None:

--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchLogTotal } from "@/features/logs/api";
 import type { LogAction, LogSeverity } from "@/features/logs/types";
-import { listVHosts } from "@/features/vhosts/api";
-import { listPolicies } from "@/features/policies/api";
+import { listAllVHosts } from "@/features/vhosts/api";
+import { listAllPolicies } from "@/features/policies/api";
 import { useAuth } from "@/hooks/use-auth";
 
 export type StatValue = {
@@ -60,7 +60,7 @@ export function useDashboardStats(): DashboardStatsState {
         if (generation === generationRef.current) setter(value);
       };
 
-    listVHosts(accessToken, controller.signal)
+    listAllVHosts(accessToken, controller.signal)
       .then((list) =>
         guard(setVHosts)(
           ok(list.filter((v) => v.is_active && v.policy_id != null).length),
@@ -68,8 +68,10 @@ export function useDashboardStats(): DashboardStatsState {
       )
       .catch((e) => { if (!isAbortError(e)) guard(setVHosts)(failed()); });
 
-    listPolicies(accessToken, controller.signal)
-      .then((list) => guard(setPolicies)(ok(list.filter((p) => p.is_active).length)))
+    listAllPolicies(accessToken, controller.signal)
+      .then((list) =>
+        guard(setPolicies)(ok(list.filter((p) => p.is_active).length)),
+      )
       .catch((e) => { if (!isAbortError(e)) guard(setPolicies)(failed()); });
 
     fetchLogTotal(accessToken, { action: "deny" as LogAction }, controller.signal)

--- a/src/frontend/src/features/logs/use-logs.ts
+++ b/src/frontend/src/features/logs/use-logs.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/hooks/use-auth";
-import { listPolicies } from "@/features/vhosts/api";
+import { listAllPolicies } from "@/features/vhosts/api";
 import type { Policy } from "@/features/vhosts/types";
 
 import { listLogs } from "./api";
@@ -63,7 +63,7 @@ export function useLogs(): LogsState {
         },
         controller.signal,
       ),
-      listPolicies(accessToken, controller.signal),
+      listAllPolicies(accessToken, controller.signal),
     ])
       .then(([logList, policyList]) => {
         if (generation !== refreshCountRef.current) return;

--- a/src/frontend/src/features/policies/api.test.ts
+++ b/src/frontend/src/features/policies/api.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { listAllPolicies } from "./api";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("policies API pagination helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("loads every policy page for complete dashboard counts", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, name: "First policy", is_active: true }],
+          total: 2,
+          page: 1,
+          per_page: 500,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 501, name: "Late policy", is_active: true }],
+          total: 2,
+          page: 2,
+          per_page: 500,
+        }),
+      );
+
+    const policies = await listAllPolicies("token");
+
+    expect(policies.map((policy) => policy.name)).toEqual([
+      "First policy",
+      "Late policy",
+    ]);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/v1/policies?page=1&per_page=500",
+      "/api/v1/policies?page=2&per_page=500",
+    ]);
+  });
+});

--- a/src/frontend/src/features/policies/api.ts
+++ b/src/frontend/src/features/policies/api.ts
@@ -7,6 +7,7 @@ import type {
   Policy,
   PolicyCreate,
   PolicyDetail,
+  PolicyListResponse,
   PolicyUpdate,
   RuleExclusion,
   RuleExclusionCreate,
@@ -16,8 +17,50 @@ import type {
   RuleOverrideUpdate,
 } from "./types";
 
-export function listPolicies(token: string, signal?: AbortSignal) {
-  return apiRequest<Policy[]>("/policies", { token, signal });
+export type ListPoliciesParams = {
+  page?: number;
+  per_page?: number;
+  q?: string;
+};
+
+function withQuery(path: string, params: ListPoliciesParams) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+
+  const queryString = query.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+export function listPolicies(
+  token: string,
+  params: ListPoliciesParams = {},
+  signal?: AbortSignal,
+) {
+  return apiRequest<PolicyListResponse>(withQuery("/policies", params), {
+    token,
+    signal,
+  });
+}
+
+export async function listAllPolicies(token: string, signal?: AbortSignal) {
+  const perPage = 500;
+  let page = 1;
+  const items: Policy[] = [];
+
+  while (true) {
+    const response = await listPolicies(token, { page, per_page: perPage }, signal);
+    items.push(...response.items);
+
+    if (items.length >= response.total || response.items.length === 0) {
+      return items;
+    }
+
+    page += 1;
+  }
 }
 
 export function getPolicy(token: string, id: number, signal?: AbortSignal) {

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -12,6 +12,13 @@ export type Policy = {
   updated_at: string;
 };
 
+export type PolicyListResponse = {
+  items: Policy[];
+  total: number;
+  page: number;
+  per_page: number;
+};
+
 export type RuleOverride = {
   id: number;
   policy_id: number;

--- a/src/frontend/src/features/policies/use-policies.ts
+++ b/src/frontend/src/features/policies/use-policies.ts
@@ -1,22 +1,32 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { listVHosts } from "@/features/vhosts/api";
+import { listAllVHosts } from "@/features/vhosts/api";
 import { useAuth } from "@/hooks/use-auth";
 
 import { listPolicies } from "./api";
 import type { Policy } from "./types";
 
+const PAGE_SIZE = 50;
 type PoliciesState = {
   policies: Policy[];
+  total: number;
+  page: number;
+  pageSize: number;
+  searchQuery: string;
   assignedPolicyIds: Set<number>;
   isLoading: boolean;
   error: string | null;
+  setPage: (page: number) => void;
+  setSearchQuery: (query: string) => void;
   refresh: () => void;
 };
 
 export function usePolicies(): PoliciesState {
   const { accessToken } = useAuth();
   const [policies, setPolicies] = useState<Policy[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPageState] = useState(1);
+  const [searchQuery, setSearchQueryState] = useState("");
   const [assignedPolicyIds, setAssignedPolicyIds] = useState<Set<number>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -32,12 +42,17 @@ export function usePolicies(): PoliciesState {
     setError(null);
 
     Promise.all([
-      listPolicies(accessToken, controller.signal),
-      listVHosts(accessToken, controller.signal),
+      listPolicies(
+        accessToken,
+        { page, per_page: PAGE_SIZE, q: searchQuery.trim() || undefined },
+        controller.signal,
+      ),
+      listAllVHosts(accessToken, controller.signal),
     ])
       .then(([policyList, vhostList]) => {
         if (generation !== refreshCountRef.current) return;
-        setPolicies(policyList);
+        setPolicies(policyList.items);
+        setTotal(policyList.total);
         const ids = new Set(
           vhostList
             .map((v) => v.policy_id)
@@ -56,7 +71,7 @@ export function usePolicies(): PoliciesState {
     return () => {
       controller.abort();
     };
-  }, [accessToken]);
+  }, [accessToken, page, searchQuery]);
 
   useEffect(() => {
     const cleanup = fetch();
@@ -67,5 +82,26 @@ export function usePolicies(): PoliciesState {
     fetch();
   }, [fetch]);
 
-  return { policies, assignedPolicyIds, isLoading, error, refresh };
+  const setPage = useCallback((nextPage: number) => {
+    setPageState(nextPage);
+  }, []);
+
+  const setSearchQuery = useCallback((query: string) => {
+    setPageState(1);
+    setSearchQueryState(query);
+  }, []);
+
+  return {
+    policies,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    searchQuery,
+    assignedPolicyIds,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  };
 }

--- a/src/frontend/src/features/vhosts/api.test.ts
+++ b/src/frontend/src/features/vhosts/api.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { listAllPolicies, listAllVHosts } from "./api";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("vhosts API pagination helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("loads every vhost page for complete relationship checks", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, domain: "first.example.com" }],
+          total: 2,
+          page: 1,
+          per_page: 500,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 501, domain: "late.example.com" }],
+          total: 2,
+          page: 2,
+          per_page: 500,
+        }),
+      );
+
+    const vhosts = await listAllVHosts("token");
+
+    expect(vhosts.map((vhost) => vhost.domain)).toEqual([
+      "first.example.com",
+      "late.example.com",
+    ]);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/v1/vhosts?page=1&per_page=500",
+      "/api/v1/vhosts?page=2&per_page=500",
+    ]);
+  });
+
+  it("loads every policy page for vhost assignment selectors", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, name: "First policy" }],
+          total: 2,
+          page: 1,
+          per_page: 500,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 501, name: "Late policy" }],
+          total: 2,
+          page: 2,
+          per_page: 500,
+        }),
+      );
+
+    const policies = await listAllPolicies("token");
+
+    expect(policies.map((policy) => policy.name)).toEqual([
+      "First policy",
+      "Late policy",
+    ]);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "/api/v1/policies?page=1&per_page=500",
+      "/api/v1/policies?page=2&per_page=500",
+    ]);
+  });
+});

--- a/src/frontend/src/features/vhosts/api.ts
+++ b/src/frontend/src/features/vhosts/api.ts
@@ -1,9 +1,62 @@
 import { apiRequest } from "@/lib/api-client";
 
-import type { Policy, VHost, VHostCreate, VHostDetail, VHostUpdate } from "./types";
+import type {
+  Policy,
+  PolicyListResponse,
+  VHost,
+  VHostCreate,
+  VHostDetail,
+  VHostListResponse,
+  VHostUpdate,
+} from "./types";
 
-export function listVHosts(token: string, signal?: AbortSignal) {
-  return apiRequest<VHost[]>("/vhosts", { token, signal });
+export type ListVHostsParams = {
+  page?: number;
+  per_page?: number;
+  q?: string;
+};
+
+export type ListPoliciesParams = {
+  page?: number;
+  per_page?: number;
+  q?: string;
+};
+
+function withQuery(path: string, params: ListVHostsParams | ListPoliciesParams) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+
+  const queryString = query.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+export function listVHosts(
+  token: string,
+  params: ListVHostsParams = {},
+  signal?: AbortSignal,
+) {
+  return apiRequest<VHostListResponse>(withQuery("/vhosts", params), { token, signal });
+}
+
+export async function listAllVHosts(token: string, signal?: AbortSignal) {
+  const perPage = 500;
+  let page = 1;
+  const items: VHost[] = [];
+
+  while (true) {
+    const response = await listVHosts(token, { page, per_page: perPage }, signal);
+    items.push(...response.items);
+
+    if (items.length >= response.total || response.items.length === 0) {
+      return items;
+    }
+
+    page += 1;
+  }
 }
 
 export function getVHost(token: string, id: number, signal?: AbortSignal) {
@@ -26,6 +79,27 @@ export function deleteVHost(token: string, id: number) {
   });
 }
 
-export function listPolicies(token: string, signal?: AbortSignal) {
-  return apiRequest<Policy[]>("/policies", { token, signal });
+export function listPolicies(
+  token: string,
+  params: ListPoliciesParams = {},
+  signal?: AbortSignal,
+) {
+  return apiRequest<PolicyListResponse>(withQuery("/policies", params), { token, signal });
+}
+
+export async function listAllPolicies(token: string, signal?: AbortSignal) {
+  const perPage = 500;
+  let page = 1;
+  const items: Policy[] = [];
+
+  while (true) {
+    const response = await listPolicies(token, { page, per_page: perPage }, signal);
+    items.push(...response.items);
+
+    if (items.length >= response.total || response.items.length === 0) {
+      return items;
+    }
+
+    page += 1;
+  }
 }

--- a/src/frontend/src/features/vhosts/types.ts
+++ b/src/frontend/src/features/vhosts/types.ts
@@ -13,6 +13,13 @@ export type VHost = {
   updated_at: string;
 };
 
+export type VHostListResponse = {
+  items: VHost[];
+  total: number;
+  page: number;
+  per_page: number;
+};
+
 export type VHostAssignedPolicy = {
   id: number;
   name: string;
@@ -58,4 +65,11 @@ export type VHostUpdate = {
 export type Policy = {
   id: number;
   name: string;
+};
+
+export type PolicyListResponse = {
+  items: Policy[];
+  total: number;
+  page: number;
+  per_page: number;
 };

--- a/src/frontend/src/features/vhosts/use-vhosts.ts
+++ b/src/frontend/src/features/vhosts/use-vhosts.ts
@@ -2,21 +2,31 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/hooks/use-auth";
 
-import { listPolicies, listVHosts } from "./api";
+import { listAllPolicies, listVHosts } from "./api";
 import type { Policy, VHost } from "./types";
 
+const PAGE_SIZE = 50;
 type VHostsState = {
   vhosts: VHost[];
+  total: number;
+  page: number;
+  pageSize: number;
+  searchQuery: string;
   policies: Policy[];
   policyNameById: Record<number, string>;
   isLoading: boolean;
   error: string | null;
+  setPage: (page: number) => void;
+  setSearchQuery: (query: string) => void;
   refresh: () => void;
 };
 
 export function useVHosts(): VHostsState {
   const { accessToken } = useAuth();
   const [vhosts, setVHosts] = useState<VHost[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPageState] = useState(1);
+  const [searchQuery, setSearchQueryState] = useState("");
   const [policies, setPolicies] = useState<Policy[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -32,12 +42,17 @@ export function useVHosts(): VHostsState {
     setError(null);
 
     Promise.all([
-      listVHosts(accessToken, controller.signal),
-      listPolicies(accessToken, controller.signal),
+      listVHosts(
+        accessToken,
+        { page, per_page: PAGE_SIZE, q: searchQuery.trim() || undefined },
+        controller.signal,
+      ),
+      listAllPolicies(accessToken, controller.signal),
     ])
       .then(([vhostList, policyList]) => {
         if (generation !== refreshCountRef.current) return;
-        setVHosts(vhostList);
+        setVHosts(vhostList.items);
+        setTotal(vhostList.total);
         setPolicies(policyList);
         setIsLoading(false);
       })
@@ -51,7 +66,7 @@ export function useVHosts(): VHostsState {
     return () => {
       controller.abort();
     };
-  }, [accessToken]);
+  }, [accessToken, page, searchQuery]);
 
   useEffect(() => {
     const cleanup = fetch();
@@ -62,10 +77,32 @@ export function useVHosts(): VHostsState {
     fetch();
   }, [fetch]);
 
+  const setPage = useCallback((nextPage: number) => {
+    setPageState(nextPage);
+  }, []);
+
+  const setSearchQuery = useCallback((query: string) => {
+    setPageState(1);
+    setSearchQueryState(query);
+  }, []);
+
   const policyNameById: Record<number, string> = {};
   for (const p of policies) {
     policyNameById[p.id] = p.name;
   }
 
-  return { vhosts, policies, policyNameById, isLoading, error, refresh };
+  return {
+    vhosts,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    searchQuery,
+    policies,
+    policyNameById,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  };
 }

--- a/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -59,8 +59,8 @@ function renderPage() {
 
 describe("DashboardPage StatCards", () => {
   it("shows loading skeletons while all fetches are in-flight", () => {
-    vi.mocked(vhostsApi.listVHosts).mockReturnValue(new Promise(() => undefined));
-    vi.mocked(policiesApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listAllVHosts).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(policiesApi.listAllPolicies).mockReturnValue(new Promise(() => undefined));
     vi.mocked(logsApi.fetchLogTotal).mockReturnValue(new Promise(() => undefined));
 
     renderPage();
@@ -69,8 +69,8 @@ describe("DashboardPage StatCards", () => {
   });
 
   it("renders real counts after data loads", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
-    vi.mocked(policiesApi.listPolicies).mockResolvedValue(mockPolicies as never);
+    vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHosts as never);
+    vi.mocked(policiesApi.listAllPolicies).mockResolvedValue(mockPolicies as never);
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(42);
 
     renderPage();
@@ -84,8 +84,8 @@ describe("DashboardPage StatCards", () => {
   });
 
   it("shows — only for the card whose endpoint fails, real counts for others", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts as never);
-    vi.mocked(policiesApi.listPolicies).mockRejectedValue(new Error("Network error"));
+    vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHosts as never);
+    vi.mocked(policiesApi.listAllPolicies).mockRejectedValue(new Error("Network error"));
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(7);
 
     renderPage();
@@ -99,8 +99,8 @@ describe("DashboardPage StatCards", () => {
   });
 
   it("shows — for all cards when all endpoints fail", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockRejectedValue(new Error("down"));
-    vi.mocked(policiesApi.listPolicies).mockRejectedValue(new Error("down"));
+    vi.mocked(vhostsApi.listAllVHosts).mockRejectedValue(new Error("down"));
+    vi.mocked(policiesApi.listAllPolicies).mockRejectedValue(new Error("down"));
     vi.mocked(logsApi.fetchLogTotal).mockRejectedValue(new Error("down"));
 
     renderPage();

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -66,7 +66,7 @@ function renderPage() {
 describe("LogsPage", () => {
   it("shows loading state initially", () => {
     vi.mocked(logsApi.listLogs).mockReturnValue(new Promise(() => undefined));
-    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listAllPolicies).mockReturnValue(new Promise(() => undefined));
 
     renderPage();
     expect(screen.getByText(/loading logs/i)).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe("LogsPage", () => {
 
   it("renders log rows from API response", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
 
@@ -88,7 +88,7 @@ describe("LogsPage", () => {
 
   it("shows error state on API failure", async () => {
     vi.mocked(logsApi.listLogs).mockRejectedValue(new Error("Network error"));
-    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+    vi.mocked(vhostsApi.listAllPolicies).mockRejectedValue(new Error("Network error"));
 
     renderPage();
 
@@ -100,7 +100,7 @@ describe("LogsPage", () => {
 
   it("shows empty state when no logs match", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(emptyListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue([]);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue([]);
 
     renderPage();
 
@@ -111,7 +111,7 @@ describe("LogsPage", () => {
 
   it("hides filter inputs until the Filters toggle is opened", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -125,7 +125,7 @@ describe("LogsPage", () => {
 
   it("shows an active filter count badge after applying filters", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -141,7 +141,7 @@ describe("LogsPage", () => {
 
   it("labels the allow filter option to clarify it means flagged-but-allowed", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -155,7 +155,7 @@ describe("LogsPage", () => {
 
   it("applying filters re-fetches with filter params", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -175,7 +175,7 @@ describe("LogsPage", () => {
 
   it("applies the new severity, method, source IP, rule ID and min score filters", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -206,7 +206,7 @@ describe("LogsPage", () => {
 
   it("applies from and to date/time filters", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -241,7 +241,7 @@ describe("LogsPage", () => {
 
   it("clearing filters resets to empty params", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -261,7 +261,7 @@ describe("LogsPage", () => {
 
   it("View button opens detail modal with log fields", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
@@ -289,7 +289,7 @@ describe("LogsPage", () => {
         },
       ],
     });
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
     await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());

--- a/src/frontend/src/pages/policies/PoliciesPage.test.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as policiesApi from "@/features/policies/api";
+import * as vhostsApi from "@/features/vhosts/api";
+
+import { PoliciesPage } from "./PoliciesPage";
+
+vi.mock("@/features/policies/api");
+vi.mock("@/features/vhosts/api");
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockPolicies = [
+  {
+    id: 1,
+    name: "Default WAF",
+    description: null,
+    paranoia_level: 2 as const,
+    inbound_anomaly_threshold: 5,
+    outbound_anomaly_threshold: 4,
+    enforcement_mode: "block" as const,
+    is_active: true,
+    created_by: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const mockPolicyListResponse = {
+  items: mockPolicies,
+  total: 1,
+  page: 1,
+  per_page: 50,
+};
+
+const mockVHostListResponse = {
+  items: [
+    {
+      id: 1,
+      domain: "app.example.com",
+      backend_url: "https://backend.internal",
+      description: null,
+      ssl_enabled: false,
+      ssl_provider: "none" as const,
+      ssl_expires_at: null,
+      is_active: true,
+      policy_id: 1,
+      created_by: 1,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  total: 1,
+  page: 1,
+  per_page: 50,
+};
+
+function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext(authOverrides)}>
+      <MemoryRouter initialEntries={["/policies"]}>
+        <Routes>
+          <Route path="/policies" element={<PoliciesPage />} />
+          <Route path="/policies/:policyId" element={<p>Policy detail page</p>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+}
+
+describe("PoliciesPage", () => {
+  it("renders paginated policy rows from the API response", async () => {
+    vi.mocked(policiesApi.listPolicies).mockResolvedValue(mockPolicyListResponse);
+    vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHostListResponse.items);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Default WAF")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Block")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 1 · 1 policies")).toBeInTheDocument();
+  });
+
+  it("requests the next page and filters by policy search", async () => {
+    vi.mocked(policiesApi.listPolicies).mockResolvedValue({
+      ...mockPolicyListResponse,
+      total: 75,
+    });
+    vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHostListResponse.items);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("Default WAF")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() =>
+      expect(policiesApi.listPolicies).toHaveBeenLastCalledWith(
+        "test-token",
+        { page: 2, per_page: 50, q: undefined },
+        expect.any(AbortSignal),
+      ),
+    );
+
+    await userEvent.type(screen.getByLabelText(/search policies/i), "strict");
+
+    await waitFor(() =>
+      expect(policiesApi.listPolicies).toHaveBeenLastCalledWith(
+        "test-token",
+        { page: 1, per_page: 50, q: "strict" },
+        expect.any(AbortSignal),
+      ),
+    );
+  });
+
+  it("does not show admin actions to viewers", async () => {
+    vi.mocked(policiesApi.listPolicies).mockResolvedValue(mockPolicyListResponse);
+    vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHostListResponse.items);
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(false), role: "viewer" });
+
+    await waitFor(() =>
+      expect(screen.getByText("Default WAF")).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /new policy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { DeletePolicyDialog } from "@/features/policies/DeletePolicyDialog";
 import { PolicyFormModal } from "@/features/policies/PolicyFormModal";
 import type { Policy } from "@/features/policies/types";
@@ -25,9 +26,22 @@ type ModalState =
 export function PoliciesPage() {
   const navigate = useNavigate();
   const { hasRole } = useAuth();
-  const { policies, assignedPolicyIds, isLoading, error, refresh } = usePolicies();
+  const {
+    policies,
+    total,
+    page,
+    pageSize,
+    searchQuery,
+    assignedPolicyIds,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  } = usePolicies();
   const [modal, setModal] = useState<ModalState>(null);
   const isAdmin = hasRole("admin");
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   function closeAndRefresh() {
     setModal(null);
@@ -147,7 +161,19 @@ export function PoliciesPage() {
         }
       />
 
-      <SectionCard title="Policies" description="All configured WAF policies and their current settings.">
+      <SectionCard
+        title="Policies"
+        description="All configured WAF policies and their current settings."
+        actions={
+          <Input
+            aria-label="Search policies"
+            className="w-full sm:w-72"
+            placeholder="Search names"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
+        }
+      >
         {isLoading ? (
           <LoadingState label="Loading policies…" />
         ) : error ? (
@@ -165,14 +191,42 @@ export function PoliciesPage() {
             }
           />
         ) : (
-          <DataTable
-            columns={columns}
-            rows={policies}
-            getRowKey={(row) => String(row.id)}
-            emptyTitle="No policies yet"
-            emptyDescription="Create your first WAF policy to start protecting your virtual hosts."
-            onRowClick={(row) => navigate(getPolicyDetailPath(row.id))}
-          />
+          <>
+            <DataTable
+              columns={columns}
+              rows={policies}
+              getRowKey={(row) => String(row.id)}
+              emptyTitle="No policies found"
+              emptyDescription="Create a WAF policy or adjust the search query."
+              onRowClick={(row) => navigate(getPolicyDetailPath(row.id))}
+            />
+
+            {total > 0 && (
+              <div className="mt-4 flex items-center justify-between gap-4">
+                <span className="text-sm text-muted-foreground">
+                  Page {page} of {totalPages} · {total} policies
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page - 1)}
+                    disabled={page <= 1}
+                    variant="outline"
+                  >
+                    Prev
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page + 1)}
+                    disabled={page >= totalPages}
+                    variant="outline"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </SectionCard>
 

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
@@ -80,7 +80,7 @@ function mockSuccessfulLoad(
   overrides: RuleOverride[] = mockOverrides,
 ) {
   vi.mocked(vhostsApi.getVHost).mockResolvedValue(vhost);
-  vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+  vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
   vi.mocked(policiesApi.listRuleOverrides).mockResolvedValue(overrides);
 }
 
@@ -107,7 +107,7 @@ describe("VHostDetailPage", () => {
 
   it("shows loading state initially", () => {
     vi.mocked(vhostsApi.getVHost).mockReturnValue(new Promise(() => undefined));
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
 
@@ -134,7 +134,7 @@ describe("VHostDetailPage", () => {
     vi.mocked(vhostsApi.getVHost)
       .mockRejectedValueOnce(new Error("Network error"))
       .mockResolvedValue(mockVHost);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
     vi.mocked(policiesApi.listRuleOverrides).mockResolvedValue(mockOverrides);
 
     renderPage();

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -15,7 +15,7 @@ import {
   type RuleOverrideModalState,
 } from "@/features/policies/RuleOverrideModals";
 import type { RuleOverride } from "@/features/policies/types";
-import { getVHost, listPolicies, updateVHost } from "@/features/vhosts/api";
+import { getVHost, listAllPolicies, updateVHost } from "@/features/vhosts/api";
 import type { Policy, VHostDetail } from "@/features/vhosts/types";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
@@ -61,7 +61,7 @@ export function VHostDetailPage() {
 
     Promise.all([
       getVHost(accessToken, parsedVHostId, controller.signal),
-      listPolicies(accessToken, controller.signal),
+      listAllPolicies(accessToken, controller.signal),
     ])
       .then(async ([vhostDetail, policyList]) => {
         let overrides: RuleOverride[] = [];

--- a/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
@@ -43,6 +43,18 @@ const mockVHosts = [
 ];
 
 const mockPolicies = [{ id: 1, name: "Default" }];
+const mockVHostListResponse = {
+  items: mockVHosts,
+  total: 1,
+  page: 1,
+  per_page: 50,
+};
+const emptyVHostListResponse = {
+  items: [],
+  total: 0,
+  page: 1,
+  per_page: 50,
+};
 
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
@@ -60,15 +72,15 @@ function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
 describe("VHostsPage", () => {
   it("shows loading state initially", () => {
     vi.mocked(vhostsApi.listVHosts).mockReturnValue(new Promise(() => undefined));
-    vi.mocked(vhostsApi.listPolicies).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(vhostsApi.listAllPolicies).mockReturnValue(new Promise(() => undefined));
 
     renderPage();
     expect(screen.getByText(/loading virtual hosts/i)).toBeInTheDocument();
   });
 
   it("renders rows from API response", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
 
@@ -81,7 +93,7 @@ describe("VHostsPage", () => {
 
   it("shows error state and retry button on failure", async () => {
     vi.mocked(vhostsApi.listVHosts).mockRejectedValue(new Error("Network error"));
-    vi.mocked(vhostsApi.listPolicies).mockRejectedValue(new Error("Network error"));
+    vi.mocked(vhostsApi.listAllPolicies).mockRejectedValue(new Error("Network error"));
 
     renderPage();
 
@@ -92,19 +104,19 @@ describe("VHostsPage", () => {
   });
 
   it("shows empty state when no vhosts", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue([]);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue([]);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(emptyVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue([]);
 
     renderPage();
 
     await waitFor(() =>
-      expect(screen.getByText(/no virtual hosts yet/i)).toBeInTheDocument(),
+      expect(screen.getByText(/no virtual hosts found/i)).toBeInTheDocument(),
     );
   });
 
   it("admin sees New vhost button and Edit/Delete actions", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage({ hasRole: vi.fn().mockReturnValue(true) });
 
@@ -117,8 +129,8 @@ describe("VHostsPage", () => {
   });
 
   it("viewer does not see New vhost button or Edit/Delete actions", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage({ hasRole: vi.fn().mockReturnValue(false) });
 
@@ -131,8 +143,8 @@ describe("VHostsPage", () => {
   });
 
   it("navigates to the vhost detail page when a row is clicked", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage();
 
@@ -145,8 +157,8 @@ describe("VHostsPage", () => {
   });
 
   it("does not navigate when row action buttons are clicked", async () => {
-    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies).mockResolvedValue(mockPolicies);
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
 
     renderPage({ hasRole: vi.fn().mockReturnValue(true) });
 
@@ -162,8 +174,8 @@ describe("VHostsPage", () => {
   it("retry button calls refresh after error", async () => {
     vi.mocked(vhostsApi.listVHosts)
       .mockRejectedValueOnce(new Error("Network error"))
-      .mockResolvedValue(mockVHosts);
-    vi.mocked(vhostsApi.listPolicies)
+      .mockResolvedValue(mockVHostListResponse);
+    vi.mocked(vhostsApi.listAllPolicies)
       .mockRejectedValueOnce(new Error("Network error"))
       .mockResolvedValue(mockPolicies);
 
@@ -175,6 +187,39 @@ describe("VHostsPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));
     await waitFor(() =>
       expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+  });
+
+  it("requests the next page and filters by domain search", async () => {
+    vi.mocked(vhostsApi.listVHosts).mockResolvedValue({
+      ...mockVHostListResponse,
+      total: 75,
+    });
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText("app.example.com")).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() =>
+      expect(vhostsApi.listVHosts).toHaveBeenLastCalledWith(
+        "test-token",
+        { page: 2, per_page: 50, q: undefined },
+        expect.any(AbortSignal),
+      ),
+    );
+
+    await userEvent.type(screen.getByLabelText(/search virtual hosts/i), "api");
+
+    await waitFor(() =>
+      expect(vhostsApi.listVHosts).toHaveBeenLastCalledWith(
+        "test-token",
+        { page: 1, per_page: 50, q: "api" },
+        expect.any(AbortSignal),
+      ),
     );
   });
 });

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { DeleteVHostDialog } from "@/features/vhosts/DeleteVHostDialog";
 import { VHostFormModal } from "@/features/vhosts/VHostFormModal";
 import { useVHosts } from "@/features/vhosts/use-vhosts";
@@ -25,9 +26,23 @@ type ModalState =
 export function VHostsPage() {
   const navigate = useNavigate();
   const { hasRole } = useAuth();
-  const { vhosts, policies, policyNameById, isLoading, error, refresh } = useVHosts();
+  const {
+    vhosts,
+    total,
+    page,
+    pageSize,
+    searchQuery,
+    policies,
+    policyNameById,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  } = useVHosts();
   const [modal, setModal] = useState<ModalState>(null);
   const isAdmin = hasRole("admin");
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   function closeAndRefresh() {
     setModal(null);
@@ -132,7 +147,19 @@ export function VHostsPage() {
         }
       />
 
-      <SectionCard title="Registered hosts" description="All configured virtual hosts and their current status.">
+      <SectionCard
+        title="Registered hosts"
+        description="All configured virtual hosts and their current status."
+        actions={
+          <Input
+            aria-label="Search virtual hosts"
+            className="w-full sm:w-72"
+            placeholder="Search domains"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
+        }
+      >
         {isLoading ? (
           <LoadingState label="Loading virtual hosts…" />
         ) : error ? (
@@ -150,14 +177,42 @@ export function VHostsPage() {
             }
           />
         ) : (
-          <DataTable
-            columns={columns}
-            rows={vhosts}
-            getRowKey={(row) => String(row.id)}
-            onRowClick={(row) => navigate(getVHostDetailPath(row.id))}
-            emptyTitle="No virtual hosts yet"
-            emptyDescription="Create your first virtual host to start routing traffic through Guard Proxy."
-          />
+          <>
+            <DataTable
+              columns={columns}
+              rows={vhosts}
+              getRowKey={(row) => String(row.id)}
+              onRowClick={(row) => navigate(getVHostDetailPath(row.id))}
+              emptyTitle="No virtual hosts found"
+              emptyDescription="Create a virtual host or adjust the search query."
+            />
+
+            {total > 0 && (
+              <div className="mt-4 flex items-center justify-between gap-4">
+                <span className="text-sm text-muted-foreground">
+                  Page {page} of {totalPages} · {total} virtual hosts
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page - 1)}
+                    disabled={page <= 1}
+                    variant="outline"
+                  >
+                    Prev
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page + 1)}
+                    disabled={page >= totalPages}
+                    variant="outline"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
         )}
       </SectionCard>
 


### PR DESCRIPTION
## Summary
- Add server-side pagination and search to `GET /vhosts` and `GET /policies`.
- Update frontend vhost and policy pages to consume `{ items, total, page, per_page }`, including search and Prev/Next controls.
- Update dependent frontend callers, lab scripts, tests, and course handoff documentation for the new response shape.

## Validation
- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`
- Focused affected Vitest suites
- `git diff --check`
- HAProxy config validated with the repo-local Coraza SPOE config path substituted for the container-only `/usr/local/etc/haproxy/coraza.cfg` path.

Closes #127
