### PR TITLE
fix(cli): replace make users target with bin/users wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPOSE_FILE := docker/docker-compose.yml
 COMPOSE_DEBUG_FILE := docker/docker-compose.debug.yml
 ENV_FILE := docker/.env
 
-.PHONY: run dev down clean logs ps seed users coraza-build \
+.PHONY: run dev down clean logs ps seed coraza-build \
         eval-up eval-down eval-clean eval-ftw eval-corpus eval-zap eval-nuclei eval-load eval-metrics eval-all eval-results
 
 run:
@@ -27,14 +27,6 @@ ps:
 
 seed:
 	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/seed_admin.py
-
-ifeq (users,$(firstword $(MAKECMDGOALS)))
-  USERS_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  $(eval $(USERS_ARGS):;@:)
-endif
-
-users:
-	$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) --env-file $(ENV_FILE) exec backend /app/.venv/bin/python scripts/manage_users.py $(if $(USERS_ARGS),$(patsubst help,--help,$(USERS_ARGS)),$(ARGS))
 
 coraza-build:
 	docker build -f docker/coraza.Dockerfile -t guard-proxy/coraza-spoa:dev .

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ make seed      # add the initial admin user (ADMIN_EMAIL / ADMIN_PASSWORD from .
 Additional accounts are managed with the user CLI, e.g.:
 
 ```bash
-make users ARGS="create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice'"
-make users ARGS="list"
+./bin/users create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice'
+./bin/users list
 ```
 
 See [User Management](docs/commands.md#user-management) for all commands.

--- a/bin/users
+++ b/bin/users
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+elif command -v docker >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+else
+  echo "users: Docker Compose is required (install docker-compose or Docker Compose v2)." >&2
+  exit 127
+fi
+
+exec "${COMPOSE[@]}" \
+  -f "$REPO_ROOT/docker/docker-compose.yml" \
+  --env-file "$REPO_ROOT/docker/.env" \
+  exec backend /app/.venv/bin/python scripts/manage_users.py "$@"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,7 +67,7 @@ make seed                                                            # Seed admi
 ## User Management
 
 There is no REST endpoint for managing users; accounts are managed with the
-backend CLI scripts (run inside the backend container via `make`).
+backend CLI (run inside the backend container via `./bin/users`).
 
 ```bash
 # Bootstrap the first admin (idempotent; reads ADMIN_EMAIL / ADMIN_PASSWORD
@@ -75,21 +75,14 @@ backend CLI scripts (run inside the backend container via `make`).
 make seed
 
 # Manage further accounts with the manage_users.py CLI
-make users ARGS="create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice' --role viewer"
-make users ARGS="list"                                # All users (add --json for JSON output)
-make users ARGS="list --role admin --active"          # Filtered list
-make users ARGS="update alice@example.com --role admin"  # Promote by email
-make users ARGS="update 3 --deactivate"               # Deactivate by user ID
-make users ARGS="update 3 --password '<new password>'"   # Reset a password
-
-# Bare subcommands (no --flags) can skip ARGS=, e.g.:
-make users list
-make users help
+./bin/users create --email alice@example.com --password '<min 12 chars>' --full-name 'Alice' --role viewer
+./bin/users list                                # All users (add --json for JSON output)
+./bin/users list --role admin --active          # Filtered list
+./bin/users update alice@example.com --role admin  # Promote by email
+./bin/users update 3 --deactivate               # Deactivate by user ID
+./bin/users update 3 --password '<new password>'   # Reset a password
+./bin/users --help
 ```
-
-Note: any argument starting with `-` (e.g. `--role`, `--active`, `-h`) is
-consumed by `make` itself before it reaches the Makefile, so those must be
-passed via `ARGS="..."` as shown above.
 
 Outside Docker (local backend checkout):
 

--- a/src/backend/scripts/manage_users.py
+++ b/src/backend/scripts/manage_users.py
@@ -13,9 +13,8 @@ Usage (local):
     uv run python scripts/manage_users.py update 3 --deactivate
 
 Usage (Docker):
-    docker-compose ... exec backend /app/.venv/bin/python scripts/manage_users.py <cmd>
-    # or via make:
-    make users ARGS="list --json"
+    ./bin/users create --email alice@example.com --password '<password>' --full-name "Alice"
+    ./bin/users list --role admin --active
 
 See `scripts/manage_users.py <cmd> --help` for per-command details.
 """

--- a/src/backend/tests/unit/test_users_wrapper.py
+++ b/src/backend/tests/unit/test_users_wrapper.py
@@ -1,0 +1,110 @@
+"""Tests for the repository-level Docker user-management wrapper."""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _find_repo_root(start: Path) -> Path:
+    """Return the repository root containing the users wrapper."""
+    for directory in (start, *start.parents):
+        if (directory / "bin" / "users").is_file():
+            return directory
+    raise RuntimeError("Could not locate the repository root")
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve().parent)
+USERS_WRAPPER = REPO_ROOT / "bin" / "users"
+
+
+def _write_fake_command(directory: Path, name: str) -> Path:
+    """Create a command that captures argv and returns a configured exit code."""
+    directory.mkdir(exist_ok=True)
+    command = directory / name
+    command.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\" > \"$CAPTURE_PATH\"\n"
+        'exit "${FAKE_EXIT_CODE:-0}"\n'
+    )
+    command.chmod(command.stat().st_mode | stat.S_IXUSR)
+    return command
+
+
+def _run_wrapper(
+    tmp_path: Path, *arguments: str, exit_code: int = 0
+) -> subprocess.CompletedProcess[str]:
+    """Run the wrapper from another directory against fake Docker commands."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    capture_path = tmp_path / "arguments.txt"
+    environment = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
+        "CAPTURE_PATH": str(capture_path),
+        "FAKE_EXIT_CODE": str(exit_code),
+    }
+    return subprocess.run(
+        [str(USERS_WRAPPER), *arguments],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_users_wrapper_prefers_docker_compose_and_preserves_arguments(
+    tmp_path: Path,
+) -> None:
+    """The wrapper passes all CLI arguments unchanged to docker-compose."""
+    _write_fake_command(tmp_path / "bin", "docker-compose")
+
+    result = _run_wrapper(
+        tmp_path,
+        "create",
+        "--email",
+        "alice@example.com",
+        "--password",
+        "correct horse battery staple",
+        "--full-name",
+        "Alice Example",
+        "--role",
+        "viewer",
+    )
+
+    assert result.returncode == 0
+    assert (tmp_path / "arguments.txt").read_text().splitlines() == [
+        "-f",
+        str(REPO_ROOT / "docker" / "docker-compose.yml"),
+        "--env-file",
+        str(REPO_ROOT / "docker" / ".env"),
+        "exec",
+        "backend",
+        "/app/.venv/bin/python",
+        "scripts/manage_users.py",
+        "create",
+        "--email",
+        "alice@example.com",
+        "--password",
+        "correct horse battery staple",
+        "--full-name",
+        "Alice Example",
+        "--role",
+        "viewer",
+    ]
+
+
+def test_users_wrapper_falls_back_to_docker_compose_v2_and_preserves_exit_code(
+    tmp_path: Path,
+) -> None:
+    """The wrapper uses `docker compose` when docker-compose is unavailable."""
+    _write_fake_command(tmp_path / "bin", "docker")
+
+    result = _run_wrapper(tmp_path, "list", "--json", exit_code=23)
+
+    assert result.returncode == 23
+    assert (tmp_path / "arguments.txt").read_text().splitlines()[:2] == [
+        "compose",
+        "-f",
+    ]


### PR DESCRIPTION
## Summary
- Replace the `make users ARGS="..."` convenience target with a `bin/users` shell wrapper
- `make` was consuming any argument starting with `-` before it reached the Makefile, forcing awkward `ARGS="..."` quoting for flags like `--role`, `--active`, `-h`
- `bin/users` execs `docker-compose` (falling back to `docker compose`) directly against the backend container, passing all arguments through unchanged
- Update README.md, docs/commands.md, and the `manage_users.py` docstring to reference `./bin/users` instead of `make users ARGS="..."`

## Test plan
- [x] `uv run pytest tests/unit/test_users_wrapper.py` — covers both the `docker-compose` and `docker compose` fallback paths, and exit code passthrough