### PR TITLE
fix(frontend): align form control text states

### DIFF
--- a/src/frontend/src/components/ui/form-controls.test.tsx
+++ b/src/frontend/src/components/ui/form-controls.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+describe("form controls", () => {
+  it("uses muted text on input placeholders", () => {
+    render(<Input aria-label="Domain" placeholder="example.com" />);
+
+    expect(screen.getByLabelText("Domain")).toHaveClass("placeholder:text-muted-foreground");
+  });
+
+  it("sets muted colors for select text and native options", () => {
+    render(
+      <Select aria-label="Policy" defaultValue="">
+        <option value="">None</option>
+      </Select>,
+    );
+
+    expect(screen.getByLabelText("Policy")).toHaveClass(
+      "text-muted-foreground",
+      "[&>option]:bg-background",
+      "[&>option]:text-muted-foreground",
+    );
+  });
+});

--- a/src/frontend/src/components/ui/select.tsx
+++ b/src/frontend/src/components/ui/select.tsx
@@ -9,7 +9,7 @@ const Select = React.forwardRef<
   <select
     ref={ref}
     className={cn(
-      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground shadow-sm transition-colors hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>option]:bg-background [&>option]:text-muted-foreground",
       className,
     )}
     {...props}

--- a/src/frontend/src/features/policies/CustomRuleModals.tsx
+++ b/src/frontend/src/features/policies/CustomRuleModals.tsx
@@ -22,6 +22,7 @@ import type {
 import { CUSTOM_RULE_ID_MAX, CUSTOM_RULE_ID_MIN } from "@/features/policies/types";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
 
 export type CustomRuleModalState =
   | null
@@ -278,7 +279,10 @@ export function CustomRuleFormModal({
             checked={isActive}
             onChange={(e) => setIsActive(e.target.checked)}
           />
-          <Label htmlFor="custom-rule-is-active" className="text-foreground">
+          <Label
+            htmlFor="custom-rule-is-active"
+            className={cn(isActive && "text-foreground")}
+          >
             Active
           </Label>
         </div>

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
 
 import { createPolicy, updatePolicy } from "./api";
 import type { Policy } from "./types";
@@ -185,7 +186,7 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
         </div>
 
         {props.mode === "edit" && (
-          <Label className="flex cursor-pointer items-center gap-2">
+          <Label className={cn("flex cursor-pointer items-center gap-2", isActive && "text-foreground")}>
             <Checkbox
               checked={isActive}
               onChange={(e) => setIsActive(e.target.checked)}

--- a/src/frontend/src/features/vhosts/VHostFormModal.test.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.test.tsx
@@ -110,4 +110,15 @@ describe("VHostFormModal (create)", () => {
       expect(screen.getByRole("alert")).toHaveTextContent("Domain already exists"),
     );
   });
+
+  it("uses foreground text for checked checkbox labels", async () => {
+    renderCreateModal();
+
+    expect(screen.getByText("Health checks")).toHaveClass("text-foreground");
+    expect(screen.getByText("Enable SSL")).not.toHaveClass("text-foreground");
+
+    await userEvent.click(screen.getByLabelText("Enable SSL"));
+
+    expect(screen.getByText("Enable SSL")).toHaveClass("text-foreground");
+  });
 });

--- a/src/frontend/src/features/vhosts/VHostFormModal.tsx
+++ b/src/frontend/src/features/vhosts/VHostFormModal.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
 
 import { createVHost, updateVHost } from "./api";
 import type { Policy, VHost, VHostBackendInput } from "./types";
@@ -206,7 +207,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
                 </div>
 
                 <div className="grid gap-3 sm:grid-cols-2">
-                  <Label className="flex cursor-pointer items-center gap-2">
+                  <Label className={cn("flex cursor-pointer items-center gap-2", backend.is_active && "text-foreground")}>
                     <Checkbox
                       checked={backend.is_active}
                       onChange={(e) =>
@@ -215,7 +216,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
                     />
                     Active
                   </Label>
-                  <Label className="flex cursor-pointer items-center gap-2">
+                  <Label className={cn("flex cursor-pointer items-center gap-2", backend.health_check_enabled && "text-foreground")}>
                     <Checkbox
                       checked={backend.health_check_enabled}
                       onChange={(e) =>
@@ -323,7 +324,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
         </div>
 
         <div className="space-y-1.5 pt-2">
-          <Label className="flex cursor-pointer items-center gap-2 font-semibold">
+          <Label className={cn("flex cursor-pointer items-center gap-2 font-semibold", sslEnabled && "text-foreground")}>
             <Checkbox
               checked={sslEnabled}
               onChange={(e) => setSslEnabled(e.target.checked)}
@@ -375,7 +376,7 @@ export function VHostFormModal(props: VHostFormModalProps) {
         </div>
 
         <div className="pt-2">
-          <Label className="flex cursor-pointer items-center gap-2">
+          <Label className={cn("flex cursor-pointer items-center gap-2", isActive && "text-foreground")}>
             <Checkbox
               checked={isActive}
               onChange={(e) => setIsActive(e.target.checked)}

--- a/src/frontend/src/pages/logs/LogsPage.test.tsx
+++ b/src/frontend/src/pages/logs/LogsPage.test.tsx
@@ -239,6 +239,23 @@ describe("LogsPage", () => {
     );
   });
 
+  it("uses muted text for empty date and time filters", async () => {
+    vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
+    vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("app.example.com")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /filters/i }));
+
+    expect(screen.getByText("From")).toHaveClass("text-muted-foreground");
+    expect(screen.getByLabelText("From date")).toHaveClass(
+      "text-muted-foreground",
+      "placeholder:text-muted-foreground",
+    );
+    expect(screen.getByLabelText("From time")).toHaveClass("text-muted-foreground");
+  });
+
   it("clearing filters resets to empty params", async () => {
     vi.mocked(logsApi.listLogs).mockResolvedValue(mockListResponse);
     vi.mocked(vhostsApi.listAllPolicies).mockResolvedValue(mockPolicies);

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -8,6 +8,7 @@ import { LoadingState } from "@/components/shared/LoadingState";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { SectionCard } from "@/components/shared/SectionCard";
 import { StatusBadge } from "@/components/shared/StatusBadge";
+import { Select } from "@/components/ui/select";
 import { listRuleOverrides } from "@/features/policies/api";
 import {
   DeleteRuleOverrideDialog,
@@ -313,11 +314,10 @@ export function VHostDetailPage() {
                   <label htmlFor="vhost-policy-assignment" className="block text-sm font-medium text-fg-muted">
                     Policy
                   </label>
-                  <select
+                  <Select
                     id="vhost-policy-assignment"
                     value={selectedPolicyId}
                     onChange={(e) => setSelectedPolicyId(e.target.value)}
-                    className="input-field"
                   >
                     <option value="">None</option>
                     {policies.map((policy) => (
@@ -325,7 +325,7 @@ export function VHostDetailPage() {
                         {policy.name}
                       </option>
                     ))}
-                  </select>
+                  </Select>
                 </div>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- make select controls use muted text to match empty input placeholders
- replace the legacy vhost policy dropdown with the shared Select component
- make checked checkbox labels switch to foreground text while unchecked labels remain muted
- add regression coverage for form controls, log time-range filters, and vhost checkbox label states

## Validation
- pnpm test
- pnpm run type-check
- pnpm run lint
- uv run --extra dev pytest --cov=app
- uv run --extra dev mypy app/
- uv run --extra dev ruff check app/

## Note
- haproxy -c -f configs/haproxy/haproxy.cfg was attempted locally, but this host cannot resolve /usr/local/etc/haproxy/coraza.cfg referenced by the checked-in config. The repository copy exists at configs/haproxy/coraza.cfg.