### PR TITLE
chore(release): add v0.1.0-beta.1 image release kit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,8 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/guard-proxy-${{ matrix.image.name }}
           tags: |
             type=ref,event=tag
-            type=raw,value=alpha
+            type=raw,value=alpha,enable=${{ !contains(github.ref, '-beta.') }}
+            type=raw,value=beta,enable=${{ contains(github.ref, '-beta.') }}
             type=sha,format=short
 
       - name: Set up Docker Buildx
@@ -65,3 +66,32 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+  release-kit:
+    name: release-kit
+    needs: publish
+    if: contains(github.ref, '-beta.')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Derive release tag
+        id: tag
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release-kit archive
+        run: |
+          mkdir -p dist
+          tar -czf "dist/guard-proxy-release-${{ steps.tag.outputs.tag }}.tar.gz" \
+            -C release .
+
+      - name: Create GitHub prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          prerelease: true
+          files: dist/guard-proxy-release-${{ steps.tag.outputs.tag }}.tar.gz
+          generate_release_notes: true

--- a/release/.env.example
+++ b/release/.env.example
@@ -1,0 +1,44 @@
+# Copy this file to .env before running docker compose.
+# Replace every placeholder value below — these are NOT safe defaults.
+
+# Image to pull. GUARD_PROXY_IMAGE_TAG must match a published release tag,
+# e.g. v0.1.0-beta.1. GUARD_PROXY_IMAGE_REPO only needs to change if you are
+# pulling from a fork or a private mirror.
+GUARD_PROXY_IMAGE_REPO=ghcr.io/bihius
+GUARD_PROXY_IMAGE_TAG=v0.1.0-beta.1
+
+POSTGRES_USER=guard_proxy
+POSTGRES_PASSWORD=change-me-generate-a-strong-password
+POSTGRES_DB=guard_proxy
+
+# Generate with `openssl rand -hex 32` or similar. Rotating either secret
+# invalidates existing sessions / the log-shipper's ingest auth.
+JWT_SECRET_KEY=change-me-generate-a-strong-secret
+LOG_INGEST_SHARED_SECRET=change-me-generate-a-strong-secret
+
+# JSON array of origins allowed to make cross-origin requests to the backend.
+# Set this to the URL(s) you will access the admin UI from.
+CORS_ORIGINS=["https://admin.example.com"]
+
+# Optional log-shipper tuning (defaults shown)
+# SHIPPER_POLL_INTERVAL=1
+# SHIPPER_BACKOFF_BASE=1
+# SHIPPER_BACKOFF_MAX=30
+# SHIPPER_REQUEST_TIMEOUT=5
+
+# Number of days to keep log rows before the retention cleanup removes them.
+# LOG_RETENTION_DAYS=30
+
+# Used once, by the `docker compose exec backend ... seed_admin.py` command
+# in the install guide, to create the first admin login. Not read at
+# container startup. Password must be at least 12 characters.
+# ADMIN_EMAIL=admin@example.com
+# ADMIN_PASSWORD=change-me-generate-a-strong-password
+# ADMIN_FULL_NAME=Administrator
+
+# Ports HAProxy exposes on the host.
+HAPROXY_HTTP_PORT=80
+HAPROXY_HTTPS_PORT=443
+
+# Port the admin frontend is exposed on (host:container 5173).
+FRONTEND_PORT=3000

--- a/release/.env.example
+++ b/release/.env.example
@@ -29,9 +29,10 @@ CORS_ORIGINS=["https://admin.example.com"]
 # Number of days to keep log rows before the retention cleanup removes them.
 # LOG_RETENTION_DAYS=30
 
-# Used once, by the `docker compose exec backend ... seed_admin.py` command
-# in the install guide, to create the first admin login. Not read at
-# container startup. Password must be at least 12 characters.
+# Not read at container startup. The install guide's seed_admin.py step
+# passes ADMIN_EMAIL/ADMIN_PASSWORD via `docker compose exec -e ...` instead
+# of setting them here, so a plaintext admin password isn't left at rest —
+# leave these commented out.
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASSWORD=change-me-generate-a-strong-password
 # ADMIN_FULL_NAME=Administrator

--- a/release/README.md
+++ b/release/README.md
@@ -22,9 +22,9 @@ between beta releases yet — back up `pgdata` before upgrading. See
 ## 1. Get the release kit
 
 Download and extract the `guard-proxy-release-v0.1.0-beta.1.tar.gz` asset
