### PR TITLE
ci(release): drop alpha channel, publish stable to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/guard-proxy-${{ matrix.image.name }}
           tags: |
             type=ref,event=tag
-            type=raw,value=alpha,enable=${{ !contains(github.ref, '-beta.') }}
             type=raw,value=beta,enable=${{ contains(github.ref, '-beta.') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
             type=sha,format=short
 
       - name: Set up Docker Buildx
@@ -70,7 +70,7 @@ jobs:
   release-kit:
     name: release-kit
     needs: publish
-    if: contains(github.ref, '-beta.')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -88,10 +88,12 @@ jobs:
           tar -czf "dist/guard-proxy-release-${{ steps.tag.outputs.tag }}.tar.gz" \
             -C release .
 
-      - name: Create GitHub prerelease
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          prerelease: true
+          # A tag with a pre-release suffix (e.g. -beta.2) is a prerelease;
+          # a bare version tag (e.g. v1.0.0) is a stable release.
+          prerelease: ${{ contains(github.ref, '-') }}
           files: dist/guard-proxy-release-${{ steps.tag.outputs.tag }}.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
Simplifies the release streams to just **beta** (prerelease) and **stable**, per project scope — alpha is unnecessary overhead for a project this size.

## Changes to `publish.yml`

- **Image channels**: removed the `alpha` channel. `-beta.` tags publish the `beta` channel; version tags with no pre-release suffix (e.g. `v1.0.0`) publish `latest`. The exact version tag is always published.
- **Release job**: `release-kit` now runs for any `v*` tag (previously beta-only). The GitHub release is marked `prerelease` only when the tag carries a suffix, so a bare version tag yields a full stable release with the release-kit archive attached.

## Why now

Without this, a future stable tag would have (a) landed images on the `alpha` channel and (b) skipped release creation entirely, since both were gated on `-beta.`. This unblocks cutting the first stable release.

## Verification

- `publish.yml` parses as valid YAML; job graph unchanged (`publish` → `release-kit`).
- No behavioural change for the existing beta flow: `-beta.` tags still publish `beta` + a prerelease.