### PR TITLE
test(logs): cover policy filter selection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,10 @@ machine-readable degraded reason header.
    `transaction.id`; the backend returns `200` for a duplicate rather than
    creating a second row.
 5. FastAPI validates and normalizes payloads into the persisted `Log` model.
+   During ingest, the backend resolves the current vhost row by domain and stores
+   nullable `vhost_id` and `policy_id` snapshots on the log row. `GET /logs`
+   policy filtering uses the stored `logs.policy_id`, so results reflect the
+   policy assignment captured at event-ingest time, not a later vhost reassignment.
 6. `GET /logs` exposes stored events for the admin panel log viewer.
 
 ### Log Retention

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -173,6 +173,26 @@ describe("LogsPage", () => {
     );
   });
 
+  it("selecting a policy filter re-fetches with policy_id", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+    await userEvent.selectOptions(screen.getByLabelText(/^policy$/i), "1");
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    await waitFor(() =>
+      expect(vi.mocked(logsApi.listLogs)).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ policy_id: 1, page: 1 }),
+        expect.anything(),
+      ),
+    );
+  });
+
   it("applies the new severity, method, source IP, rule ID and min score filters", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
     vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
@@ -248,12 +268,13 @@ describe("LogsPage", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /filters/i }));
     await userEvent.type(screen.getByLabelText(/vhost/i), "something");
+    await userEvent.selectOptions(screen.getByLabelText(/^policy$/i), "1");
     await userEvent.click(screen.getByRole("button", { name: /clear/i }));
 
     await waitFor(() =>
       expect(vi.mocked(logsApi.listLogs)).toHaveBeenLastCalledWith(
         "test-token",
-        expect.objectContaining({ vhost: undefined, page: 1 }),
+        expect.objectContaining({ vhost: undefined, policy_id: undefined, page: 1 }),
         expect.anything(),
       ),
     );


### PR DESCRIPTION
## Summary

- Document that log policy filtering uses the stored `logs.policy_id` snapshot captured at ingest time.
- Add frontend coverage for selecting the Policy filter and clearing it back to empty request params.

Closes #194

## Validation

- `uv run pytest tests/integration/test_logs_router.py`
- `pnpm exec vitest run src/pages/logs/LogsPage.test.tsx`
- `uv run pytest --cov=app`
- `uv run mypy app/`
- `uv run ruff check app/`
- `pnpm run type-check`
- `pnpm run lint`

## Note

- `haproxy -c -f configs/haproxy/haproxy.cfg` could not complete on this host because HAProxy expects `/usr/local/etc/haproxy/coraza.cfg`, while this checkout has the referenced file at `configs/haproxy/coraza.cfg` and creating the `/usr/local/etc` path is blocked by local permissions.