-from the [GitHub Releases page](../../releases), or copy this `release/`
-directory if you already have the repository checked out. You should end
-up with:
+from the [GitHub Releases page](https://github.com/bihius/guard-proxy/releases),
+or copy this `release/` directory if you already have the repository
+checked out. You should end up with:
 
 ```
 guard-proxy-release/
@@ -67,12 +67,20 @@ docker compose ps    # wait for all services to report healthy
 ```
 
 Create the first admin account (idempotent — safe to re-run, it skips if
-an admin already exists):
+an admin already exists). Use the `ADMIN_EMAIL`/`ADMIN_PASSWORD` env vars
+rather than `--email`/`--password` flags, so the password isn't written to
+your shell history:
 
 ```sh
-docker compose exec backend /app/.venv/bin/python scripts/seed_admin.py \
-  --email you@example.com --password 'a-strong-password-here'
+docker compose exec \
+  -e ADMIN_EMAIL=you@example.com \
+  -e ADMIN_PASSWORD='a-strong-password-here' \
+  backend /app/.venv/bin/python scripts/seed_admin.py
 ```
+
+If you set `ADMIN_EMAIL`/`ADMIN_PASSWORD` in `.env` instead, remove them
+again after the account is created — they aren't read at container
+startup, so leaving them there only leaves a plaintext password at rest.
 
 Log in to the admin UI at `http://<host>:${FRONTEND_PORT:-3000}` (or
 through HAProxy on port 80/443, once you've added a vhost — see below).

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,111 @@
+# Guard Proxy — beta install guide
+
+This release kit runs Guard Proxy from prebuilt images published to GHCR.
+It does not require cloning the source repository or building anything
+locally.
+
+**Beta status.** This is a pre-release build for early testers. Expect
+rough edges. Ban/rate-limit state, generated configs, and the database are
+all persisted in Docker volumes, but no upgrade-path guarantees are made
+between beta releases yet — back up `pgdata` before upgrading. See
+[Known limitations](#known-limitations) and
+[Reporting feedback](#reporting-feedback) below.
+
+## Requirements
+
+- Docker Engine with the Compose plugin (`docker compose version` prints
+  something).
+- A domain or hostname you control, pointed at the machine you're
+  deploying to, if you want HTTPS via the app's built-in cert flow.
+  HTTP-only testing works with `localhost` too.
+
+## 1. Get the release kit
+
+Download and extract the `guard-proxy-release-v0.1.0-beta.1.tar.gz` asset
+from the [GitHub Releases page](../../releases), or copy this `release/`
+directory if you already have the repository checked out. You should end
+up with:
+
+```
+guard-proxy-release/
+├── docker-compose.yml
+├── .env.example
+└── haproxy/
+    ├── haproxy.cfg
+    └── coraza.cfg
+```
+
+## 2. Configure
+
+```sh
+cd guard-proxy-release
+cp .env.example .env
+```
+
+Edit `.env` and replace every `change-me` placeholder:
+
+- `GUARD_PROXY_IMAGE_TAG` — pin this to the release you're installing,
+  e.g. `v0.1.0-beta.1`. Do not use a mutable tag like `beta` for anything
+  you want to reproduce later.
+- `POSTGRES_PASSWORD`, `JWT_SECRET_KEY`, `LOG_INGEST_SHARED_SECRET` —
+  generate real secrets, e.g. `openssl rand -hex 32`.
+- `CORS_ORIGINS` — the URL(s) you'll open the admin UI from.
+- `HAPROXY_HTTP_PORT` / `HAPROXY_HTTPS_PORT` / `FRONTEND_PORT` — adjust if
+  80/443/3000 are already in use on the host.
+
+`haproxy/haproxy.cfg` and `haproxy/coraza.cfg` are the seed configuration
+HAProxy boots with before you configure anything. Once you apply your
+first configuration from the admin UI (see step 4), Guard Proxy generates
+and reloads its own HAProxy config from the database — you generally
+don't need to hand-edit these files.
+
+## 3. Start the stack
+
+```sh
+docker compose up -d
+docker compose ps    # wait for all services to report healthy
+```
+
+Create the first admin account (idempotent — safe to re-run, it skips if
+an admin already exists):
+
+```sh
+docker compose exec backend /app/.venv/bin/python scripts/seed_admin.py \
+  --email you@example.com --password 'a-strong-password-here'
+```
+
+Log in to the admin UI at `http://<host>:${FRONTEND_PORT:-3000}` (or
+through HAProxy on port 80/443, once you've added a vhost — see below).
+
+## 4. Configure your first vhost
+
+In the admin UI: add a vhost pointing at your real origin server, set up
+a WAF policy, then use **Apply configuration**. This validates and
+generates a new HAProxy config from the database and reloads HAProxy with
+it — the static `haproxy.cfg` seed is replaced at that point.
+
+## Upgrading
+
+1. Read the release notes for the target version — note any migration or
+   breaking-change callouts.
+2. Back up the `pgdata` volume (`docker compose exec postgres pg_dump ...`
+   or a volume snapshot) before upgrading, out of caution during beta.
+3. Update `GUARD_PROXY_IMAGE_TAG` in `.env` to the new version.
+4. `docker compose pull && docker compose up -d`. The backend runs
+   `alembic upgrade head` automatically on startup.
+
+## Known limitations
+
+- Beta status: expect bugs; APIs and config formats may still change
+  between beta releases.
+- No automated upgrade testing between beta versions yet — back up before
+  upgrading.
+- Single-node only; no HA/clustering.
+- DDoS/rate-limit protection ships in a later beta (tracked as issue
+  #176) and is not present in this release.
+
+## Reporting feedback
+
+Please file issues on the project's GitHub Issues page, including your
+`GUARD_PROXY_IMAGE_TAG`, `docker compose logs <service>` output for the
+affected service, and steps to reproduce.

--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -1,0 +1,164 @@
+name: guard-proxy
+
+# Image-only release stack for Guard Proxy beta testers.
+#
+# This file pulls prebuilt images from GHCR instead of building from
+# source. Set GUARD_PROXY_IMAGE_TAG (see .env.example) to the release
+# you want to run, e.g. v0.1.0-beta.1.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    networks:
+      - gp_internal
+
+  backend:
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-backend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.1}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}"
+      RUNTIME_GENERATED_CONFIG_ROOT: /var/lib/guard-proxy/generated
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/ready', timeout=2)\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+    volumes:
+      - backend_logs:/var/log/guard-proxy
+      - ./haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
+      - generated_config:/var/lib/guard-proxy/generated
+      - haproxy_runtime:/var/run/haproxy
+    networks:
+      - gp_internal
+
+  frontend:
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-frontend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.1}
+    restart: unless-stopped
+    environment:
+      # Explicit base URL is optional. If unset, the frontend uses relative
+      # paths and expects HAProxy to route /api/v1 to the backend.
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${FRONTEND_PORT:-3000}:5173"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:5173 >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - gp_edge
+      - gp_internal
+
+  coraza:
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-coraza:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.1}
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    volumes:
+      - generated_config:/runtime:ro
+      - coraza_audit:/var/log/coraza
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "9000"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - gp_internal
+
+  log-shipper:
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-log-shipper:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.1}
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      INGEST_URL: "http://backend:8000/logs/ingest"
+      CORAZA_AUDIT_LOG: "/var/log/coraza/audit.log"
+      SHIPPER_STATE_FILE: "/var/lib/log-shipper/offset"
+    depends_on:
+      backend:
+        condition: service_healthy
+      coraza:
+        condition: service_healthy
+    volumes:
+      - coraza_audit:/var/log/coraza:ro
+      - shipper_state:/var/lib/log-shipper
+    networks:
+      - gp_internal
+
+  haproxy:
+    image: haproxy:3.0-alpine
+    user: "0:0"
+    command:
+      [
+        "sh",
+        "-c",
+        "set -eu; if [ ! -f /etc/haproxy/generated/current/haproxy.cfg ]; then mkdir -p /etc/haproxy/generated/releases/seed; cp /usr/local/etc/haproxy/haproxy.cfg /etc/haproxy/generated/releases/seed/haproxy.cfg; ln -sfn releases/seed /etc/haproxy/generated/current; fi; exec haproxy -W -S /var/run/haproxy/master.sock,mode,666,level,operator -f /etc/haproxy/generated/current/haproxy.cfg",
+      ]
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+      coraza:
+        condition: service_started
+    ports:
+      - "${HAPROXY_HTTP_PORT:-80}:80"
+      - "${HAPROXY_HTTPS_PORT:-443}:443"
+    volumes:
+      - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+      - ./haproxy/coraza.cfg:/usr/local/etc/haproxy/coraza.cfg:ro
+      - haproxy_logs:/var/log/haproxy
+      - generated_config:/etc/haproxy/generated
+      - haproxy_runtime:/var/run/haproxy
+    healthcheck:
+      test: ["CMD-SHELL", "haproxy -c -f /etc/haproxy/generated/current/haproxy.cfg"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - gp_edge
+      - gp_internal
+
+networks:
+  gp_edge:
+    driver: bridge
+  gp_internal:
+    driver: bridge
+
+volumes:
+  pgdata:
+  haproxy_logs:
+  haproxy_runtime:
+  backend_logs:
+  generated_config:
+  coraza_audit:
+  shipper_state:

--- a/release/haproxy/coraza.cfg
+++ b/release/haproxy/coraza.cfg
@@ -1,0 +1,41 @@
+# SPOE engine configuration for the Coraza SPOA.
+#
+# This file is referenced from haproxy.cfg via:
+#   filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
+#
+# Section name "[coraza]" must match the engine name passed to the
+# filter directive. The SPOA itself is reached through the
+# "coraza-spoa" backend defined in haproxy.cfg.
+
+[coraza]
+
+spoe-agent coraza-agent
+    # Groups this agent is allowed to send.
+    groups              coraza-req
+
+    # All variables produced by the agent are exposed under
+    # txn.coraza.*  (e.g. txn.coraza.action, txn.coraza.score).
+    option              var-prefix  coraza
+
+    # If the SPOA is unreachable or replies with an error, mark the
+    # transaction as errored by setting txn.coraza.error=1.
+    # haproxy.cfg checks this variable and returns 503 (fail-closed).
+    option              set-on-error  error
+
+    # SPOE handshake / idle / per-request timeouts. Keep processing
+    # tight so a slow WAF cannot block the request path indefinitely.
+    timeout hello       2s
+    timeout idle        2m
+    timeout processing  500ms
+
+    use-backend         coraza-spoa
+    log                 global
+
+# Sent once per HTTP request. The argument names on the right hand
+# side are HAProxy fetches; the names on the left hand side are what
+# the Coraza SPOA expects.
+spoe-message coraza-req
+    args app=str(default) id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body exportRuleIDs=bool(false)
+
+spoe-group coraza-req
+    messages            coraza-req

--- a/release/haproxy/haproxy.cfg
+++ b/release/haproxy/haproxy.cfg
@@ -1,0 +1,98 @@
+# Guard Proxy HAProxy configuration.
+# Generated from the policy database; manual edits are overwritten on the
+# next config apply.
+
+global
+    log stdout format raw local0 info
+    maxconn 2000
+    # Operator level avoids exposing administrative Runtime API commands.
+    stats socket /tmp/haproxy.sock mode 660 level operator
+
+defaults
+    mode http
+    log global
+    option httplog
+    option dontlognull
+    timeout connect 5s
+    timeout client  30s
+    timeout server  30s
+
+frontend fe_http
+    bind *:80
+    # Correlate log lines and SPOE frames.
+    unique-id-format %[uuid()]
+    unique-id-header X-Request-ID
+    acl is_health path /health
+    http-request set-log-level silent if is_health
+
+    # Let's Encrypt HTTP-01 challenges bypass the unknown-host deny rule.
+    acl is_acme path_beg /.well-known/acme-challenge/
+
+    # Reject unknown hosts before WAF inspection. The request port is
+    # stripped from Host so app.local:8080 still matches app.local.
+
+    acl host_app hdr(host),field(1,:) -i app.local localhost 127.0.0.1
+
+
+    http-request deny deny_status 421 if !host_app !is_acme
+
+
+    # Redirect to HTTPS for SSL-enabled vhosts.
+
+
+
+
+    # Overwrite client-supplied X-Forwarded-For so the backend rate limiter
+    # cannot be bypassed by header spoofing.
+    http-request set-header X-Forwarded-For %[src]
+
+    # Fail closed (503) when HAProxy has no usable Coraza SPOA server.
+    http-request set-var(txn.waf_degraded_reason) str(coraza-unavailable) if !is_health { nbsrv(coraza-spoa) eq 0 }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason coraza-unavailable if { var(txn.waf_degraded_reason) -m str coraza-unavailable }
+
+    # WAF inspection via the Coraza SPOA ("coraza" matches coraza.cfg).
+    filter spoe engine coraza config /usr/local/etc/haproxy/coraza.cfg
+    http-request send-spoe-group coraza coraza-req unless is_health
+
+    # Fail closed (503) when SPOE processing starts but fails.
+    http-request set-var(txn.waf_degraded_reason) str(spoe-processing-error) if { var(txn.coraza.error) -m found }
+    http-request set-log-level err if { var(txn.waf_degraded_reason) -m found }
+    http-request capture var(txn.waf_degraded_reason) len 32 if { var(txn.waf_degraded_reason) -m found }
+    http-request return status 503 content-type text/plain string "WAF inspection unavailable" hdr X-WAF-Status degraded hdr X-WAF-Degraded-Reason spoe-processing-error hdr X-WAF-Error-Code %[var(txn.coraza.error)] if { var(txn.coraza.error) -m found }
+
+    # Block requests the WAF denies.
+    http-request deny deny_status 403 if { var(txn.coraza.action) -m str deny }
+
+    use_backend backend_acme if is_acme
+
+    use_backend be_app if host_app
+
+
+
+
+
+# --- Application backends ----------------------------------------
+
+backend be_app
+    option httpchk GET /
+    # Accept 200-499 so apps without a dedicated health endpoint still pass;
+    # only 5xx/connection failures mark a backend down.
+    http-check expect status 200-499
+    # init-addr lets `haproxy -c` succeed when the DNS name is unresolvable.
+    server app backend:8000 check inter 5s fall 3 rise 2 init-addr last,libc,none
+
+
+
+# The Coraza SPOA speaks SPOP (binary) over TCP; no HTTP check.
+backend coraza-spoa
+    mode tcp
+    option spop-check
+    timeout connect 5s
+    timeout server  3m
+    server coraza coraza:9000 check inter 2s fall 3 rise 2 init-addr last,libc,none
+
+# Certbot backend for ACME HTTP-01 challenges.
+backend backend_acme
+    server certbot backend:8888 init-addr last,libc,none

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-backend"
-version = "0.1.0a0"
+version = "0.1.0b1"
 description = "Guard Proxy — admin panel REST API"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-backend"
-version = "0.1.0a0"
+version = "0.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guard-proxy-frontend",
   "private": true,
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-beta.1",
   "type": "module",
   "packageManager": "pnpm@10.30.0",
   "scripts": {

--- a/src/log-shipper/pyproject.toml
+++ b/src/log-shipper/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-log-shipper"
-version = "0.1.0a0"
+version = "0.1.0b1"
 description = "Guard Proxy — Coraza audit log to ingest endpoint sidecar"
 requires-python = ">=3.13"
 dependencies = []   # runtime: stdlib only

--- a/src/log-shipper/uv.lock
+++ b/src/log-shipper/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-log-shipper"
-version = "0.1.0a0"
+version = "0.1.0b1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump backend, log-shipper, and frontend versions to their 0.1.0 beta1 releases.
- Add an image-only Compose release kit under `release/` (manifest pulling prebuilt GHCR images, env template, HAProxy reference config, install/upgrade guide) so testers can run Guard Proxy without building from source.
- Extend `publish.yml` so a `v*-beta.*` tag publishes images on the mutable `beta` channel (instead of `alpha`) plus the immutable version/SHA tags, and attaches a release-kit archive to a GitHub prerelease.

## Test plan
- [x] `pytest --cov=app` (527 passed, 90% coverage)
- [x] `mypy app/` (clean)
- [x] `ruff check app/` (pre-existing unrelated failure in `scripts/manage_users.py` on `main`, not touched here)
- [x] `pnpm run type-check` / `pnpm run lint` / `pnpm run test` (107 passed)
- [x] `haproxy -c` structural check — `release/haproxy/*.cfg` confirmed byte-identical to the already-validated `configs/haproxy/*.cfg`
- [x] `docker compose config` validation of `release/docker-compose.yml`
- [ ] Tag push → image publish → anonymous `docker pull` verification (requires pushing `v0.1.0-beta.1`, done after this PR merges)
- [ ] Release-kit startup smoke test against published images