### PR TITLE
fix(release): give the release-kit Compose stack its own project name

### DIFF
--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -1,4 +1,4 @@
-name: guard-proxy
+name: guard-proxy-release
 
 # Image-only release stack for Guard Proxy beta testers.
 #


### PR DESCRIPTION
## Summary
- `release/docker-compose.yml` reused the `guard-proxy` project name, colliding with `docker/docker-compose.yml`'s containers/volumes on a machine that also has a source checkout.

## Test plan
- [x] Discovered and reproduced during the v0.1.0-beta.1 release-kit smoke test: starting the release kit under the shared project name reused the dev stack's `pgdata` volume (auth failure against a differently-seeded password) and replaced its running containers.
- [x] Re-ran the smoke test under `-p guard-proxy-release-smoketest` (now the default via `name:`) — all 5 services became healthy, frontend/backend/HAProxy responded correctly, dev stack volumes were left untouched.