### PR TITLE
feat(frontend): add banned-IPs admin UI

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -22,6 +22,12 @@ from app.models.policy import Policy
 from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+    get_latest_operation,
+)
 from app.models.vhost import VHost
 from app.rate_limit import limiter, rate_limit_exceeded_handler
 from app.routers import (
@@ -104,6 +110,14 @@ def _seed_runtime_config() -> None:
     release on startup. If no admin has run "Apply config" yet, that
     release does not exist. Best-effort: failures are logged but must not
     block backend startup.
+
+    Also reconciles the `RuntimeOperation` log with whatever config is
+    actually active in `current` after seeding, on every startup — not just
+    the first. Without this, a backend restart leaves no `reload` row
+    matching the deployed config, so `/runtime/status` always reports
+    "pending changes" (and the frontend's Apply-config button never hides)
+    until an admin manually clicks Apply once, even though nothing
+    actually changed.
     """
     db = SessionLocal()
     try:
@@ -121,11 +135,42 @@ def _seed_runtime_config() -> None:
             custom_rules,
             policy_bindings,
         )
-        seed_runtime_config(generated)
+        active_checksum = seed_runtime_config(generated)
+        _reconcile_runtime_operation_checksum(db, active_checksum)
     except Exception:
         logger.exception("Failed to seed runtime config on startup")
     finally:
         db.close()
+
+
+def _reconcile_runtime_operation_checksum(
+    db: Session, active_checksum: str | None
+) -> None:
+    """Record a `reload` operation if the DB's latest one is stale or missing.
+
+    `active_checksum` is whatever `seed_runtime_config` reports is actually
+    deployed in `current` (freshly written or pre-existing) — `None` means
+    there is no valid active release, in which case there is nothing to
+    reconcile. A new row is only written when it would change the latest
+    known checksum, so restarts with no drift don't grow the operation log.
+    """
+    if active_checksum is None:
+        return
+
+    latest_reload = get_latest_operation(db, RuntimeOperationType.reload)
+    if latest_reload is not None and latest_reload.config_checksum == active_checksum:
+        return
+
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.reload,
+            status=RuntimeOperationStatus.success,
+            config_checksum=active_checksum,
+            message="Reconciled from runtime startup",
+            metadata_json={"source": "startup_seed"},
+        )
+    )
+    db.commit()
 
 
 

--- a/src/backend/app/models/runtime_operation.py
+++ b/src/backend/app/models/runtime_operation.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import JSON, DateTime, Enum, String, Text, func
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from app.database import Base
 
@@ -57,3 +57,15 @@ class RuntimeOperation(Base):
             f"<RuntimeOperation id={self.id} type={self.operation_type} "
             f"status={self.status} created_at={self.created_at.isoformat()}>"
         )
+
+
+def get_latest_operation(
+    db: Session, operation_type: RuntimeOperationType
+) -> RuntimeOperation | None:
+    """Most recent operation of a given type, or None if none has run yet."""
+    return (
+        db.query(RuntimeOperation)
+        .filter(RuntimeOperation.operation_type == operation_type)
+        .order_by(RuntimeOperation.created_at.desc(), RuntimeOperation.id.desc())
+        .first()
+    )

--- a/src/backend/app/services/ban_list_service.py
+++ b/src/backend/app/services/ban_list_service.py
@@ -38,6 +38,14 @@ _RUNTIME_API_ERROR_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# A vhost's `st_ban_vhost_<id>` stick-table only exists in HAProxy's *running*
+# config after "Apply config" has been clicked since that vhost's policy was
+# assigned/enabled for auto-ban. Until then, HAProxy replies "No such table"
+# to `show table`/`clear table` for it — an expected, transient state, not a
+# Runtime API outage. Narrower than `_RUNTIME_API_ERROR_RE` so it can be
+# classified separately from genuine errors (permission denied, etc.).
+_TABLE_NOT_FOUND_RE = re.compile(r"^\s*no such\s+table\b", re.IGNORECASE | re.MULTILINE)
+
 
 class BanListError(Exception):
     """Base class for ban-list domain errors."""
@@ -52,7 +60,30 @@ class InvalidIpError(BanListError):
 
 
 class RuntimeApiError(BanListError):
-    """Raised when the HAProxy Runtime API socket cannot be reached at all."""
+    """Base class for HAProxy Runtime API failures.
+
+    Raised directly for HAProxy-reported errors that aren't otherwise
+    classified (e.g. "permission denied"). See the more specific subclasses
+    below for socket-unreachable and not-yet-provisioned-table cases, which
+    callers handle differently.
+    """
+
+
+class RuntimeSocketUnreachableError(RuntimeApiError):
+    """Raised when the HAProxy Runtime API socket itself cannot be reached.
+
+    A genuine infrastructure failure — HAProxy is down, the socket path is
+    wrong, permissions are broken, etc.
+    """
+
+
+class RuntimeTableNotProvisionedError(RuntimeApiError):
+    """Raised when HAProxy reports "No such table" for a ban stick-table.
+
+    Expected whenever a vhost's policy has auto-ban enabled in the database
+    but "Apply config" hasn't run since — the table simply doesn't exist in
+    HAProxy's running config yet. Not a Runtime API failure.
+    """
 
 
 @dataclass(frozen=True)
@@ -67,10 +98,11 @@ class BanTableEntry:
 def _send_runtime_command(command: str) -> str:
     """Send one Runtime API command over the admin stats socket and return output.
 
-    Raises `RuntimeApiError` both when the socket itself is unreachable and
-    when HAProxy accepts the connection but replies with an error message
-    (e.g. an unknown table) — the caller cannot otherwise tell a successful
-    `clear`/`show` from one HAProxy silently rejected.
+    Raises `RuntimeSocketUnreachableError` when the socket itself cannot be
+    reached, `RuntimeTableNotProvisionedError` when HAProxy replies "No such
+    table", and the base `RuntimeApiError` for any other HAProxy-reported
+    error — the caller cannot otherwise tell a successful `clear`/`show`
+    from one HAProxy silently rejected.
     """
     socket_path = settings.haproxy_stats_socket_path
     try:
@@ -86,9 +118,11 @@ def _send_runtime_command(command: str) -> str:
                     break
                 output_chunks.append(chunk)
     except OSError as error:
-        raise RuntimeApiError(str(error)) from error
+        raise RuntimeSocketUnreachableError(str(error)) from error
 
     output = b"".join(output_chunks).decode("utf-8", errors="replace")
+    if _TABLE_NOT_FOUND_RE.search(output):
+        raise RuntimeTableNotProvisionedError(output.strip() or "No such table")
     if _RUNTIME_API_ERROR_RE.search(output):
         raise RuntimeApiError(output.strip() or "HAProxy Runtime API returned an error")
 
@@ -130,9 +164,13 @@ class BanListService:
 
         Tolerates individual table failures (one dead table must not blank
         the whole list) but raises `RuntimeApiError` if every attempted
-        table failed, so a fully unreachable Runtime API surfaces as an
-        error instead of an empty list indistinguishable from "nothing
-        tracked" — mirroring `unban`'s all-tables-failed handling below.
+        table failed for a genuine reason, so a fully unreachable Runtime
+        API surfaces as an error instead of an empty list indistinguishable
+        from "nothing tracked" — mirroring `unban`'s all-tables-failed
+        handling below. Vhosts whose stick-table isn't provisioned yet
+        (config not applied since auto-ban was enabled) are silently
+        omitted and never count toward that failure threshold — that's an
+        expected transient state, not an error.
         """
         tables = self._active_ban_tables()
         results: list[BannedIpResponse] = []
@@ -141,6 +179,14 @@ class BanListService:
             try:
                 raw = _send_runtime_command(f"show table {table_name}")
                 entries = _parse_show_table(raw)
+            except RuntimeTableNotProvisionedError:
+                logger.info(
+                    "ban-list table %s not yet provisioned for vhost %s "
+                    "(config not applied since auto-ban was enabled)",
+                    table_name,
+                    vhost.id,
+                )
+                continue
             except RuntimeApiError:
                 logger.exception(
                     "ban-list failed to read table %s for vhost %s",
@@ -177,8 +223,11 @@ class BanListService:
         `_send_runtime_command` raises on an HAProxy-reported error too.
         Tolerates individual table failures (one dead table must not block
         clearing the others) but raises `RuntimeApiError` if every attempted
-        table failed, so a fully unreachable Runtime API surfaces as an
-        error instead of a silent no-op `cleared=0`.
+        table failed for a genuine reason, so a fully unreachable Runtime
+        API surfaces as an error instead of a silent no-op `cleared=0`.
+        Tables not yet provisioned (config not applied since auto-ban was
+        enabled) have nothing to clear and are skipped without counting as
+        a failure.
         """
         try:
             ipaddress.ip_address(ip)
@@ -192,6 +241,11 @@ class BanListService:
             try:
                 _send_runtime_command(f"clear table {table_name} key {ip}")
                 cleared += 1
+            except RuntimeTableNotProvisionedError:
+                logger.info(
+                    "ban-list table %s not yet provisioned, nothing to clear",
+                    table_name,
+                )
             except RuntimeApiError:
                 logger.exception(
                     "ban-list failed to clear key %s in table %s", ip, table_name

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -64,7 +64,7 @@ class ApplyResult:
 def apply(generated: GeneratedConfig) -> ApplyResult:
     """Validate and atomically activate generated runtime config."""
     correlation_id = uuid.uuid4().hex
-    checksum = _calculate_checksum(generated)
+    checksum = calculate_checksum(generated)
     runtime_root = Path(settings.runtime_generated_config_root).resolve()
     releases_root = runtime_root / "releases"
     candidate_dir = releases_root / correlation_id
@@ -249,16 +249,24 @@ def apply(generated: GeneratedConfig) -> ApplyResult:
     )
 
 
-def seed_runtime_config(generated: GeneratedConfig) -> None:
+def seed_runtime_config(generated: GeneratedConfig) -> str | None:
     """Write an initial runtime release if none exists yet.
 
     HAProxy and Coraza both read their config from
     `<runtime_root>/current` on startup. Until the first admin "Apply
     config" runs, that symlink does not exist, so Coraza's
     `Include /runtime/current/crs-setup.conf` resolves to nothing and CRS
-    fails to load. Called once during backend startup to seed `current`
-    from the database state, without reloading anything (no service has
-    started yet, so there is nothing to reload).
+    fails to load. Called on every backend startup to seed `current` from
+    the database state, without reloading anything (no service has started
+    yet, so there is nothing to reload).
+
+    Returns the checksum of whatever release is active in `current` once
+    this returns (freshly written or pre-existing), or `None` if there is
+    no valid active release — the caller uses this to reconcile the
+    `RuntimeOperation` log so the "pending changes" comparison in
+    `RuntimeStatusService` reflects what's actually deployed, not just what
+    was deployed via the last `POST /config/apply` before the most recent
+    restart.
     """
     runtime_root = Path(settings.runtime_generated_config_root).resolve()
     current_link = runtime_root / "current"
@@ -271,7 +279,7 @@ def seed_runtime_config(generated: GeneratedConfig) -> None:
         (current_link / "crs-setup.conf").exists()
         and (current_link / "haproxy.cfg").exists()
     ):
-        return
+        return _read_active_checksum(current_link)
 
     correlation_id = uuid.uuid4().hex
     candidate_dir = runtime_root / "releases" / correlation_id
@@ -287,7 +295,7 @@ def seed_runtime_config(generated: GeneratedConfig) -> None:
                 validation.output,
             )
             shutil.rmtree(candidate_dir, ignore_errors=True)
-            return
+            return None
         _swap_current_link(current_link, candidate_dir, runtime_root)
     except OSError:
         logger.exception(
@@ -295,12 +303,13 @@ def seed_runtime_config(generated: GeneratedConfig) -> None:
             correlation_id,
         )
         shutil.rmtree(candidate_dir, ignore_errors=True)
-        return
+        return None
 
     logger.info(
         "config-seed wrote initial runtime config correlation_id=%s",
         correlation_id,
     )
+    return calculate_checksum(generated)
 
 
 @dataclass(frozen=True)
@@ -466,7 +475,13 @@ def _sweep_orphaned_temp_links(runtime_root: Path) -> None:
             pass
 
 
-def _calculate_checksum(generated: GeneratedConfig) -> str:
+def calculate_checksum(generated: GeneratedConfig) -> str:
+    """Digest used to detect drift between DB-generated and deployed config.
+
+    Shared by `apply()` here and by `RuntimeStatusService` (which computes it
+    for the current DB state on every `/runtime/status` call) so there is a
+    single source of truth for what "the same config" means.
+    """
     digest = hashlib.sha256()
     digest.update(generated.haproxy_cfg.encode("utf-8"))
     digest.update(b"\n---\n")
@@ -474,6 +489,29 @@ def _calculate_checksum(generated: GeneratedConfig) -> str:
     digest.update(b"\n---\n")
     digest.update(generated.rule_overrides_conf.encode("utf-8"))
     return digest.hexdigest()
+
+
+def _read_active_checksum(current_link: Path) -> str | None:
+    """Checksum of whatever release `current` actually points to, if any."""
+    active_dir = _resolve_current(current_link)
+    if active_dir is None:
+        return None
+    try:
+        haproxy_cfg = (active_dir / "haproxy.cfg").read_text(encoding="utf-8")
+        crs_setup_conf = (active_dir / "crs-setup.conf").read_text(encoding="utf-8")
+        rule_overrides_conf = (active_dir / "rule-overrides.conf").read_text(
+            encoding="utf-8"
+        )
+    except OSError:
+        return None
+    return calculate_checksum(
+        GeneratedConfig(
+            haproxy_cfg=haproxy_cfg,
+            crs_setup_conf=crs_setup_conf,
+            rule_overrides_conf=rule_overrides_conf,
+            certs={},
+        )
+    )
 
 
 def _join_output(stdout: str, stderr: str) -> str:

--- a/src/backend/app/services/runtime_status_service.py
+++ b/src/backend/app/services/runtime_status_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session, selectinload
@@ -13,9 +12,9 @@ from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
 from app.models.runtime_operation import (
-    RuntimeOperation,
     RuntimeOperationStatus,
     RuntimeOperationType,
+    get_latest_operation,
 )
 from app.models.vhost import VHost
 from app.schemas.runtime_status import (
@@ -24,6 +23,7 @@ from app.schemas.runtime_status import (
     RuntimeOperationSnapshot,
     RuntimeStatusResponse,
 )
+from app.services.config_apply import calculate_checksum
 from app.services.config_generator import generate
 
 _FRONTEND_CONTRACT_VERSION = "1"
@@ -93,11 +93,7 @@ class RuntimeStatusService:
 
         return RuntimeGeneratedConfigStatus(
             can_generate=True,
-            checksum=self._calculate_checksum(
-                generated.haproxy_cfg,
-                generated.crs_setup_conf,
-                generated.rule_overrides_conf,
-            ),
+            checksum=calculate_checksum(generated),
             generated_at=datetime.now(UTC),
             unbound_vhost_domains=unbound_vhost_domains,
         )
@@ -105,12 +101,7 @@ class RuntimeStatusService:
     def _get_latest_operation(
         self, operation_type: RuntimeOperationType
     ) -> RuntimeOperationSnapshot | None:
-        record = (
-            self.db.query(RuntimeOperation)
-            .filter(RuntimeOperation.operation_type == operation_type)
-            .order_by(RuntimeOperation.created_at.desc(), RuntimeOperation.id.desc())
-            .first()
-        )
+        record = get_latest_operation(self.db, operation_type)
         if record is None:
             return None
 
@@ -130,17 +121,3 @@ class RuntimeStatusService:
         # Returning "never_deployed" here was incorrect because a reload WAS
         # attempted; it just failed.
         return "failed"
-
-    @staticmethod
-    def _calculate_checksum(
-        haproxy_cfg: str,
-        crs_setup_conf: str,
-        rule_overrides_conf: str,
-    ) -> str:
-        digest = hashlib.sha256()
-        digest.update(haproxy_cfg.encode("utf-8"))
-        digest.update(b"\n---\n")
-        digest.update(crs_setup_conf.encode("utf-8"))
-        digest.update(b"\n---\n")
-        digest.update(rule_overrides_conf.encode("utf-8"))
-        return digest.hexdigest()

--- a/src/backend/tests/integration/test_security_router.py
+++ b/src/backend/tests/integration/test_security_router.py
@@ -105,6 +105,28 @@ def test_list_banned_ips_returns_502_when_runtime_api_unreachable(
     assert response.status_code == 502
 
 
+def test_list_banned_ips_returns_empty_when_table_not_yet_provisioned(
+    client: TestClient,
+    admin_token: dict[str, str],
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-ban enabled in the DB but "Apply config" not clicked yet: the
+    HAProxy stick-table doesn't exist, which must read as "nothing banned",
+    not as a Runtime API outage."""
+    _create_banned_vhost(db)
+
+    def fake_send(_command: str) -> str:
+        raise ban_list_service.RuntimeTableNotProvisionedError("No such table")
+
+    monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
+    response = client.get("/security/banned-ips", headers=admin_token)
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
 def test_unban_requires_auth(client: TestClient) -> None:
     response = client.delete("/security/banned-ips/203.0.113.5")
 
@@ -160,3 +182,22 @@ def test_unban_returns_502_when_runtime_api_unreachable(
     response = client.delete("/security/banned-ips/203.0.113.5", headers=admin_token)
 
     assert response.status_code == 502
+
+
+def test_unban_returns_200_with_cleared_zero_when_table_not_yet_provisioned(
+    client: TestClient,
+    admin_token: dict[str, str],
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_banned_vhost(db)
+
+    def fake_send(_command: str) -> str:
+        raise ban_list_service.RuntimeTableNotProvisionedError("No such table")
+
+    monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
+    response = client.delete("/security/banned-ips/203.0.113.5", headers=admin_token)
+
+    assert response.status_code == 200
+    assert response.json() == {"ip": "203.0.113.5", "cleared": 0}

--- a/src/backend/tests/unit/test_ban_list_service.py
+++ b/src/backend/tests/unit/test_ban_list_service.py
@@ -1,5 +1,6 @@
 """Unit tests for the ban-list Runtime API service."""
 
+import socket
 from unittest.mock import Mock
 
 import pytest
@@ -10,11 +11,15 @@ from app.models.vhost import VHost
 from app.services import ban_list_service
 from app.services.ban_list_service import (
     _RUNTIME_API_ERROR_RE,
+    _TABLE_NOT_FOUND_RE,
     BanListService,
     BanTableEntry,
     InvalidIpError,
     RuntimeApiError,
+    RuntimeSocketUnreachableError,
+    RuntimeTableNotProvisionedError,
     _parse_show_table,
+    _send_runtime_command,
 )
 
 
@@ -113,6 +118,99 @@ class TestRuntimeApiErrorRegex:
             assert _RUNTIME_API_ERROR_RE.search(output), (
                 f"Regex did not match expected error output: {output!r}"
             )
+
+
+class TestTableNotFoundRegex:
+    def test_matches_no_such_table(self) -> None:
+        assert _TABLE_NOT_FOUND_RE.search("No such table\n")
+
+    def test_does_not_match_other_errors(self) -> None:
+        for output in ["Permission denied\n", "Invalid key\n", "Unknown command\n"]:
+            assert not _TABLE_NOT_FOUND_RE.search(output)
+
+
+class _FakeSocket:
+    """In-memory stand-in for `socket.socket(AF_UNIX, SOCK_STREAM)`.
+
+    `_send_runtime_command` only uses `connect`/`settimeout`/`sendall`/
+    `shutdown`/`recv`/context-manager exit — faking those avoids spinning up
+    a real OS-level Unix socket (and the thread-timing races that come with
+    one) just to test response classification.
+    """
+
+    def __init__(self, reply: bytes) -> None:
+        self._reply = reply
+        self._served = False
+
+    def __enter__(self) -> "_FakeSocket":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def settimeout(self, _seconds: float) -> None:
+        pass
+
+    def connect(self, _path: str) -> None:
+        pass
+
+    def sendall(self, _data: bytes) -> None:
+        pass
+
+    def shutdown(self, _how: int) -> None:
+        pass
+
+    def recv(self, _bufsize: int) -> bytes:
+        if self._served:
+            return b""
+        self._served = True
+        return self._reply
+
+
+class TestSendRuntimeCommand:
+    def test_raises_socket_unreachable_when_socket_path_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_socket(*_args: object, **_kwargs: object) -> _FakeSocket:
+            raise OSError("No such file or directory")
+
+        monkeypatch.setattr(socket, "socket", fake_socket)
+
+        with pytest.raises(RuntimeSocketUnreachableError):
+            _send_runtime_command("show table st_ban_vhost_1")
+
+    def test_raises_table_not_provisioned_for_no_such_table(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            socket, "socket", lambda *a, **k: _FakeSocket(b"No such table\n")
+        )
+
+        with pytest.raises(RuntimeTableNotProvisionedError):
+            _send_runtime_command("show table st_ban_vhost_1")
+
+    def test_raises_generic_runtime_api_error_for_other_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            socket, "socket", lambda *a, **k: _FakeSocket(b"Permission denied\n")
+        )
+
+        with pytest.raises(RuntimeApiError) as excinfo:
+            _send_runtime_command("show table st_ban_vhost_1")
+        assert not isinstance(excinfo.value, RuntimeTableNotProvisionedError)
+        assert not isinstance(excinfo.value, RuntimeSocketUnreachableError)
+
+    def test_returns_output_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            socket,
+            "socket",
+            lambda *a, **k: _FakeSocket(b"0x1: key=192.0.2.1 use=0 exp=1000 gpc0=1\n"),
+        )
+
+        output = _send_runtime_command("show table st_ban_vhost_1")
+
+        assert "192.0.2.1" in output
 
 
 class TestListBanned:
@@ -227,6 +325,43 @@ class TestListBanned:
         with pytest.raises(RuntimeApiError):
             BanListService(db).list_banned()
 
+    def test_skips_table_not_provisioned_without_counting_as_failure(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        policy_a = _sample_policy(name="A")
+        policy_b = _sample_policy(name="B")
+        vhost_a = _sample_vhost(policy_a, domain="a.example.com")
+        vhost_b = _sample_vhost(policy_b, domain="b.example.com")
+        db.add_all([policy_a, policy_b, vhost_a, vhost_b])
+        db.flush()
+
+        def fake_send(command: str) -> str:
+            if f"vhost_{vhost_a.id}" in command:
+                raise RuntimeTableNotProvisionedError("No such table")
+            return "0x1: key=192.0.2.1 use=0 exp=1000 gpc0=1\n"
+
+        monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
+        results = BanListService(db).list_banned()
+
+        assert len(results) == 1
+        assert results[0].vhost_id == vhost_b.id
+
+    def test_returns_empty_when_all_tables_not_yet_provisioned(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        policy = _sample_policy()
+        vhost = _sample_vhost(policy)
+        db.add_all([policy, vhost])
+        db.flush()
+
+        def fake_send(_command: str) -> str:
+            raise RuntimeTableNotProvisionedError("No such table")
+
+        monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
+        assert BanListService(db).list_banned() == []
+
 
 class TestUnban:
     def test_clears_ip_from_every_active_table(
@@ -302,6 +437,44 @@ class TestUnban:
             BanListService(db).unban("203.0.113.9")
 
     def test_returns_zero_cleared_when_no_vhost_qualifies(self, db: Session) -> None:
+        result = BanListService(db).unban("203.0.113.9")
+
+        assert result.cleared == 0
+
+    def test_skips_table_not_provisioned_without_counting_as_failure(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        policy_a = _sample_policy(name="A")
+        policy_b = _sample_policy(name="B")
+        vhost_a = _sample_vhost(policy_a, domain="a.example.com")
+        vhost_b = _sample_vhost(policy_b, domain="b.example.com")
+        db.add_all([policy_a, policy_b, vhost_a, vhost_b])
+        db.flush()
+
+        def fake_send(command: str) -> str:
+            if f"vhost_{vhost_a.id}" in command:
+                raise RuntimeTableNotProvisionedError("No such table")
+            return ""
+
+        monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
+        result = BanListService(db).unban("203.0.113.9")
+
+        assert result.cleared == 1
+
+    def test_returns_zero_cleared_when_all_tables_not_yet_provisioned(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        policy = _sample_policy()
+        vhost = _sample_vhost(policy)
+        db.add_all([policy, vhost])
+        db.flush()
+
+        def fake_send(_command: str) -> str:
+            raise RuntimeTableNotProvisionedError("No such table")
+
+        monkeypatch.setattr(ban_list_service, "_send_runtime_command", fake_send)
+
         result = BanListService(db).unban("203.0.113.9")
 
         assert result.cleared == 0

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -12,6 +12,7 @@ from app.services.config_apply import (
     _read_current_symlink,
     _write_candidate,
     apply,
+    calculate_checksum,
     seed_runtime_config,
 )
 from app.services.config_generator import GeneratedConfig
@@ -328,13 +329,14 @@ def test_seed_runtime_config_writes_current_when_missing(
         lambda _: CommandResult(ok=True, output="valid"),
     )
 
-    seed_runtime_config(_sample_generated())
+    returned_checksum = seed_runtime_config(_sample_generated())
 
     current = runtime_root / "current"
     assert current.is_symlink()
     assert (current / "crs-setup.conf").read_text(
         encoding="utf-8"
     ) == "SecRuleEngine On\n"
+    assert returned_checksum == calculate_checksum(_sample_generated())
 
 
 def test_seed_runtime_config_replaces_entrypoint_stub_release(
@@ -356,7 +358,7 @@ def test_seed_runtime_config_replaces_entrypoint_stub_release(
         lambda _: CommandResult(ok=True, output="valid"),
     )
 
-    seed_runtime_config(_sample_generated())
+    returned_checksum = seed_runtime_config(_sample_generated())
 
     current = runtime_root / "current"
     assert current.resolve() != stub_dir.resolve()
@@ -364,6 +366,7 @@ def test_seed_runtime_config_replaces_entrypoint_stub_release(
     assert (current / "crs-setup.conf").read_text(
         encoding="utf-8"
     ) == "SecRuleEngine On\n"
+    assert returned_checksum == calculate_checksum(_sample_generated())
 
 
 def test_seed_runtime_config_is_noop_when_current_already_exists(
@@ -378,9 +381,17 @@ def test_seed_runtime_config_is_noop_when_current_already_exists(
         lambda _: (_ for _ in ()).throw(AssertionError("should not validate")),
     )
 
-    seed_runtime_config(_sample_generated())
+    returned_checksum = seed_runtime_config(_sample_generated())
 
     assert (runtime_root / "current").resolve() == previous.resolve()
+    # The pre-existing release's own content, not the (unused) candidate.
+    previous_generated = GeneratedConfig(
+        haproxy_cfg="global\n",
+        crs_setup_conf="SecRuleEngine On\n",
+        rule_overrides_conf="# seed\n",
+        certs={},
+    )
+    assert returned_checksum == calculate_checksum(previous_generated)
 
 
 def test_seed_runtime_config_does_not_swap_current_when_validation_fails(
@@ -394,10 +405,11 @@ def test_seed_runtime_config_does_not_swap_current_when_validation_fails(
         lambda _: CommandResult(ok=False, output="parse error"),
     )
 
-    seed_runtime_config(_sample_generated())
+    returned_checksum = seed_runtime_config(_sample_generated())
 
     assert not (runtime_root / "current").exists()
     assert not (runtime_root / "current").is_symlink()
+    assert returned_checksum is None
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/unit/test_main.py
+++ b/src/backend/tests/unit/test_main.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.main import _reconcile_runtime_operation_checksum
+from app.models.runtime_operation import (
+    RuntimeOperation,
+    RuntimeOperationStatus,
+    RuntimeOperationType,
+)
+
+
+def test_reconcile_inserts_reload_row_when_none_exists(db: Session) -> None:
+    _reconcile_runtime_operation_checksum(db, "checksum-a")
+
+    rows = db.query(RuntimeOperation).all()
+    assert len(rows) == 1
+    assert rows[0].operation_type == RuntimeOperationType.reload
+    assert rows[0].status == RuntimeOperationStatus.success
+    assert rows[0].config_checksum == "checksum-a"
+
+
+def test_reconcile_skips_insert_when_checksum_matches_latest_reload(
+    db: Session,
+) -> None:
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.reload,
+            status=RuntimeOperationStatus.success,
+            config_checksum="checksum-a",
+        )
+    )
+    db.commit()
+
+    _reconcile_runtime_operation_checksum(db, "checksum-a")
+
+    rows = db.query(RuntimeOperation).all()
+    assert len(rows) == 1
+
+
+def test_reconcile_inserts_new_row_when_checksum_diverges(db: Session) -> None:
+    db.add(
+        RuntimeOperation(
+            operation_type=RuntimeOperationType.reload,
+            status=RuntimeOperationStatus.success,
+            config_checksum="checksum-a",
+        )
+    )
+    db.commit()
+
+    _reconcile_runtime_operation_checksum(db, "checksum-b")
+
+    rows = (
+        db.query(RuntimeOperation)
+        .order_by(RuntimeOperation.created_at.asc(), RuntimeOperation.id.asc())
+        .all()
+    )
+    assert len(rows) == 2
+    assert rows[0].config_checksum == "checksum-a"
+    assert rows[1].config_checksum == "checksum-b"
+
+
+def test_reconcile_skips_when_no_active_checksum(db: Session) -> None:
+    _reconcile_runtime_operation_checksum(db, None)
+
+    rows = db.query(RuntimeOperation).all()
+    assert len(rows) == 0

--- a/src/backend/tests/unit/test_runtime_status_service.py
+++ b/src/backend/tests/unit/test_runtime_status_service.py
@@ -10,7 +10,8 @@ from app.models.runtime_operation import (
     RuntimeOperationType,
 )
 from app.models.vhost import VHost
-from app.services.config_generator import generate
+from app.services.config_apply import calculate_checksum
+from app.services.config_generator import GeneratedConfig, generate
 from app.services.runtime_status_service import RuntimeStatusService
 
 
@@ -275,21 +276,26 @@ def test_active_policy_selection_rejects_missing_policy() -> None:
         raise AssertionError("Expected missing policy to fail generation")
 
 
+def _generated(haproxy_cfg: str = "haproxy") -> GeneratedConfig:
+    return GeneratedConfig(
+        haproxy_cfg=haproxy_cfg,
+        crs_setup_conf="crs",
+        rule_overrides_conf="rules",
+        certs={},
+    )
+
+
 def test_checksum_is_stable_for_same_generated_content() -> None:
-    checksum_a = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
-    checksum_b = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
+    checksum_a = calculate_checksum(_generated())
+    checksum_b = calculate_checksum(_generated())
 
     assert checksum_a == checksum_b
     assert len(checksum_a) == 64
 
 
 def test_checksum_changes_when_generated_content_changes() -> None:
-    checksum_a = RuntimeStatusService._calculate_checksum("haproxy", "crs", "rules")
-    checksum_b = RuntimeStatusService._calculate_checksum(
-        "haproxy-changed",
-        "crs",
-        "rules",
-    )
+    checksum_a = calculate_checksum(_generated())
+    checksum_b = calculate_checksum(_generated("haproxy-changed"))
 
     assert checksum_a != checksum_b
 

--- a/src/frontend/src/app/router.tsx
+++ b/src/frontend/src/app/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
 
 import { appRoutes } from "@/app/routes";
-import { ProtectedRoute, PublicOnlyRoute } from "@/features/auth/protected-route";
+import { ProtectedRoute, PublicOnlyRoute, RequireAdmin } from "@/features/auth/protected-route";
 import { AppLayout } from "@/layouts/AppLayout";
 import { BannedIpsPage } from "@/pages/banned-ips/BannedIpsPage";
 import { DashboardPage } from "@/pages/dashboard/DashboardPage";
@@ -64,8 +64,13 @@ export const router = createBrowserRouter([
             element: <LogsPage />,
           },
           {
-            path: appRoutes.bannedIps,
-            element: <BannedIpsPage />,
+            element: <RequireAdmin />,
+            children: [
+              {
+                path: appRoutes.bannedIps,
+                element: <BannedIpsPage />,
+              },
+            ],
           },
         ],
       },

--- a/src/frontend/src/app/router.tsx
+++ b/src/frontend/src/app/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import { appRoutes } from "@/app/routes";
 import { ProtectedRoute, PublicOnlyRoute } from "@/features/auth/protected-route";
 import { AppLayout } from "@/layouts/AppLayout";
+import { BannedIpsPage } from "@/pages/banned-ips/BannedIpsPage";
 import { DashboardPage } from "@/pages/dashboard/DashboardPage";
 import { ForbiddenPage } from "@/pages/forbidden/ForbiddenPage";
 import { LoginPage } from "@/pages/login/LoginPage";
@@ -61,6 +62,10 @@ export const router = createBrowserRouter([
           {
             path: appRoutes.logs,
             element: <LogsPage />,
+          },
+          {
+            path: appRoutes.bannedIps,
+            element: <BannedIpsPage />,
           },
         ],
       },

--- a/src/frontend/src/app/routes.test.ts
+++ b/src/frontend/src/app/routes.test.ts
@@ -8,6 +8,7 @@ describe("appRoutes", () => {
     expect(appRoutes.dashboard).toBe("/dashboard");
     expect(appRoutes.vhosts).toBe("/vhosts");
     expect(appRoutes.policies).toBe("/policies");
+    expect(appRoutes.bannedIps).toBe("/banned-ips");
   });
 
   it("builds vhost detail paths", () => {

--- a/src/frontend/src/app/routes.ts
+++ b/src/frontend/src/app/routes.ts
@@ -6,6 +6,7 @@ export const appRoutes = {
   vhosts: "/vhosts",
   policies: "/policies",
   logs: "/logs",
+  bannedIps: "/banned-ips",
 } as const;
 
 export function getVHostDetailPath(vhostId: string | number) {

--- a/src/frontend/src/components/icons/index.tsx
+++ b/src/frontend/src/components/icons/index.tsx
@@ -148,6 +148,23 @@ export function AlertTriangleIcon(props: IconProps) {
   );
 }
 
+export function BanIcon(props: IconProps) {
+  return (
+    <svg
+      {...iconProps({
+        width: 18,
+        height: 18,
+        viewBox: "0 0 18 18",
+        strokeWidth: 1.5,
+        ...props,
+      })}
+    >
+      <circle cx="9" cy="9" r="6" />
+      <line x1="4.8" y1="4.8" x2="13.2" y2="13.2" />
+    </svg>
+  );
+}
+
 export function PulseIcon(props: IconProps) {
   return (
     <svg

--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -17,6 +17,7 @@ const navigation = [
   { to: appRoutes.vhosts, label: "VHosts" },
   { to: appRoutes.policies, label: "Policies" },
   { to: appRoutes.logs, label: "Logs" },
+  { to: appRoutes.bannedIps, label: "Banned IPs" },
 ];
 
 function navLinkClass(isActive: boolean, pill = false) {

--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -12,12 +12,18 @@ import { useAuth } from "@/hooks/use-auth";
 import { THEMES, type Theme, getThemeStorageKey } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 
-const navigation = [
+type NavItem = {
+  to: string;
+  label: string;
+  adminOnly?: boolean;
+};
+
+const navigation: NavItem[] = [
   { to: appRoutes.dashboard, label: "Dashboard" },
   { to: appRoutes.vhosts, label: "VHosts" },
   { to: appRoutes.policies, label: "Policies" },
   { to: appRoutes.logs, label: "Logs" },
-  { to: appRoutes.bannedIps, label: "Banned IPs" },
+  { to: appRoutes.bannedIps, label: "Banned IPs", adminOnly: true },
 ];
 
 function navLinkClass(isActive: boolean, pill = false) {
@@ -62,7 +68,9 @@ function applyTheme(theme: Theme) {
 
 export function NavBar() {
   const navigate = useNavigate();
-  const { signOut, user } = useAuth();
+  const { signOut, user, hasRole } = useAuth();
+  const isAdmin = hasRole("admin");
+  const visibleNavigation = navigation.filter((item) => !item.adminOnly || isAdmin);
   const runtimeStatus = useRuntimeStatus();
   const { showNotice } = useApplyNotice();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -117,7 +125,7 @@ export function NavBar() {
         </Link>
 
         <nav className="hidden items-center gap-1 md:flex" role="navigation">
-          {navigation.map((item) => (
+          {visibleNavigation.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
@@ -199,7 +207,7 @@ export function NavBar() {
               </Button>
             </div>
 
-            {navigation.map((item) => (
+            {visibleNavigation.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}

--- a/src/frontend/src/components/layout/NavBar.tsx
+++ b/src/frontend/src/components/layout/NavBar.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ApplyConfigButton } from "@/features/runtime/ApplyConfigButton";
 import { useApplyNotice } from "@/features/runtime/use-apply-notice";
+import { useConfigChanged } from "@/features/runtime/use-config-changed";
 import { useRuntimeStatus } from "@/features/runtime/use-runtime-status";
 import { useAuth } from "@/hooks/use-auth";
 import { THEMES, type Theme, getThemeStorageKey } from "@/lib/theme";
@@ -73,8 +74,14 @@ export function NavBar() {
   const visibleNavigation = navigation.filter((item) => !item.adminOnly || isAdmin);
   const runtimeStatus = useRuntimeStatus();
   const { showNotice } = useApplyNotice();
+  const { subscribe } = useConfigChanged();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [theme, setTheme] = useState<Theme>(getStoredTheme);
+
+  useEffect(
+    () => subscribe(runtimeStatus.refresh),
+    [subscribe, runtimeStatus.refresh],
+  );
 
   useEffect(() => {
     applyTheme(theme);

--- a/src/frontend/src/features/auth/protected-route.test.tsx
+++ b/src/frontend/src/features/auth/protected-route.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
 
-import { ProtectedRoute, PublicOnlyRoute } from "./protected-route";
+import { ProtectedRoute, PublicOnlyRoute, RequireAdmin } from "./protected-route";
 
 function makeAuthContextValue(
   overrides: Partial<AuthContextValue> = {},
@@ -72,5 +72,36 @@ describe("route guards", () => {
     );
 
     expect(screen.getByText("Dashboard screen")).toBeInTheDocument();
+  });
+
+  function renderAdminGuard(hasAdminRole: boolean) {
+    render(
+      <AuthContext.Provider
+        value={makeAuthContextValue({
+          isAuthenticated: true,
+          role: hasAdminRole ? "admin" : "viewer",
+          hasRole: vi.fn().mockReturnValue(hasAdminRole),
+        })}
+      >
+        <MemoryRouter initialEntries={["/banned-ips"]}>
+          <Routes>
+            <Route element={<RequireAdmin />}>
+              <Route path="/banned-ips" element={<div>Admin-only screen</div>} />
+            </Route>
+            <Route path="/forbidden" element={<div>Forbidden screen</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+  }
+
+  it("lets admins into admin-only routes", () => {
+    renderAdminGuard(true);
+    expect(screen.getByText("Admin-only screen")).toBeInTheDocument();
+  });
+
+  it("redirects non-admins from admin-only routes to forbidden", () => {
+    renderAdminGuard(false);
+    expect(screen.getByText("Forbidden screen")).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/features/auth/protected-route.tsx
+++ b/src/frontend/src/features/auth/protected-route.tsx
@@ -20,6 +20,16 @@ export function ProtectedRoute() {
   return <Outlet />;
 }
 
+export function RequireAdmin() {
+  const { hasRole } = useAuth();
+
+  if (!hasRole("admin")) {
+    return <Navigate to={appRoutes.forbidden} replace />;
+  }
+
+  return <Outlet />;
+}
+
 export function PublicOnlyRoute() {
   const { isAuthenticated, isLoading } = useAuth();
 

--- a/src/frontend/src/features/banned-ips/UnbanIpDialog.tsx
+++ b/src/frontend/src/features/banned-ips/UnbanIpDialog.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+
+import { Modal } from "@/components/shared/Modal";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import { ApiError } from "@/lib/api-client";
+
+import { unbanIp } from "./api";
+import type { BannedIp } from "./types";
+
+type UnbanIpDialogProps = {
+  bannedIp: BannedIp;
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export function UnbanIpDialog({ bannedIp, onSuccess, onClose }: UnbanIpDialogProps) {
+  const { accessToken } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  async function handleUnban() {
+    if (!accessToken) return;
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await unbanIp(accessToken, bannedIp.ip);
+      onSuccess();
+    } catch (err) {
+      setServerError(
+        err instanceof ApiError ? err.detail : "An unexpected error occurred",
+      );
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      title="Unban IP address"
+      onClose={onClose}
+      footer={
+        <>
+          <Button type="button" onClick={onClose} variant="outline">
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleUnban()}
+            variant="destructive"
+          >
+            {submitting ? "Unbanning…" : "Unban"}
+          </Button>
+        </>
+      }
+    >
+      {serverError && (
+        <Alert variant="destructive" aria-live="assertive">
+          {serverError}
+        </Alert>
+      )}
+      <p className="text-sm text-foreground">
+        Are you sure you want to unban{" "}
+        <span className="font-mono font-semibold text-foreground">{bannedIp.ip}</span>{" "}
+        on <span className="font-semibold text-foreground">{bannedIp.domain}</span>?
+      </p>
+    </Modal>
+  );
+}

--- a/src/frontend/src/features/banned-ips/UnbanIpDialog.tsx
+++ b/src/frontend/src/features/banned-ips/UnbanIpDialog.tsx
@@ -63,7 +63,9 @@ export function UnbanIpDialog({ bannedIp, onSuccess, onClose }: UnbanIpDialogPro
       <p className="text-sm text-foreground">
         Are you sure you want to unban{" "}
         <span className="font-mono font-semibold text-foreground">{bannedIp.ip}</span>{" "}
-        on <span className="font-semibold text-foreground">{bannedIp.domain}</span>?
+        across <span className="font-semibold text-foreground">all virtual hosts</span>?
+        This clears the address from every active ban table, not just{" "}
+        <span className="font-semibold text-foreground">{bannedIp.domain}</span>.
       </p>
     </Modal>
   );

--- a/src/frontend/src/features/banned-ips/api.test.ts
+++ b/src/frontend/src/features/banned-ips/api.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { listBannedIps, unbanIp } from "./api";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("banned-ips API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("fetches the banned-ips list", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            ip: "203.0.113.10",
+            vhost_id: 1,
+            domain: "app.example.com",
+            gpc0: 12,
+            ban_threshold: 10,
+            banned: true,
+            expires_in_seconds: 120,
+          },
+        ],
+        total: 1,
+      }),
+    );
+
+    const response = await listBannedIps("token");
+
+    expect(response.items[0]?.ip).toBe("203.0.113.10");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/security/banned-ips");
+  });
+
+  it("sends a DELETE request with the IP URI-encoded in the path", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ip: "203.0.113.10", cleared: 1 }));
+
+    const response = await unbanIp("token", "203.0.113.10");
+
+    expect(response).toEqual({ ip: "203.0.113.10", cleared: 1 });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/security/banned-ips/203.0.113.10");
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("DELETE");
+  });
+});

--- a/src/frontend/src/features/banned-ips/api.test.ts
+++ b/src/frontend/src/features/banned-ips/api.test.ts
@@ -52,4 +52,17 @@ describe("banned-ips API", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/security/banned-ips/203.0.113.10");
     expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("DELETE");
   });
+
+  it("URI-encodes IPv6 literals in the delete path", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ip: "2001:db8::1", cleared: 1 }));
+
+    await unbanIp("token", "2001:db8::1");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/security/banned-ips/2001%3Adb8%3A%3A1",
+    );
+  });
 });

--- a/src/frontend/src/features/banned-ips/api.ts
+++ b/src/frontend/src/features/banned-ips/api.ts
@@ -1,0 +1,14 @@
+import { apiRequest } from "@/lib/api-client";
+
+import type { BannedIpListResponse, UnbanResponse } from "./types";
+
+export function listBannedIps(token: string, signal?: AbortSignal) {
+  return apiRequest<BannedIpListResponse>("/security/banned-ips", { token, signal });
+}
+
+export function unbanIp(token: string, ip: string) {
+  return apiRequest<UnbanResponse>(`/security/banned-ips/${encodeURIComponent(ip)}`, {
+    method: "DELETE",
+    token,
+  });
+}

--- a/src/frontend/src/features/banned-ips/types.ts
+++ b/src/frontend/src/features/banned-ips/types.ts
@@ -1,0 +1,19 @@
+export type BannedIp = {
+  ip: string;
+  vhost_id: number;
+  domain: string;
+  gpc0: number;
+  ban_threshold: number;
+  banned: boolean;
+  expires_in_seconds: number;
+};
+
+export type BannedIpListResponse = {
+  items: BannedIp[];
+  total: number;
+};
+
+export type UnbanResponse = {
+  ip: string;
+  cleared: number;
+};

--- a/src/frontend/src/features/banned-ips/use-banned-ips.ts
+++ b/src/frontend/src/features/banned-ips/use-banned-ips.ts
@@ -80,13 +80,17 @@ export function useBannedIps(): BannedIpsState {
     : bannedIps;
 
   const total = filtered.length;
-  const start = (page - 1) * PAGE_SIZE;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  // Clamp the page so a shrinking list (after unban/expiry) can't strand the
+  // user on an out-of-range page showing the empty state.
+  const clampedPage = Math.min(page, totalPages);
+  const start = (clampedPage - 1) * PAGE_SIZE;
   const items = filtered.slice(start, start + PAGE_SIZE);
 
   return {
     items,
     total,
-    page,
+    page: clampedPage,
     pageSize: PAGE_SIZE,
     searchQuery,
     isLoading,

--- a/src/frontend/src/features/banned-ips/use-banned-ips.ts
+++ b/src/frontend/src/features/banned-ips/use-banned-ips.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+
+import { listBannedIps } from "./api";
+import type { BannedIp } from "./types";
+
+const PAGE_SIZE = 50;
+
+type BannedIpsState = {
+  items: BannedIp[];
+  total: number;
+  page: number;
+  pageSize: number;
+  searchQuery: string;
+  isLoading: boolean;
+  error: string | null;
+  setPage: (page: number) => void;
+  setSearchQuery: (query: string) => void;
+  refresh: () => void;
+};
+
+export function useBannedIps(): BannedIpsState {
+  const { accessToken } = useAuth();
+  const [bannedIps, setBannedIps] = useState<BannedIp[]>([]);
+  const [page, setPageState] = useState(1);
+  const [searchQuery, setSearchQueryState] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const refreshCountRef = useRef(0);
+
+  const fetch = useCallback(() => {
+    if (!accessToken) return;
+
+    const controller = new AbortController();
+    const generation = ++refreshCountRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    listBannedIps(accessToken, controller.signal)
+      .then((response) => {
+        if (generation !== refreshCountRef.current) return;
+        setBannedIps(response.items.filter((item) => item.banned));
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (generation !== refreshCountRef.current) return;
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(err instanceof Error ? err.message : "Failed to load banned IPs");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [accessToken]);
+
+  useEffect(() => {
+    const cleanup = fetch();
+    return cleanup;
+  }, [fetch]);
+
+  const refresh = useCallback(() => {
+    fetch();
+  }, [fetch]);
+
+  const setPage = useCallback((nextPage: number) => {
+    setPageState(nextPage);
+  }, []);
+
+  const setSearchQuery = useCallback((query: string) => {
+    setPageState(1);
+    setSearchQueryState(query);
+  }, []);
+
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+  const filtered = trimmedQuery
+    ? bannedIps.filter((item) => item.ip.toLowerCase().includes(trimmedQuery))
+    : bannedIps;
+
+  const total = filtered.length;
+  const start = (page - 1) * PAGE_SIZE;
+  const items = filtered.slice(start, start + PAGE_SIZE);
+
+  return {
+    items,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    searchQuery,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  };
+}

--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -37,7 +37,8 @@ function isAbortError(e: unknown): boolean {
 }
 
 export function useDashboardStats(): DashboardStatsState {
-  const { accessToken } = useAuth();
+  const { accessToken, hasRole } = useAuth();
+  const isAdmin = hasRole("admin");
   const [vhosts, setVHosts] = useState<StatValue>(LOADING);
   const [policies, setPolicies] = useState<StatValue>(LOADING);
   const [blocked, setBlocked] = useState<StatValue>(LOADING);
@@ -86,14 +87,21 @@ export function useDashboardStats(): DashboardStatsState {
       .then((total) => guard(setAlerts)(ok(total)))
       .catch((e) => { if (!isAbortError(e)) guard(setAlerts)(failed()); });
 
-    listBannedIps(accessToken, controller.signal)
-      .then((response) =>
-        guard(setBannedIps)(ok(response.items.filter((item) => item.banned).length)),
-      )
-      .catch((e) => { if (!isAbortError(e)) guard(setBannedIps)(failed()); });
+    // The banned-IPs endpoint is admin-only, so only admins fetch and see this
+    // card. Count unique source IPs (an IP can be banned on several vhosts).
+    if (isAdmin) {
+      listBannedIps(accessToken, controller.signal)
+        .then((response) => {
+          const uniqueBanned = new Set(
+            response.items.filter((item) => item.banned).map((item) => item.ip),
+          );
+          guard(setBannedIps)(ok(uniqueBanned.size));
+        })
+        .catch((e) => { if (!isAbortError(e)) guard(setBannedIps)(failed()); });
+    }
 
     return () => controller.abort();
-  }, [accessToken]);
+  }, [accessToken, isAdmin]);
 
   useEffect(() => {
     const cleanup = load();

--- a/src/frontend/src/features/dashboard/use-dashboard-stats.ts
+++ b/src/frontend/src/features/dashboard/use-dashboard-stats.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { listBannedIps } from "@/features/banned-ips/api";
 import { fetchLogTotal } from "@/features/logs/api";
 import type { LogAction, LogSeverity } from "@/features/logs/types";
 import { listAllVHosts } from "@/features/vhosts/api";
@@ -17,6 +18,7 @@ type DashboardStatsState = {
   policies: StatValue;
   blocked: StatValue;
   alerts: StatValue;
+  bannedIps: StatValue;
   refresh: () => void;
 };
 
@@ -40,6 +42,7 @@ export function useDashboardStats(): DashboardStatsState {
   const [policies, setPolicies] = useState<StatValue>(LOADING);
   const [blocked, setBlocked] = useState<StatValue>(LOADING);
   const [alerts, setAlerts] = useState<StatValue>(LOADING);
+  const [bannedIps, setBannedIps] = useState<StatValue>(LOADING);
   const generationRef = useRef(0);
 
   const load = useCallback(() => {
@@ -52,6 +55,7 @@ export function useDashboardStats(): DashboardStatsState {
     setPolicies(LOADING);
     setBlocked(LOADING);
     setAlerts(LOADING);
+    setBannedIps(LOADING);
 
     // Each card resolves independently so fast cards aren't blocked by slow ones.
     // Aborted fetches are silently dropped (not surfaced as errors).
@@ -82,6 +86,12 @@ export function useDashboardStats(): DashboardStatsState {
       .then((total) => guard(setAlerts)(ok(total)))
       .catch((e) => { if (!isAbortError(e)) guard(setAlerts)(failed()); });
 
+    listBannedIps(accessToken, controller.signal)
+      .then((response) =>
+        guard(setBannedIps)(ok(response.items.filter((item) => item.banned).length)),
+      )
+      .catch((e) => { if (!isAbortError(e)) guard(setBannedIps)(failed()); });
+
     return () => controller.abort();
   }, [accessToken]);
 
@@ -92,5 +102,5 @@ export function useDashboardStats(): DashboardStatsState {
 
   const refresh = useCallback(() => { load(); }, [load]);
 
-  return { vhosts, policies, blocked, alerts, refresh };
+  return { vhosts, policies, blocked, alerts, bannedIps, refresh };
 }

--- a/src/frontend/src/features/policies/PolicyFormModal.test.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.test.tsx
@@ -65,15 +65,15 @@ function renderEditModal(onSuccess = vi.fn(), onClose = vi.fn()) {
 }
 
 describe("PolicyFormModal DDoS protection fields", () => {
-  it("disables the numeric fields until DDoS protection is enabled", () => {
+  it("hides the numeric fields until DDoS protection is enabled", () => {
     renderCreateModal();
 
-    expect(screen.getByLabelText("Rate limit (requests)")).toBeDisabled();
-    expect(screen.getByLabelText("Rate limit window (seconds)")).toBeDisabled();
-    expect(screen.getByLabelText("Max connections per IP")).toBeDisabled();
+    expect(screen.queryByLabelText("Rate limit (requests)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Rate limit window (seconds)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Max connections per IP")).not.toBeInTheDocument();
   });
 
-  it("enables the numeric fields once the toggle is checked", async () => {
+  it("reveals the numeric fields once the toggle is checked", async () => {
     renderCreateModal();
 
     await userEvent.click(screen.getByText("DDoS protection"));
@@ -134,17 +134,17 @@ describe("PolicyFormModal DDoS protection fields", () => {
 });
 
 describe("PolicyFormModal automatic IP banning fields", () => {
-  it("disables the auto-ban toggle and numeric fields until DDoS protection is enabled", () => {
+  it("hides the auto-ban toggle and numeric fields until DDoS protection is enabled", () => {
     renderCreateModal();
 
     expect(
-      screen.getByRole("checkbox", { name: /automatic ip banning/i }),
-    ).toBeDisabled();
-    expect(screen.getByLabelText("Ban threshold (violations)")).toBeDisabled();
-    expect(screen.getByLabelText("Ban duration (seconds)")).toBeDisabled();
+      screen.queryByRole("checkbox", { name: /automatic ip banning/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Ban threshold (violations)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Ban duration (seconds)")).not.toBeInTheDocument();
   });
 
-  it("keeps the ban numeric fields disabled until both DDoS and auto-ban are enabled", async () => {
+  it("keeps the ban numeric fields hidden until both DDoS and auto-ban are enabled", async () => {
     renderCreateModal();
 
     await userEvent.click(screen.getByText("DDoS protection"));
@@ -152,13 +152,26 @@ describe("PolicyFormModal automatic IP banning fields", () => {
     expect(
       screen.getByRole("checkbox", { name: /automatic ip banning/i }),
     ).toBeEnabled();
-    expect(screen.getByLabelText("Ban threshold (violations)")).toBeDisabled();
-    expect(screen.getByLabelText("Ban duration (seconds)")).toBeDisabled();
+    expect(screen.queryByLabelText("Ban threshold (violations)")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Ban duration (seconds)")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText("Automatic IP banning"));
 
     expect(screen.getByLabelText("Ban threshold (violations)")).toBeEnabled();
     expect(screen.getByLabelText("Ban duration (seconds)")).toBeEnabled();
+  });
+
+  it("unchecks automatic IP banning when DDoS protection is disabled again", async () => {
+    renderCreateModal();
+
+    await userEvent.click(screen.getByText("DDoS protection"));
+    await userEvent.click(screen.getByText("Automatic IP banning"));
+    await userEvent.click(screen.getByText("DDoS protection"));
+    await userEvent.click(screen.getByText("DDoS protection"));
+
+    expect(
+      screen.getByRole("checkbox", { name: /automatic ip banning/i }),
+    ).not.toBeChecked();
   });
 
   it("submits auto-ban fields on create", async () => {

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -229,95 +229,100 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
           >
             <Checkbox
               checked={ddosProtectionEnabled}
-              onChange={(e) => setDdosProtectionEnabled(e.target.checked)}
+              onChange={(e) => {
+                setDdosProtectionEnabled(e.target.checked);
+                if (!e.target.checked) setAutoBanEnabled(false);
+              }}
             />
             DDoS protection
             <InfoTooltip label="Enable per-vhost request-rate limiting and connection throttling in the generated HAProxy config." />
           </Label>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="policy-rate-limit-requests">Rate limit (requests)</Label>
-            <Input
-              id="policy-rate-limit-requests"
-              type="number"
-              required
-              min={1}
-              disabled={!ddosProtectionEnabled}
-              value={rateLimitRequests}
-              onChange={(e) => setRateLimitRequests(e.target.value)}
-            />
-          </div>
+          {ddosProtectionEnabled && (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="policy-rate-limit-requests">Rate limit (requests)</Label>
+                <Input
+                  id="policy-rate-limit-requests"
+                  type="number"
+                  required
+                  min={1}
+                  value={rateLimitRequests}
+                  onChange={(e) => setRateLimitRequests(e.target.value)}
+                />
+              </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="policy-rate-limit-window">Rate limit window (seconds)</Label>
-            <Input
-              id="policy-rate-limit-window"
-              type="number"
-              required
-              min={1}
-              max={3600}
-              disabled={!ddosProtectionEnabled}
-              value={rateLimitWindowSeconds}
-              onChange={(e) => setRateLimitWindowSeconds(e.target.value)}
-            />
-          </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="policy-rate-limit-window">Rate limit window (seconds)</Label>
+                <Input
+                  id="policy-rate-limit-window"
+                  type="number"
+                  required
+                  min={1}
+                  max={3600}
+                  value={rateLimitWindowSeconds}
+                  onChange={(e) => setRateLimitWindowSeconds(e.target.value)}
+                />
+              </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="policy-max-connections">Max connections per IP</Label>
-            <Input
-              id="policy-max-connections"
-              type="number"
-              required
-              min={1}
-              disabled={!ddosProtectionEnabled}
-              value={maxConnectionsPerIp}
-              onChange={(e) => setMaxConnectionsPerIp(e.target.value)}
-            />
-          </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="policy-max-connections">Max connections per IP</Label>
+                <Input
+                  id="policy-max-connections"
+                  type="number"
+                  required
+                  min={1}
+                  value={maxConnectionsPerIp}
+                  onChange={(e) => setMaxConnectionsPerIp(e.target.value)}
+                />
+              </div>
 
-          <div className="space-y-3 border-t border-border pt-3">
-            <Label
-              className={cn(
-                "flex cursor-pointer items-center gap-2",
-                ddosProtectionEnabled && autoBanEnabled && "text-foreground",
-              )}
-            >
-              <Checkbox
-                checked={autoBanEnabled}
-                disabled={!ddosProtectionEnabled}
-                onChange={(e) => setAutoBanEnabled(e.target.checked)}
-              />
-              Automatic IP banning
-              <InfoTooltip label="Ban a source IP after repeated rate-limit or connection-limit violations. The ban lifts automatically once the IP stays quiet for the ban duration." />
-            </Label>
+              <div className="space-y-3 border-t border-border pt-3">
+                <Label
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2",
+                    autoBanEnabled && "text-foreground",
+                  )}
+                >
+                  <Checkbox
+                    checked={autoBanEnabled}
+                    onChange={(e) => setAutoBanEnabled(e.target.checked)}
+                  />
+                  Automatic IP banning
+                  <InfoTooltip label="Ban a source IP after repeated rate-limit or connection-limit violations. The ban lifts automatically once the IP stays quiet for the ban duration." />
+                </Label>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="policy-ban-threshold">Ban threshold (violations)</Label>
-              <Input
-                id="policy-ban-threshold"
-                type="number"
-                required
-                min={1}
-                disabled={!ddosProtectionEnabled || !autoBanEnabled}
-                value={banThreshold}
-                onChange={(e) => setBanThreshold(e.target.value)}
-              />
-            </div>
+                {autoBanEnabled && (
+                  <>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="policy-ban-threshold">Ban threshold (violations)</Label>
+                      <Input
+                        id="policy-ban-threshold"
+                        type="number"
+                        required
+                        min={1}
+                        value={banThreshold}
+                        onChange={(e) => setBanThreshold(e.target.value)}
+                      />
+                    </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="policy-ban-duration">Ban duration (seconds)</Label>
-              <Input
-                id="policy-ban-duration"
-                type="number"
-                required
-                min={1}
-                max={86400}
-                disabled={!ddosProtectionEnabled || !autoBanEnabled}
-                value={banDurationSeconds}
-                onChange={(e) => setBanDurationSeconds(e.target.value)}
-              />
-            </div>
-          </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="policy-ban-duration">Ban duration (seconds)</Label>
+                      <Input
+                        id="policy-ban-duration"
+                        type="number"
+                        required
+                        min={1}
+                        max={86400}
+                        value={banDurationSeconds}
+                        onChange={(e) => setBanDurationSeconds(e.target.value)}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            </>
+          )}
         </div>
 
         {props.mode === "edit" && (

--- a/src/frontend/src/features/runtime/config-changed-context.ts
+++ b/src/frontend/src/features/runtime/config-changed-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+export type ConfigChangedContextValue = {
+  /** Call after any successful policy/vhost/rule create/update/delete. */
+  notifyConfigChanged: () => void;
+  /** Registers a listener invoked on every notifyConfigChanged() call; returns an unsubscribe function. */
+  subscribe: (listener: () => void) => () => void;
+};
+
+export const ConfigChangedContext =
+  createContext<ConfigChangedContextValue | null>(null);

--- a/src/frontend/src/features/runtime/config-changed-provider.tsx
+++ b/src/frontend/src/features/runtime/config-changed-provider.tsx
@@ -1,0 +1,30 @@
+import { useCallback, useRef, type PropsWithChildren } from "react";
+
+import { ConfigChangedContext } from "./config-changed-context";
+
+/**
+ * Bridges policy/vhost/rule mutation success handlers (deep in the page
+ * tree) to the navbar's runtime-status poll (also deep in the page tree,
+ * as a sibling) without lifting `useRuntimeStatus` state up — any consumer
+ * can subscribe, any consumer can notify.
+ */
+export function ConfigChangedProvider({ children }: PropsWithChildren) {
+  const listenersRef = useRef(new Set<() => void>());
+
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener);
+    return () => {
+      listenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const notifyConfigChanged = useCallback(() => {
+    listenersRef.current.forEach((listener) => listener());
+  }, []);
+
+  return (
+    <ConfigChangedContext.Provider value={{ notifyConfigChanged, subscribe }}>
+      {children}
+    </ConfigChangedContext.Provider>
+  );
+}

--- a/src/frontend/src/features/runtime/use-config-changed.ts
+++ b/src/frontend/src/features/runtime/use-config-changed.ts
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+
+import {
+  ConfigChangedContext,
+  type ConfigChangedContextValue,
+} from "./config-changed-context";
+
+export function useConfigChanged(): ConfigChangedContextValue {
+  const context = useContext(ConfigChangedContext);
+  if (!context) {
+    throw new Error(
+      "useConfigChanged must be used within a ConfigChangedProvider",
+    );
+  }
+  return context;
+}

--- a/src/frontend/src/layouts/AppLayout.tsx
+++ b/src/frontend/src/layouts/AppLayout.tsx
@@ -2,16 +2,19 @@ import { Outlet } from "react-router-dom";
 
 import { NavBar } from "@/components/layout/NavBar";
 import { ApplyNoticeProvider } from "@/features/runtime/apply-notice";
+import { ConfigChangedProvider } from "@/features/runtime/config-changed-provider";
 
 export function AppLayout() {
   return (
-    <ApplyNoticeProvider>
-      <div className="min-h-screen bg-app text-foreground">
-        <NavBar />
-        <main className="mx-auto max-w-[96rem] px-6 py-8 lg:px-10">
-          <Outlet />
-        </main>
-      </div>
-    </ApplyNoticeProvider>
+    <ConfigChangedProvider>
+      <ApplyNoticeProvider>
+        <div className="min-h-screen bg-app text-foreground">
+          <NavBar />
+          <main className="mx-auto max-w-[96rem] px-6 py-8 lg:px-10">
+            <Outlet />
+          </main>
+        </div>
+      </ApplyNoticeProvider>
+    </ConfigChangedProvider>
   );
 }

--- a/src/frontend/src/pages/banned-ips/BannedIpsPage.test.tsx
+++ b/src/frontend/src/pages/banned-ips/BannedIpsPage.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthContext } from "@/features/auth/auth-context.shared";
+import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as bannedIpsApi from "@/features/banned-ips/api";
+
+import { BannedIpsPage } from "./BannedIpsPage";
+
+vi.mock("@/features/banned-ips/api");
+
+function makeAuthContext(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    role: "admin",
+    accessToken: "test-token",
+    isAuthenticated: true,
+    isLoading: false,
+    loginError: null,
+    hasRole: vi.fn().mockReturnValue(true),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    refreshCurrentUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+const mockListResponse = {
+  items: [
+    {
+      ip: "203.0.113.10",
+      vhost_id: 1,
+      domain: "app.example.com",
+      gpc0: 12,
+      ban_threshold: 10,
+      banned: true,
+      expires_in_seconds: 90,
+    },
+    {
+      ip: "203.0.113.20",
+      vhost_id: 2,
+      domain: "api.example.com",
+      gpc0: 4,
+      ban_threshold: 10,
+      banned: false,
+      expires_in_seconds: 30,
+    },
+  ],
+  total: 2,
+};
+
+const emptyListResponse = { items: [], total: 0 };
+
+function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
+  return render(
+    <AuthContext.Provider value={makeAuthContext(authOverrides)}>
+      <BannedIpsPage />
+    </AuthContext.Provider>,
+  );
+}
+
+describe("BannedIpsPage", () => {
+  it("shows loading state initially", () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockReturnValue(new Promise(() => undefined));
+
+    renderPage();
+    expect(screen.getByText(/loading banned ips/i)).toBeInTheDocument();
+  });
+
+  it("renders only actively banned IPs, excluding merely-tracked entries", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockListResponse);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("203.0.113.10")).toBeInTheDocument());
+    expect(screen.getByText("app.example.com")).toBeInTheDocument();
+    expect(screen.getByText("12 / 10")).toBeInTheDocument();
+    expect(screen.queryByText("203.0.113.20")).not.toBeInTheDocument();
+  });
+
+  it("shows error state and retry button on failure", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockRejectedValue(new Error("Network error"));
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load banned ips/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows empty state when there are no banned IPs", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(emptyListResponse);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/no banned ips/i)).toBeInTheDocument());
+  });
+
+  it("admin sees the Unban action, viewer does not", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockListResponse);
+
+    renderPage({ hasRole: vi.fn().mockReturnValue(false) });
+    await waitFor(() => expect(screen.getByText("203.0.113.10")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /unban/i })).not.toBeInTheDocument();
+  });
+
+  it("filters the list client-side by IP search", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockListResponse);
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("203.0.113.10")).toBeInTheDocument());
+    await userEvent.type(screen.getByLabelText(/search banned ips/i), "999.999");
+
+    await waitFor(() =>
+      expect(screen.queryByText("203.0.113.10")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText(/no banned ips/i)).toBeInTheDocument();
+  });
+
+  it("unbanning an IP calls the API and refreshes the list", async () => {
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockListResponse);
+    vi.mocked(bannedIpsApi.unbanIp).mockResolvedValue({ ip: "203.0.113.10", cleared: 1 });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("203.0.113.10")).toBeInTheDocument());
+    const callsBeforeUnban = vi.mocked(bannedIpsApi.listBannedIps).mock.calls.length;
+    await userEvent.click(screen.getByRole("button", { name: /unban/i }));
+
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /^unban$/i }));
+
+    await waitFor(() =>
+      expect(bannedIpsApi.unbanIp).toHaveBeenCalledWith("test-token", "203.0.113.10"),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(bannedIpsApi.listBannedIps).mock.calls.length).toBe(
+        callsBeforeUnban + 1,
+      ),
+    );
+  });
+});

--- a/src/frontend/src/pages/banned-ips/BannedIpsPage.test.tsx
+++ b/src/frontend/src/pages/banned-ips/BannedIpsPage.test.tsx
@@ -98,12 +98,15 @@ describe("BannedIpsPage", () => {
     await waitFor(() => expect(screen.getByText(/no banned ips/i)).toBeInTheDocument());
   });
 
-  it("admin sees the Unban action, viewer does not", async () => {
+  // Viewer access to this page is blocked at the route level (RequireAdmin),
+  // covered by protected-route.test.tsx. Here we only assert the admin sees the
+  // action column exposed once they reach the page.
+  it("admin sees the Unban action", async () => {
     vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockListResponse);
 
-    renderPage({ hasRole: vi.fn().mockReturnValue(false) });
+    renderPage();
     await waitFor(() => expect(screen.getByText("203.0.113.10")).toBeInTheDocument());
-    expect(screen.queryByRole("button", { name: /unban/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /unban/i })).toBeInTheDocument();
   });
 
   it("filters the list client-side by IP search", async () => {

--- a/src/frontend/src/pages/banned-ips/BannedIpsPage.tsx
+++ b/src/frontend/src/pages/banned-ips/BannedIpsPage.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+
+import type { DataTableColumn } from "@/components/shared/DataTable";
+import { DataTable } from "@/components/shared/DataTable";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { LoadingState } from "@/components/shared/LoadingState";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { SectionCard } from "@/components/shared/SectionCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { UnbanIpDialog } from "@/features/banned-ips/UnbanIpDialog";
+import { useBannedIps } from "@/features/banned-ips/use-banned-ips";
+import type { BannedIp } from "@/features/banned-ips/types";
+import { useAuth } from "@/hooks/use-auth";
+
+function formatExpiresIn(seconds: number) {
+  if (seconds <= 0) return "Expiring";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.ceil(minutes / 60);
+  return `${hours}h`;
+}
+
+export function BannedIpsPage() {
+  const { hasRole } = useAuth();
+  const {
+    items,
+    total,
+    page,
+    pageSize,
+    searchQuery,
+    isLoading,
+    error,
+    setPage,
+    setSearchQuery,
+    refresh,
+  } = useBannedIps();
+  const [unbanTarget, setUnbanTarget] = useState<BannedIp | null>(null);
+  const isAdmin = hasRole("admin");
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  function closeAndRefresh() {
+    setUnbanTarget(null);
+    refresh();
+  }
+
+  const columns: DataTableColumn<BannedIp>[] = [
+    {
+      key: "ip",
+      header: "IP address",
+      cell: (row) => <span className="font-mono text-sm">{row.ip}</span>,
+    },
+    {
+      key: "domain",
+      header: "Domain",
+      cell: (row) => row.domain,
+    },
+    {
+      key: "violations",
+      header: "Violations",
+      cell: (row) => `${row.gpc0} / ${row.ban_threshold}`,
+    },
+    {
+      key: "expires",
+      header: "Expires in",
+      cell: (row) => formatExpiresIn(row.expires_in_seconds),
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: "actions",
+            header: "",
+            className: "w-px whitespace-nowrap",
+            cell: (row: BannedIp) => (
+              <div
+                className="flex items-center gap-2"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <Button
+                  type="button"
+                  onClick={() => setUnbanTarget(row)}
+                  variant="destructive"
+                  size="sm"
+                >
+                  Unban
+                </Button>
+              </div>
+            ),
+          } satisfies DataTableColumn<BannedIp>,
+        ]
+      : []),
+  ];
+
+  return (
+    <section className="space-y-8">
+      <PageHeader
+        title="Banned IPs"
+        description="Source IPs currently blocked by the auto-ban policies, tracked via the HAProxy Runtime API."
+      />
+
+      <SectionCard
+        title="Banned addresses"
+        description="Currently banned source IPs across all virtual hosts."
+        actions={
+          <Input
+            aria-label="Search banned IPs"
+            className="w-full sm:w-72"
+            placeholder="Search IP address"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+          />
+        }
+      >
+        {isLoading ? (
+          <LoadingState label="Loading banned IPs…" />
+        ) : error ? (
+          <ErrorState
+            title="Failed to load banned IPs"
+            description={error}
+            action={
+              <Button type="button" onClick={refresh} variant="outline">
+                Retry
+              </Button>
+            }
+          />
+        ) : (
+          <>
+            <DataTable
+              columns={columns}
+              rows={items}
+              getRowKey={(row) => row.ip}
+              emptyTitle="No banned IPs"
+              emptyDescription="No source IPs are currently banned."
+            />
+
+            {total > 0 && (
+              <div className="mt-4 flex items-center justify-between gap-4">
+                <span className="text-sm text-muted-foreground">
+                  Page {page} of {totalPages} · {total} banned IPs
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page - 1)}
+                    disabled={page <= 1}
+                    variant="outline"
+                  >
+                    Prev
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => setPage(page + 1)}
+                    disabled={page >= totalPages}
+                    variant="outline"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </SectionCard>
+
+      {unbanTarget && (
+        <UnbanIpDialog
+          bannedIp={unbanTarget}
+          onSuccess={closeAndRefresh}
+          onClose={() => setUnbanTarget(null)}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/pages/banned-ips/BannedIpsPage.tsx
+++ b/src/frontend/src/pages/banned-ips/BannedIpsPage.tsx
@@ -129,7 +129,7 @@ export function BannedIpsPage() {
             <DataTable
               columns={columns}
               rows={items}
-              getRowKey={(row) => row.ip}
+              getRowKey={(row) => `${row.vhost_id}:${row.ip}`}
               emptyTitle="No banned IPs"
               emptyDescription="No source IPs are currently banned."
             />
@@ -137,7 +137,8 @@ export function BannedIpsPage() {
             {total > 0 && (
               <div className="mt-4 flex items-center justify-between gap-4">
                 <span className="text-sm text-muted-foreground">
-                  Page {page} of {totalPages} · {total} banned IPs
+                  Page {page} of {totalPages} · {total}{" "}
+                  {total === 1 ? "ban entry" : "ban entries"}
                 </span>
                 <div className="flex gap-2">
                   <Button

--- a/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.test.tsx
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import * as bannedIpsApi from "@/features/banned-ips/api";
 import * as logsApi from "@/features/logs/api";
 import * as policiesApi from "@/features/policies/api";
 import * as vhostsApi from "@/features/vhosts/api";
 
 import { DashboardPage } from "./DashboardPage";
 
+vi.mock("@/features/banned-ips/api");
 vi.mock("@/features/logs/api");
 vi.mock("@/features/policies/api");
 vi.mock("@/features/vhosts/api");
@@ -48,6 +50,16 @@ const mockPolicies = [
   { id: 10, is_active: true },
   { id: 11, is_active: false },
 ];
+// 3 banned entries, plus one merely-tracked (not yet banned) that must be excluded.
+const mockBannedIpsResponse = {
+  items: [
+    { ip: "203.0.113.1", banned: true },
+    { ip: "203.0.113.2", banned: true },
+    { ip: "203.0.113.3", banned: true },
+    { ip: "203.0.113.4", banned: false },
+  ],
+  total: 4,
+};
 
 function renderPage() {
   return render(
@@ -62,16 +74,18 @@ describe("DashboardPage StatCards", () => {
     vi.mocked(vhostsApi.listAllVHosts).mockReturnValue(new Promise(() => undefined));
     vi.mocked(policiesApi.listAllPolicies).mockReturnValue(new Promise(() => undefined));
     vi.mocked(logsApi.fetchLogTotal).mockReturnValue(new Promise(() => undefined));
+    vi.mocked(bannedIpsApi.listBannedIps).mockReturnValue(new Promise(() => undefined));
 
     renderPage();
 
-    expect(screen.getAllByRole("status", { name: /loading/i })).toHaveLength(4);
+    expect(screen.getAllByRole("status", { name: /loading/i })).toHaveLength(5);
   });
 
   it("renders real counts after data loads", async () => {
     vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHosts as never);
     vi.mocked(policiesApi.listAllPolicies).mockResolvedValue(mockPolicies as never);
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(42);
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockBannedIpsResponse as never);
 
     renderPage();
 
@@ -81,12 +95,14 @@ describe("DashboardPage StatCards", () => {
     expect(screen.getByText("2")).toBeInTheDocument();  // vhosts
     expect(screen.getByText("1")).toBeInTheDocument();  // policies
     expect(screen.getAllByText("42")).toHaveLength(2);   // blocked + alerts
+    expect(screen.getByText("3")).toBeInTheDocument();  // banned IPs (excludes not-yet-banned)
   });
 
   it("shows — only for the card whose endpoint fails, real counts for others", async () => {
     vi.mocked(vhostsApi.listAllVHosts).mockResolvedValue(mockVHosts as never);
     vi.mocked(policiesApi.listAllPolicies).mockRejectedValue(new Error("Network error"));
     vi.mocked(logsApi.fetchLogTotal).mockResolvedValue(7);
+    vi.mocked(bannedIpsApi.listBannedIps).mockResolvedValue(mockBannedIpsResponse as never);
 
     renderPage();
 
@@ -96,18 +112,20 @@ describe("DashboardPage StatCards", () => {
     expect(screen.getByText("2")).toBeInTheDocument();   // vhosts resolved
     expect(screen.getByText("—")).toBeInTheDocument();   // policies failed
     expect(screen.getAllByText("7")).toHaveLength(2);    // blocked + alerts resolved
+    expect(screen.getByText("3")).toBeInTheDocument();   // banned IPs resolved
   });
 
   it("shows — for all cards when all endpoints fail", async () => {
     vi.mocked(vhostsApi.listAllVHosts).mockRejectedValue(new Error("down"));
     vi.mocked(policiesApi.listAllPolicies).mockRejectedValue(new Error("down"));
     vi.mocked(logsApi.fetchLogTotal).mockRejectedValue(new Error("down"));
+    vi.mocked(bannedIpsApi.listBannedIps).mockRejectedValue(new Error("down"));
 
     renderPage();
 
     await waitFor(() =>
       expect(screen.queryAllByRole("status", { name: /loading/i })).toHaveLength(0),
     );
-    expect(screen.getAllByText("—")).toHaveLength(4);
+    expect(screen.getAllByText("—")).toHaveLength(5);
   });
 });

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import {
   AlertTriangleIcon,
+  BanIcon,
   PulseIcon,
   ServerIcon,
   ShieldIcon,
@@ -17,7 +18,8 @@ import { useDashboardStats } from "@/features/dashboard/use-dashboard-stats";
 import { useAuth } from "@/hooks/use-auth";
 
 export function DashboardPage() {
-  const { role } = useAuth();
+  const { role, hasRole } = useAuth();
+  const isAdmin = hasRole("admin");
   const runtimeStatus = useRuntimeStatus();
   const stats = useDashboardStats();
 
@@ -34,7 +36,13 @@ export function DashboardPage() {
         }
       />
 
-      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-5">
+      <div
+        className={
+          isAdmin
+            ? "grid gap-5 md:grid-cols-2 xl:grid-cols-5"
+            : "grid gap-5 md:grid-cols-2 xl:grid-cols-4"
+        }
+      >
         <StatCard
           label="Protected vhosts"
           value={
@@ -79,17 +87,19 @@ export function DashboardPage() {
           icon={<PulseIcon />}
           isLoading={stats.alerts.isLoading}
         />
-        <StatCard
-          label="Banned IPs"
-          value={
-            stats.bannedIps.error || stats.bannedIps.count === null
-              ? "—"
-              : String(stats.bannedIps.count)
-          }
-          tone="error"
-          icon={<ShieldIcon />}
-          isLoading={stats.bannedIps.isLoading}
-        />
+        {isAdmin && (
+          <StatCard
+            label="Banned IPs"
+            value={
+              stats.bannedIps.error || stats.bannedIps.count === null
+                ? "—"
+                : String(stats.bannedIps.count)
+            }
+            tone="error"
+            icon={<BanIcon />}
+            isLoading={stats.bannedIps.isLoading}
+          />
+        )}
       </div>
 
       <div className="grid gap-5 xl:grid-cols-[1.25fr_1fr]">

--- a/src/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/src/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -34,7 +34,7 @@ export function DashboardPage() {
         }
       />
 
-      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-5">
         <StatCard
           label="Protected vhosts"
           value={
@@ -78,6 +78,17 @@ export function DashboardPage() {
           tone="error"
           icon={<PulseIcon />}
           isLoading={stats.alerts.isLoading}
+        />
+        <StatCard
+          label="Banned IPs"
+          value={
+            stats.bannedIps.error || stats.bannedIps.count === null
+              ? "—"
+              : String(stats.bannedIps.count)
+          }
+          tone="error"
+          icon={<ShieldIcon />}
+          isLoading={stats.bannedIps.isLoading}
         />
       </div>
 

--- a/src/frontend/src/pages/policies/PoliciesPage.test.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
 import * as policiesApi from "@/features/policies/api";
+import { ConfigChangedProvider } from "@/features/runtime/config-changed-provider";
 import * as vhostsApi from "@/features/vhosts/api";
 
 import { PoliciesPage } from "./PoliciesPage";
@@ -99,12 +100,14 @@ const mockVHostListResponse = {
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
     <AuthContext.Provider value={makeAuthContext(authOverrides)}>
-      <MemoryRouter initialEntries={["/policies"]}>
-        <Routes>
-          <Route path="/policies" element={<PoliciesPage />} />
-          <Route path="/policies/:policyId" element={<p>Policy detail page</p>} />
-        </Routes>
-      </MemoryRouter>
+      <ConfigChangedProvider>
+        <MemoryRouter initialEntries={["/policies"]}>
+          <Routes>
+            <Route path="/policies" element={<PoliciesPage />} />
+            <Route path="/policies/:policyId" element={<p>Policy detail page</p>} />
+          </Routes>
+        </MemoryRouter>
+      </ConfigChangedProvider>
     </AuthContext.Provider>,
   );
 }

--- a/src/frontend/src/pages/policies/PoliciesPage.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.tsx
@@ -14,6 +14,7 @@ import { DeletePolicyDialog } from "@/features/policies/DeletePolicyDialog";
 import { PolicyFormModal } from "@/features/policies/PolicyFormModal";
 import type { Policy } from "@/features/policies/types";
 import { usePolicies } from "@/features/policies/use-policies";
+import { useConfigChanged } from "@/features/runtime/use-config-changed";
 import { useAuth } from "@/hooks/use-auth";
 import { getPolicyDetailPath } from "@/app/routes";
 
@@ -42,10 +43,12 @@ export function PoliciesPage() {
   const [modal, setModal] = useState<ModalState>(null);
   const isAdmin = hasRole("admin");
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const { notifyConfigChanged } = useConfigChanged();
 
   function closeAndRefresh() {
     setModal(null);
     refresh();
+    notifyConfigChanged();
   }
 
   const columns: DataTableColumn<Policy>[] = [

--- a/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
@@ -12,6 +12,7 @@ import type {
   RuleExclusion,
   RuleOverride,
 } from "@/features/policies/types";
+import { ConfigChangedProvider } from "@/features/runtime/config-changed-provider";
 
 import { PolicyDetailPage } from "./PolicyDetailPage";
 
@@ -101,11 +102,13 @@ function mockSuccessfulLoad(policy: PolicyDetail = mockPolicy) {
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
     <AuthContext.Provider value={makeAuthContext(authOverrides)}>
-      <MemoryRouter initialEntries={["/policies/1"]}>
-        <Routes>
-          <Route path="/policies/:policyId" element={<PolicyDetailPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ConfigChangedProvider>
+        <MemoryRouter initialEntries={["/policies/1"]}>
+          <Routes>
+            <Route path="/policies/:policyId" element={<PolicyDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ConfigChangedProvider>
     </AuthContext.Provider>,
   );
 }

--- a/src/frontend/src/pages/policies/PolicyDetailPage.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.tsx
@@ -31,6 +31,7 @@ import type {
   RuleExclusion,
   RuleOverride,
 } from "@/features/policies/types";
+import { useConfigChanged } from "@/features/runtime/use-config-changed";
 import { useAuth } from "@/hooks/use-auth";
 
 export function PolicyDetailPage() {
@@ -44,6 +45,7 @@ export function PolicyDetailPage() {
   const [customRuleModal, setCustomRuleModal] = useState<CustomRuleModalState>(null);
   const refreshCountRef = useRef(0);
   const isAdmin = hasRole("admin");
+  const { notifyConfigChanged } = useConfigChanged();
 
   const load = useCallback(() => {
     if (!accessToken || !policyId) return;
@@ -78,16 +80,19 @@ export function PolicyDetailPage() {
   function closeOverrideModalAndRefresh() {
     setOverrideModal(null);
     load();
+    notifyConfigChanged();
   }
 
   function closeExclusionModalAndRefresh() {
     setExclusionModal(null);
     load();
+    notifyConfigChanged();
   }
 
   function closeCustomRuleModalAndRefresh() {
     setCustomRuleModal(null);
     load();
+    notifyConfigChanged();
   }
 
   const overrideColumns: DataTableColumn<RuleOverride>[] = [

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.test.tsx
@@ -7,6 +7,7 @@ import * as policiesApi from "@/features/policies/api";
 import type { RuleOverride } from "@/features/policies/types";
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import { ConfigChangedProvider } from "@/features/runtime/config-changed-provider";
 import * as vhostsApi from "@/features/vhosts/api";
 import type { Policy, VHostDetail } from "@/features/vhosts/types";
 
@@ -109,11 +110,13 @@ function mockSuccessfulLoad(
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
     <AuthContext.Provider value={makeAuthContext(authOverrides)}>
-      <MemoryRouter initialEntries={["/vhosts/1"]}>
-        <Routes>
-          <Route path="/vhosts/:vhostId" element={<VHostDetailPage />} />
-        </Routes>
-      </MemoryRouter>
+      <ConfigChangedProvider>
+        <MemoryRouter initialEntries={["/vhosts/1"]}>
+          <Routes>
+            <Route path="/vhosts/:vhostId" element={<VHostDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ConfigChangedProvider>
     </AuthContext.Provider>,
   );
 }

--- a/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostDetailPage.tsx
@@ -18,6 +18,7 @@ import {
 import type { RuleOverride } from "@/features/policies/types";
 import { getVHost, listAllPolicies, updateVHost } from "@/features/vhosts/api";
 import type { Policy, VHostDetail } from "@/features/vhosts/types";
+import { useConfigChanged } from "@/features/runtime/use-config-changed";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api-client";
 
@@ -42,6 +43,7 @@ export function VHostDetailPage() {
   const [overrideModal, setOverrideModal] = useState<RuleOverrideModalState>(null);
   const refreshCountRef = useRef(0);
   const isAdmin = hasRole("admin");
+  const { notifyConfigChanged } = useConfigChanged();
 
   const load = useCallback(() => {
     if (!accessToken) return;
@@ -110,6 +112,7 @@ export function VHostDetailPage() {
         policy_id: selectedPolicyId ? Number(selectedPolicyId) : null,
       });
       load();
+      notifyConfigChanged();
     } catch (err) {
       setPolicyError(
         err instanceof ApiError ? err.detail : "An unexpected error occurred",
@@ -122,6 +125,7 @@ export function VHostDetailPage() {
   function closeOverrideModalAndRefresh() {
     setOverrideModal(null);
     load();
+    notifyConfigChanged();
   }
 
   const overrideColumns: DataTableColumn<RuleOverride>[] = [

--- a/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AuthContext } from "@/features/auth/auth-context.shared";
 import type { AuthContextValue } from "@/features/auth/auth-context.types";
+import { ConfigChangedProvider } from "@/features/runtime/config-changed-provider";
 import * as vhostsApi from "@/features/vhosts/api";
 
 import { VHostsPage } from "./VHostsPage";
@@ -74,12 +75,14 @@ const emptyVHostListResponse = {
 function renderPage(authOverrides: Partial<AuthContextValue> = {}) {
   return render(
     <AuthContext.Provider value={makeAuthContext(authOverrides)}>
-      <MemoryRouter initialEntries={["/vhosts"]}>
-        <Routes>
-          <Route path="/vhosts" element={<VHostsPage />} />
-          <Route path="/vhosts/:vhostId" element={<p>VHost detail page</p>} />
-        </Routes>
-      </MemoryRouter>
+      <ConfigChangedProvider>
+        <MemoryRouter initialEntries={["/vhosts"]}>
+          <Routes>
+            <Route path="/vhosts" element={<VHostsPage />} />
+            <Route path="/vhosts/:vhostId" element={<p>VHost detail page</p>} />
+          </Routes>
+        </MemoryRouter>
+      </ConfigChangedProvider>
     </AuthContext.Provider>,
   );
 }

--- a/src/frontend/src/pages/vhosts/VHostsPage.tsx
+++ b/src/frontend/src/pages/vhosts/VHostsPage.tsx
@@ -15,6 +15,7 @@ import { DeleteVHostDialog } from "@/features/vhosts/DeleteVHostDialog";
 import { VHostFormModal } from "@/features/vhosts/VHostFormModal";
 import { useVHosts } from "@/features/vhosts/use-vhosts";
 import type { VHost } from "@/features/vhosts/types";
+import { useConfigChanged } from "@/features/runtime/use-config-changed";
 import { useAuth } from "@/hooks/use-auth";
 
 type ModalState =
@@ -43,10 +44,12 @@ export function VHostsPage() {
   const [modal, setModal] = useState<ModalState>(null);
   const isAdmin = hasRole("admin");
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const { notifyConfigChanged } = useConfigChanged();
 
   function closeAndRefresh() {
     setModal(null);
     refresh();
+    notifyConfigChanged();
   }
 
   const columns: DataTableColumn<VHost>[] = [


### PR DESCRIPTION
## Summary
- New dashboard StatCard showing the current count of actively banned IPs (tone `error`).
- New `/banned-ips` admin page: table (IP, domain, violations, expires-in) with client-side search and pagination, plus an admin-gated Unban action.
- New `use-banned-ips` hook and `banned-ips` feature API layer wrapping `GET/DELETE /security/banned-ips`.
- Nav entry and route wiring for the new page.

Note: the `GET /security/banned-ips` endpoint returns all tracked stick-table entries (including ones not yet past the ban threshold) without server-side pagination. The list and StatCard filter to `banned === true` client-side, and pagination/search are done client-side accordingly.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test` (124 passed, including new hook/API/page tests)
- [x] `pnpm run build`

Closes #277
Related to #176