### PR TITLE
chore(release): bump version to 0.1.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Python distributions use the [PEP 440](https://peps.python.org/pep-0440/)
 spelling of the same version (e.g. `0.1.0b2` for `0.1.0-beta.2`).
 
+## [0.1.0-beta.3] - 2026-07-27
+
+### Added
+
+- Banned IPs admin page: table of source IPs currently blocked by the
+  auto-ban mechanism (IP, domain, violations, expires-in), with search,
+  client-side pagination, and an admin-gated Unban action backed by the
+  HAProxy Runtime API.
+- Dashboard stat card showing the current count of actively banned IPs.
+
+### Changed
+
+- Policy form now hides the DDoS/auto-ban sub-fields entirely until their
+  parent toggle is enabled, instead of just disabling them; disabling DDoS
+  protection also clears the auto-ban toggle so it can't stay enabled
+  invisibly.
+
+### Fixed
+
+- `GET /security/banned-ips` and the Unban action no longer return `502`
+  when a vhost's auto-ban stick-table hasn't been provisioned by HAProxy
+  yet — an unprovisioned table is now treated as an empty ban list.
+- The "Apply config" button no longer stays stuck visible after a plain
+  backend restart with no pending changes; the deployed config's checksum
+  is now reconciled against the runtime operation log on every startup.
+
 ## [0.1.0-beta.2] - 2026-07-21
 
 ### Added
@@ -48,6 +74,7 @@ spelling of the same version (e.g. `0.1.0b2` for `0.1.0-beta.2`).
   exclusions, and custom rules, plus runtime config generation and apply.
 - Coraza audit-log ingestion via the log-shipper sidecar.
 
+[0.1.0-beta.3]: https://github.com/bihius/guard-proxy/compare/v0.1.0-beta.2...v0.1.0-beta.3
 [0.1.0-beta.2]: https://github.com/bihius/guard-proxy/compare/v0.1.0-beta.1...v0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/bihius/guard-proxy/compare/v0.1.0-alpha...v0.1.0-beta.1
 [0.1.0-alpha]: https://github.com/bihius/guard-proxy/releases/tag/v0.1.0-alpha

--- a/release/.env.example
+++ b/release/.env.example
@@ -2,10 +2,10 @@
 # Replace every placeholder value below — these are NOT safe defaults.
 
 # Image to pull. GUARD_PROXY_IMAGE_TAG must match a published release tag,
-# e.g. v0.1.0-beta.2. GUARD_PROXY_IMAGE_REPO only needs to change if you are
+# e.g. v0.1.0-beta.3. GUARD_PROXY_IMAGE_REPO only needs to change if you are
 # pulling from a fork or a private mirror.
 GUARD_PROXY_IMAGE_REPO=ghcr.io/bihius
-GUARD_PROXY_IMAGE_TAG=v0.1.0-beta.2
+GUARD_PROXY_IMAGE_TAG=v0.1.0-beta.3
 
 POSTGRES_USER=guard_proxy
 POSTGRES_PASSWORD=change-me-generate-a-strong-password

--- a/release/README.md
+++ b/release/README.md
@@ -21,7 +21,7 @@ between beta releases yet — back up `pgdata` before upgrading. See
 
 ## 1. Get the release kit
 
-Download and extract the `guard-proxy-release-v0.1.0-beta.2.tar.gz` asset
+Download and extract the `guard-proxy-release-v0.1.0-beta.3.tar.gz` asset
 from the [GitHub Releases page](https://github.com/bihius/guard-proxy/releases),
 or copy this `release/` directory if you already have the repository
 checked out. You should end up with:
@@ -45,7 +45,7 @@ cp .env.example .env
 Edit `.env` and replace every `change-me` placeholder:
 
 - `GUARD_PROXY_IMAGE_TAG` — pin this to the release you're installing,
-  e.g. `v0.1.0-beta.2`. Do not use a mutable tag like `beta` for anything
+  e.g. `v0.1.0-beta.3`. Do not use a mutable tag like `beta` for anything
   you want to reproduce later.
 - `POSTGRES_PASSWORD`, `JWT_SECRET_KEY`, `LOG_INGEST_SHARED_SECRET` —
   generate real secrets, e.g. `openssl rand -hex 32`.

--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -4,7 +4,7 @@ name: guard-proxy-release
 #
 # This file pulls prebuilt images from GHCR instead of building from
 # source. Set GUARD_PROXY_IMAGE_TAG (see .env.example) to the release
-# you want to run, e.g. v0.1.0-beta.2.
+# you want to run, e.g. v0.1.0-beta.3.
 
 services:
   postgres:
@@ -26,7 +26,7 @@ services:
       - gp_internal
 
   backend:
-    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-backend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.2}
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-backend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.3}
     restart: unless-stopped
     env_file:
       - .env
@@ -55,7 +55,7 @@ services:
       - gp_internal
 
   frontend:
-    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-frontend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.2}
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-frontend:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.3}
     restart: unless-stopped
     environment:
       # Explicit base URL is optional. If unset, the frontend uses relative
@@ -77,7 +77,7 @@ services:
       - gp_internal
 
   coraza:
-    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-coraza:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.2}
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-coraza:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.3}
     restart: unless-stopped
     depends_on:
       backend:
@@ -95,7 +95,7 @@ services:
       - gp_internal
 
   log-shipper:
-    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-log-shipper:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.2}
+    image: ${GUARD_PROXY_IMAGE_REPO:-ghcr.io/bihius}/guard-proxy-log-shipper:${GUARD_PROXY_IMAGE_TAG:?set GUARD_PROXY_IMAGE_TAG in .env, e.g. v0.1.0-beta.3}
     restart: unless-stopped
     env_file:
       - .env

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-backend"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Guard Proxy — admin panel REST API"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-backend"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guard-proxy-frontend",
   "private": true,
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "type": "module",
   "packageManager": "pnpm@10.30.0",
   "scripts": {

--- a/src/log-shipper/pyproject.toml
+++ b/src/log-shipper/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guard-proxy-log-shipper"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Guard Proxy — Coraza audit log to ingest endpoint sidecar"
 requires-python = ">=3.13"
 dependencies = []   # runtime: stdlib only

--- a/src/log-shipper/uv.lock
+++ b/src/log-shipper/uv.lock
@@ -126,7 +126,7 @@ wheels = [
 
 [[package]]
 name = "guard-proxy-log-shipper"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump backend, frontend, and log-shipper package versions to 0.1.0-beta.3
- Update release-kit references (`.env.example`, `docker-compose.yml`, `README.md`) to the new tag
- Add CHANGELOG entry summarizing changes since 0.1.0-beta.2 (banned-IPs admin UI, DDoS/auto-ban form UX, Apply-config reconciliation fix, banned-ips 502 fix)

## Test plan
- [x] `uv run pytest --cov=app`
- [x] `uv run mypy app/`
- [x] `uv run ruff check app/`
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm run test`