### PR TITLE
feat(geoip): per-policy country allowlist/blocklist filtering

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -25,11 +25,11 @@ CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
 # Number of days to keep log rows before the retention cleanup removes them.
 # LOG_RETENTION_DAYS=30
 
-# Optional GeoIP country filtering (issue #175)
-# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
-# Leave unset to disable database downloads — filtering then always fails open.
-# MAXMIND_LICENSE_KEY=
-# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GeoIP country filtering (issue #175)
+# Free, no license key, no registration required. Database from ip66.dev,
+# licensed CC BY 4.0, rebuilt daily upstream.
+# GEOIP_DATABASE_URL=https://downloads.ip66.dev/db/ip66.mmdb
+# GEOIP_REFRESH_INTERVAL_DAYS=1
 # GEOIP_FAIL_OPEN=true
 
 # Local admin seed used by `make seed` and the benchmark lab.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -25,6 +25,13 @@ CORS_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
 # Number of days to keep log rows before the retention cleanup removes them.
 # LOG_RETENTION_DAYS=30
 
+# Optional GeoIP country filtering (issue #175)
+# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
+# Leave unset to disable database downloads — filtering then always fails open.
+# MAXMIND_LICENSE_KEY=
+# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GEOIP_FAIL_OPEN=true
+
 # Local admin seed used by `make seed` and the benchmark lab.
 # Should be changed after initial deployment. 
 # ADMIN_EMAIL=admin@domain.com

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,14 +139,25 @@ A policy can restrict a vhost by client country (issue #175) with `geoip_mode`
 (`off` / `allowlist` / `blocklist`) and `geoip_countries` (a list of ISO
 3166-1 alpha-2 codes). The mechanism is intentionally native to HAProxy:
 
-1. `app.services.geoip_service.download_database()` downloads the free
-   MaxMind GeoLite2-Country MMDB using a license key supplied via
-   `MAXMIND_LICENSE_KEY`.
+1. `app.services.geoip_service.download_database()` downloads the free,
+   no-registration, no-license-key country-level MMDB published by
+   [ip66.dev](https://ip66.dev) from `GEOIP_DATABASE_URL`. GeoIP data is
+   provided by ip66.dev and licensed under
+   [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The download is
+   a conditional GET using the ETag/Last-Modified validators persisted from
+   the previous run; a `304 Not Modified` response is a no-op.
 2. `generate_map_file()` converts the MMDB into a plain-text HAProxy map file
    (`CIDR <space> ISO-country-code` per line), written atomically
    (`os.replace()`) to `<runtime_root>/geoip/country.map` on the shared
    `guard_proxy_runtime` volume — the same volume HAProxy reads at
-   `/etc/haproxy/generated`.
+   `/etc/haproxy/generated`. Because ip66.dev splits blocks by ASN as well as
+   by country, adjacent networks are grouped by `(country_code, ip_version)`
+   and merged with `ipaddress.collapse_addresses()` before writing, cutting
+   roughly 1.3M raw networks down to ~920k lines (~18 MB). Merging is done per
+   run of consecutive same-country networks as the reader streams them, not by
+   buffering everything first: only networks adjacent in address space can
+   merge, so the result is identical while peak memory stays around 70 MB
+   instead of ~780 MB.
 3. The generated `haproxy.cfg` uses HAProxy's native `map_ip()` fetch against
    that file to resolve `src` to a country in `var(txn.geoip_country)`, then
    denies with `403` when the resolved (or absent) country violates the
@@ -154,11 +165,22 @@ A policy can restrict a vhost by client country (issue #175) with `geoip_mode`
    map lookup is table-driven and fully supported by stock HAProxy, and
    `haproxy -c` never fails because of a missing map: a non-empty stub map is
    always written first if no real database has been downloaded yet.
-4. A weekly APScheduler job (`refresh_geoip_database`, interval controlled by
-   `GEOIP_REFRESH_INTERVAL_DAYS`) re-downloads the MMDB and regenerates the
-   map. `POST /geoip/refresh` (admin only) triggers the same pipeline
-   on-demand. Both paths reload HAProxy only when the generated map actually
-   changed, so a no-op refresh does not cause an unnecessary reload.
+   Country codes are emitted as repeated same-name ACLs of 50 codes each,
+   which HAProxy ORs together — HAProxy truncates any config line after 64
+   words, so a single-line list of every ISO code yields a fatally invalid
+   config. Only ACME challenges are exempt from the deny rules (they have
+   their own local `backend_acme`); `/health` deliberately is **not**, because
+   it is a host-independent path match routed to the customer origin and
+   exempting it would make it a trivial full bypass of country filtering.
+   Loading the ~920k-entry map costs HAProxy roughly **280 MB RSS**
+   (measured on `haproxy:3.0-alpine`), which is the main operational cost of
+   this feature.
+4. A daily APScheduler job (`refresh_geoip_database`, interval controlled by
+   `GEOIP_REFRESH_INTERVAL_DAYS`, matching ip66.dev's daily rebuild cadence)
+   re-downloads the MMDB and regenerates the map. `POST /geoip/refresh`
+   (admin only) triggers the same pipeline on-demand. Both paths reload
+   HAProxy only when the generated map actually changed, so a no-op refresh
+   does not cause an unnecessary reload.
 
 **Fail-open by default.** Unlike the SPOE WAF inspection path above — which
 fails *closed* with `503` because an unavailable Coraza SPOA is a security
@@ -170,6 +192,16 @@ sense; it must never take a site offline on its own. This default is
 controlled by `GEOIP_FAIL_OPEN` (default `true`); set `GEOIP_FAIL_OPEN=false`
 to fail closed instead, at the cost of blocking traffic whenever geolocation
 data is unavailable.
+
+**Not every address resolves to a country.** Around 306k networks in the
+upstream database carry no country at all, and a further ~90k are labelled
+`EU` — a Europe-wide allocation that is not an ISO 3166-1 country. Those are
+left unresolved, so with the default fail-open they are **allowed even in
+allowlist mode**: an allowlist of `PL` alone still admits every `EU`-labelled
+network. Set `GEOIP_FAIL_OPEN=false` if that is unacceptable. The one code
+that is rewritten is `UK`, which the database uses for a handful of networks
+that ISO 3166-1 spells `GB`; without that alias, blocking `GB` would silently
+miss them.
 
 ## Authentication & Rate Limiting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,44 @@ independently queryable or filterable. See
 and `::test_multi_rule_request_preserves_all_matched_rules_in_raw_context`
 for the tested behavior. A per-rule breakdown is deferred post-MVP.
 
+## GeoIP Country Filtering
+
+A policy can restrict a vhost by client country (issue #175) with `geoip_mode`
+(`off` / `allowlist` / `blocklist`) and `geoip_countries` (a list of ISO
+3166-1 alpha-2 codes). The mechanism is intentionally native to HAProxy:
+
+1. `app.services.geoip_service.download_database()` downloads the free
+   MaxMind GeoLite2-Country MMDB using a license key supplied via
+   `MAXMIND_LICENSE_KEY`.
+2. `generate_map_file()` converts the MMDB into a plain-text HAProxy map file
+   (`CIDR <space> ISO-country-code` per line), written atomically
+   (`os.replace()`) to `<runtime_root>/geoip/country.map` on the shared
+   `guard_proxy_runtime` volume — the same volume HAProxy reads at
+   `/etc/haproxy/generated`.
+3. The generated `haproxy.cfg` uses HAProxy's native `map_ip()` fetch against
+   that file to resolve `src` to a country in `var(txn.geoip_country)`, then
+   denies with `403` when the resolved (or absent) country violates the
+   configured mode. No Lua and no HAProxy MMDB module are required — the
+   map lookup is table-driven and fully supported by stock HAProxy, and
+   `haproxy -c` never fails because of a missing map: a non-empty stub map is
+   always written first if no real database has been downloaded yet.
+4. A weekly APScheduler job (`refresh_geoip_database`, interval controlled by
+   `GEOIP_REFRESH_INTERVAL_DAYS`) re-downloads the MMDB and regenerates the
+   map. `POST /geoip/refresh` (admin only) triggers the same pipeline
+   on-demand. Both paths reload HAProxy only when the generated map actually
+   changed, so a no-op refresh does not cause an unnecessary reload.
+
+**Fail-open by default.** Unlike the SPOE WAF inspection path above — which
+fails *closed* with `503` because an unavailable Coraza SPOA is a security
+control failure that must stop traffic — GeoIP filtering fails *open*
+(allows the request) by default when the map is missing, the database has
+never been downloaded, or an IP cannot be resolved to a country. A stale or
+absent geolocation database is not a security control failure in the same
+sense; it must never take a site offline on its own. This default is
+controlled by `GEOIP_FAIL_OPEN` (default `true`); set `GEOIP_FAIL_OPEN=false`
+to fail closed instead, at the cost of blocking traffic whenever geolocation
+data is unavailable.
+
 ## Authentication & Rate Limiting
 
 The FastAPI backend issues short-lived **JWT access tokens** (30 min, HS256) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,11 @@ A policy can restrict a vhost by client country (issue #175) with `geoip_mode`
    exempting it would make it a trivial full bypass of country filtering.
    Loading the ~920k-entry map costs HAProxy roughly **280 MB RSS**
    (measured on `haproxy:3.0-alpine`), which is the main operational cost of
-   this feature.
+   this feature. Budget for **double that** on the host: a reload runs the
+   old and new processes side by side, so the peak is ~560 MB. The `map_ip()`
+   lookup itself is emitted once per frontend and so runs for all traffic,
+   including vhosts with `geoip_mode = off`; a radix lookup is cheap, but the
+   resident map is not.
 4. A daily APScheduler job (`refresh_geoip_database`, interval controlled by
    `GEOIP_REFRESH_INTERVAL_DAYS`, matching ip66.dev's daily rebuild cadence)
    re-downloads the MMDB and regenerates the map. `POST /geoip/refresh`
@@ -191,7 +195,10 @@ absent geolocation database is not a security control failure in the same
 sense; it must never take a site offline on its own. This default is
 controlled by `GEOIP_FAIL_OPEN` (default `true`); set `GEOIP_FAIL_OPEN=false`
 to fail closed instead, at the cost of blocking traffic whenever geolocation
-data is unavailable.
+data is unavailable. Note this setting is read when the config is
+*generated*, not at request time — it is baked into the rendered
+`haproxy.cfg`, so changing the environment variable takes effect only after a
+full config re-apply, not on a plain HAProxy reload.
 
 **Not every address resolves to a country.** Around 306k networks in the
 upstream database carry no country at all, and a further ~90k are labelled

--- a/release/.env.example
+++ b/release/.env.example
@@ -29,6 +29,15 @@ CORS_ORIGINS=["https://admin.example.com"]
 # Number of days to keep log rows before the retention cleanup removes them.
 # LOG_RETENTION_DAYS=30
 
+# Optional GeoIP country filtering (issue #175)
+# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
+# Leave unset to disable database downloads — filtering then always fails open.
+# These placeholders are not safe defaults either: replace MAXMIND_LICENSE_KEY
+# with your own key if you want country filtering to work.
+# MAXMIND_LICENSE_KEY=
+# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GEOIP_FAIL_OPEN=true
+
 # Not read at container startup. The install guide's seed_admin.py step
 # passes ADMIN_EMAIL/ADMIN_PASSWORD via `docker compose exec -e ...` instead
 # of setting them here, so a plaintext admin password isn't left at rest —

--- a/release/.env.example
+++ b/release/.env.example
@@ -29,13 +29,11 @@ CORS_ORIGINS=["https://admin.example.com"]
 # Number of days to keep log rows before the retention cleanup removes them.
 # LOG_RETENTION_DAYS=30
 
-# Optional GeoIP country filtering (issue #175)
-# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
-# Leave unset to disable database downloads — filtering then always fails open.
-# These placeholders are not safe defaults either: replace MAXMIND_LICENSE_KEY
-# with your own key if you want country filtering to work.
-# MAXMIND_LICENSE_KEY=
-# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GeoIP country filtering (issue #175)
+# Free, no license key, no registration required. Database from ip66.dev,
+# licensed CC BY 4.0, rebuilt daily upstream.
+# GEOIP_DATABASE_URL=https://downloads.ip66.dev/db/ip66.mmdb
+# GEOIP_REFRESH_INTERVAL_DAYS=1
 # GEOIP_FAIL_OPEN=true
 
 # Not read at container startup. The install guide's seed_admin.py step

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -45,6 +45,13 @@ DEBUG=false
 # HAPROXY_STATS_SOCKET_PATH=/var/run/haproxy/admin.sock
 # HAPROXY_STATS_TIMEOUT_SECONDS=10
 
+# Optional GeoIP country filtering (issue #175)
+# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
+# Leave unset to disable database downloads — filtering then always fails open.
+# MAXMIND_LICENSE_KEY=
+# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GEOIP_FAIL_OPEN=true
+
 # Optional: used by scripts/seed_admin.py
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_PASSWORD=change-me-please

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -45,11 +45,11 @@ DEBUG=false
 # HAPROXY_STATS_SOCKET_PATH=/var/run/haproxy/admin.sock
 # HAPROXY_STATS_TIMEOUT_SECONDS=10
 
-# Optional GeoIP country filtering (issue #175)
-# Free GeoLite2 license key from https://www.maxmind.com/en/geolite2/signup
-# Leave unset to disable database downloads — filtering then always fails open.
-# MAXMIND_LICENSE_KEY=
-# GEOIP_REFRESH_INTERVAL_DAYS=7
+# GeoIP country filtering (issue #175)
+# Free, no license key, no registration required. Database from ip66.dev,
+# licensed CC BY 4.0, rebuilt daily upstream.
+# GEOIP_DATABASE_URL=https://downloads.ip66.dev/db/ip66.mmdb
+# GEOIP_REFRESH_INTERVAL_DAYS=1
 # GEOIP_FAIL_OPEN=true
 
 # Optional: used by scripts/seed_admin.py

--- a/src/backend/alembic/versions/80557e183990_add_geoip_fields_to_policies.py
+++ b/src/backend/alembic/versions/80557e183990_add_geoip_fields_to_policies.py
@@ -1,0 +1,50 @@
+"""add geoip fields to policies
+
+Revision ID: 80557e183990
+Revises: ea9292cbacec
+Create Date: 2026-07-28 15:24:25.952624
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "80557e183990"
+down_revision: str | Sequence[str] | None = "ea9292cbacec"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "geoip_mode",
+                sa.Enum("off", "allowlist", "blocklist", name="policygeoipmode"),
+                nullable=False,
+                server_default="off",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "geoip_countries",
+                sa.JSON(),
+                nullable=False,
+                server_default=sa.text("'[]'"),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("policies") as batch_op:
+        batch_op.drop_column("geoip_countries")
+        batch_op.drop_column("geoip_mode")
+    sa.Enum("off", "allowlist", "blocklist", name="policygeoipmode").drop(
+        op.get_bind(), checkfirst=True
+    )

--- a/src/backend/alembic/versions/80557e183990_add_geoip_fields_to_policies.py
+++ b/src/backend/alembic/versions/80557e183990_add_geoip_fields_to_policies.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-28 15:24:25.952624
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -19,13 +20,35 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _policy_geoip_mode_enum() -> sa.Enum:
+    return sa.Enum("off", "allowlist", "blocklist", name="policygeoipmode")
+
+
 def upgrade() -> None:
     """Upgrade schema."""
+    context = op.get_context()
+    bind = op.get_bind()
+
+    # PostgreSQL needs the ENUM type to exist before a column can reference
+    # it; add_column does not create it implicitly. Mirrors the pattern used
+    # by 8d4f2a6c1b90 for policyenforcementmode.
+    if context.dialect.name == "postgresql":
+        _policy_geoip_mode_enum().create(bind, checkfirst=True)
+        geoip_mode_enum: sa.types.TypeEngine[str] = postgresql.ENUM(
+            "off",
+            "allowlist",
+            "blocklist",
+            name="policygeoipmode",
+            create_type=False,
+        )
+    else:
+        geoip_mode_enum = _policy_geoip_mode_enum()
+
     with op.batch_alter_table("policies") as batch_op:
         batch_op.add_column(
             sa.Column(
                 "geoip_mode",
-                sa.Enum("off", "allowlist", "blocklist", name="policygeoipmode"),
+                geoip_mode_enum,
                 nullable=False,
                 server_default="off",
             )

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -80,11 +80,11 @@ class Settings(EnvFileSettings):
     haproxy_stats_timeout_seconds: int = 10
     log_retention_days: int = 30
 
-    # GeoIP country filtering (issue #175). An empty license key means the
-    # feature is not configured — GeoIP filtering then always fails open
-    # (see geoip_fail_open) because no database can be downloaded.
-    maxmind_license_key: str = ""
-    geoip_refresh_interval_days: int = 7
+    # GeoIP country filtering (issue #175). The database is downloaded from
+    # ip66.dev (free, no license key, rebuilt daily upstream) and refreshed
+    # on the schedule below.
+    geoip_database_url: str = "https://downloads.ip66.dev/db/ip66.mmdb"
+    geoip_refresh_interval_days: int = 1
     geoip_fail_open: bool = True
 
     @field_validator("database_url")
@@ -129,15 +129,12 @@ class Settings(EnvFileSettings):
             raise ValueError("GEOIP_REFRESH_INTERVAL_DAYS must be greater than zero.")
         return value
 
-    @field_validator("maxmind_license_key")
+    @field_validator("geoip_database_url")
     @classmethod
-    def maxmind_license_key_strip_whitespace(cls, value: str) -> str:
-        """Strip whitespace so a whitespace-only value counts as unset.
-
-        Unlike JWT_SECRET_KEY, an empty value here is a legitimate "feature
-        not configured" state and must not run through `_validate_secret`.
-        """
-        return value.strip()
+    def geoip_database_url_must_not_be_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("GEOIP_DATABASE_URL must not be empty.")
+        return value
 
     # JWT
     jwt_secret_key: str

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -80,6 +80,13 @@ class Settings(EnvFileSettings):
     haproxy_stats_timeout_seconds: int = 10
     log_retention_days: int = 30
 
+    # GeoIP country filtering (issue #175). An empty license key means the
+    # feature is not configured — GeoIP filtering then always fails open
+    # (see geoip_fail_open) because no database can be downloaded.
+    maxmind_license_key: str = ""
+    geoip_refresh_interval_days: int = 7
+    geoip_fail_open: bool = True
+
     @field_validator("database_url")
     @classmethod
     def database_url_must_not_be_empty(cls, value: str) -> str:
@@ -114,6 +121,23 @@ class Settings(EnvFileSettings):
         if value <= 0:
             raise ValueError("LOG_RETENTION_DAYS must be greater than zero.")
         return value
+
+    @field_validator("geoip_refresh_interval_days")
+    @classmethod
+    def geoip_refresh_interval_days_must_be_positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("GEOIP_REFRESH_INTERVAL_DAYS must be greater than zero.")
+        return value
+
+    @field_validator("maxmind_license_key")
+    @classmethod
+    def maxmind_license_key_strip_whitespace(cls, value: str) -> str:
+        """Strip whitespace so a whitespace-only value counts as unset.
+
+        Unlike JWT_SECRET_KEY, an empty value here is a legitimate "feature
+        not configured" state and must not run through `_validate_secret`.
+        """
+        return value.strip()
 
     # JWT
     jwt_secret_key: str

--- a/src/backend/app/constants/__init__.py
+++ b/src/backend/app/constants/__init__.py
@@ -1,0 +1,1 @@
+"""Static, app-wide constant data (no runtime dependencies)."""

--- a/src/backend/app/constants/countries.py
+++ b/src/backend/app/constants/countries.py
@@ -1,0 +1,55 @@
+"""ISO 3166-1 alpha-2 country codes for GeoIP filtering (issue #175).
+
+This is a static hardcoded list of the 249 officially assigned ISO 3166-1
+alpha-2 codes, plus the "ZZ" sentinel used internally to mark GeoLite2
+records that resolve to an unknown/reserved country. Keeping this list
+hardcoded avoids adding a `pycountry` runtime dependency for what is a very
+small, very stable dataset.
+
+The frontend keeps a parallel copy for client-side validation in
+`src/frontend/src/features/policies/countries.ts` — keep the two in sync.
+"""
+
+from __future__ import annotations
+
+_ISO_3166_1_ALPHA_2 = frozenset(
+    {
+        "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR",
+        "AS", "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE",
+        "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ",
+        "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD",
+        "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CR",
+        "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM",
+        "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI",
+        "FJ", "FK", "FM", "FO", "FR", "GA", "GB", "GD", "GE", "GF",
+        "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS",
+        "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU",
+        "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT",
+        "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN",
+        "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK",
+        "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME",
+        "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ",
+        "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA",
+        "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NU",
+        "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM",
+        "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS",
+        "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI",
+        "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SV",
+        "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK",
+        "TL", "TM", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA",
+        "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
+        "VN", "VU", "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW",
+    }
+)
+
+# "ZZ" is not an assigned ISO 3166-1 alpha-2 code; it is the sentinel used
+# internally (see app/services/geoip_service.py) for GeoLite2 records that
+# have no resolvable country. It is included here so generated map entries
+# validate, but it is explicitly rejected as an admin-selectable country in
+# app/schemas/policy.py.
+VALID_COUNTRY_CODES: frozenset[str] = _ISO_3166_1_ALPHA_2 | {"ZZ"}
+
+
+def normalize_country_code(value: str) -> str:
+    """Normalize a country code for comparison/storage (strip + upper)."""
+    return value.strip().upper()

--- a/src/backend/app/constants/countries.py
+++ b/src/backend/app/constants/countries.py
@@ -42,11 +42,17 @@ _ISO_3166_1_ALPHA_2 = frozenset(
     }
 )
 
-# "ZZ" is not an assigned ISO 3166-1 alpha-2 code; it is the sentinel used
-# internally (see app/services/geoip_service.py) for GeoIP database records
-# that have no resolvable country. It is included here so generated map
-# entries validate, but it is explicitly rejected as an admin-selectable
-# country in app/schemas/policy.py.
+# Codes that may appear in a generated map entry. "ZZ" is deliberately NOT
+# one of them: it is only a placeholder inside the stub map file written
+# before any real database exists. Emitting it as a resolved country would
+# defeat fail-open — in allowlist mode `var(txn.geoip_country) -m found`
+# would be true while "ZZ" matched no allowed code, so the request would be
+# denied instead of allowed.
+MAPPABLE_COUNTRY_CODES: frozenset[str] = _ISO_3166_1_ALPHA_2
+
+# Codes accepted anywhere a country is referenced, including the internal
+# "ZZ" sentinel. "ZZ" is rejected as an admin-selectable country in
+# app/schemas/policy.py.
 VALID_COUNTRY_CODES: frozenset[str] = _ISO_3166_1_ALPHA_2 | {"ZZ"}
 
 

--- a/src/backend/app/constants/countries.py
+++ b/src/backend/app/constants/countries.py
@@ -1,7 +1,7 @@
 """ISO 3166-1 alpha-2 country codes for GeoIP filtering (issue #175).
 
 This is a static hardcoded list of the 249 officially assigned ISO 3166-1
-alpha-2 codes, plus the "ZZ" sentinel used internally to mark GeoLite2
+alpha-2 codes, plus the "ZZ" sentinel used internally to mark GeoIP database
 records that resolve to an unknown/reserved country. Keeping this list
 hardcoded avoids adding a `pycountry` runtime dependency for what is a very
 small, very stable dataset.
@@ -43,10 +43,10 @@ _ISO_3166_1_ALPHA_2 = frozenset(
 )
 
 # "ZZ" is not an assigned ISO 3166-1 alpha-2 code; it is the sentinel used
-# internally (see app/services/geoip_service.py) for GeoLite2 records that
-# have no resolvable country. It is included here so generated map entries
-# validate, but it is explicitly rejected as an admin-selectable country in
-# app/schemas/policy.py.
+# internally (see app/services/geoip_service.py) for GeoIP database records
+# that have no resolvable country. It is included here so generated map
+# entries validate, but it is explicitly rejected as an admin-selectable
+# country in app/schemas/policy.py.
 VALID_COUNTRY_CODES: frozenset[str] = _ISO_3166_1_ALPHA_2 | {"ZZ"}
 
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -34,6 +34,7 @@ from app.routers import (
     auth,
     config,
     custom_rules,
+    geoip,
     logs,
     policies,
     rule_exclusions,
@@ -196,6 +197,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(config.router)
 app.include_router(custom_rules.router)
+app.include_router(geoip.router)
 app.include_router(logs.router)
 app.include_router(policies.router)
 app.include_router(rule_exclusions.router)

--- a/src/backend/app/models/policy.py
+++ b/src/backend/app/models/policy.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     CheckConstraint,
     DateTime,
@@ -34,6 +35,14 @@ class PolicyEnforcementMode(enum.StrEnum):
 
     block = "block"
     detect_only = "detect_only"
+
+
+class PolicyGeoipMode(enum.StrEnum):
+    """GeoIP country filtering mode for a policy."""
+
+    off = "off"
+    allowlist = "allowlist"
+    blocklist = "blocklist"
 
 
 class Policy(Base):
@@ -151,6 +160,19 @@ class Policy(Base):
         Integer,
         nullable=False,
         default=600,  # ban duration (idle-expiry), in seconds
+    )
+
+    # GeoIP country filtering (issue #175). geoip_countries is a whole-list
+    # replacement field: PATCH always assigns a fresh list, so MutableList
+    # change tracking is deliberately not needed. There is no CheckConstraint
+    # for the countries list — JSON content is validated in the schema/service
+    # layer (matching how CRS target values are handled elsewhere); the enum
+    # column already constrains geoip_mode.
+    geoip_mode: Mapped[PolicyGeoipMode] = mapped_column(
+        Enum(PolicyGeoipMode), nullable=False, default=PolicyGeoipMode.off
+    )
+    geoip_countries: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=list
     )
 
     # Audit — who created the policy

--- a/src/backend/app/routers/geoip.py
+++ b/src/backend/app/routers/geoip.py
@@ -20,7 +20,7 @@ def refresh_geoip_database(
 ) -> GeoipRefreshResponse:
     """Trigger an on-demand GeoIP database refresh (admin only).
 
-    Shares its implementation with the scheduled weekly refresh job (see
+    Shares its implementation with the scheduled daily refresh job (see
     app.services.scheduler.refresh_geoip_database).
     """
     if not _refresh_lock.acquire(blocking=False):
@@ -33,17 +33,10 @@ def refresh_geoip_database(
     finally:
         _refresh_lock.release()
 
-    response = GeoipRefreshResponse(
-        configured=result.configured,
+    return GeoipRefreshResponse(
         downloaded=result.downloaded,
         entries=result.entries,
         changed=result.changed,
         reloaded=result.reloaded,
         message=result.message,
     )
-    if not result.configured:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=response.message,
-        )
-    return response

--- a/src/backend/app/routers/geoip.py
+++ b/src/backend/app/routers/geoip.py
@@ -1,0 +1,49 @@
+"""GeoIP database refresh API router (issue #175)."""
+
+import threading
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.dependencies import require_admin
+from app.models.user import User
+from app.schemas.geoip import GeoipRefreshResponse
+from app.services import geoip_service
+
+router = APIRouter(prefix="/geoip", tags=["geoip"])
+
+# Guards against concurrent refreshes, matching app.routers.config._apply_lock.
+_refresh_lock = threading.Lock()
+
+@router.post("/refresh", response_model=GeoipRefreshResponse)
+def refresh_geoip_database(
+    _: User = Depends(require_admin),
+) -> GeoipRefreshResponse:
+    """Trigger an on-demand GeoIP database refresh (admin only).
+
+    Shares its implementation with the scheduled weekly refresh job (see
+    app.services.scheduler.refresh_geoip_database).
+    """
+    if not _refresh_lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A GeoIP refresh is already running",
+        )
+    try:
+        result = geoip_service.refresh()
+    finally:
+        _refresh_lock.release()
+
+    response = GeoipRefreshResponse(
+        configured=result.configured,
+        downloaded=result.downloaded,
+        entries=result.entries,
+        changed=result.changed,
+        reloaded=result.reloaded,
+        message=result.message,
+    )
+    if not result.configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=response.message,
+        )
+    return response

--- a/src/backend/app/routers/geoip.py
+++ b/src/backend/app/routers/geoip.py
@@ -1,7 +1,5 @@
 """GeoIP database refresh API router (issue #175)."""
 
-import threading
-
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.dependencies import require_admin
@@ -11,8 +9,6 @@ from app.services import geoip_service
 
 router = APIRouter(prefix="/geoip", tags=["geoip"])
 
-# Guards against concurrent refreshes, matching app.routers.config._apply_lock.
-_refresh_lock = threading.Lock()
 
 @router.post("/refresh", response_model=GeoipRefreshResponse)
 def refresh_geoip_database(
@@ -21,17 +17,16 @@ def refresh_geoip_database(
     """Trigger an on-demand GeoIP database refresh (admin only).
 
     Shares its implementation with the scheduled daily refresh job (see
-    app.services.scheduler.refresh_geoip_database).
+    app.services.scheduler.refresh_geoip_database). The concurrency guard
+    lives in the service, not here, so the scheduled job contends for the
+    same lock — a lock held only by this router would not serialise the two.
     """
-    if not _refresh_lock.acquire(blocking=False):
+    result = geoip_service.try_refresh()
+    if result is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="A GeoIP refresh is already running",
         )
-    try:
-        result = geoip_service.refresh()
-    finally:
-        _refresh_lock.release()
 
     return GeoipRefreshResponse(
         downloaded=result.downloaded,

--- a/src/backend/app/routers/policies.py
+++ b/src/backend/app/routers/policies.py
@@ -18,6 +18,7 @@ from app.services.policy_service import (
     PolicyDatabaseConstraintError,
     PolicyDisallowedFieldError,
     PolicyFieldCannotBeNullError,
+    PolicyGeoipConfigurationError,
     PolicyInUseError,
     PolicyNameAlreadyExistsError,
     PolicyNotFoundError,
@@ -51,6 +52,8 @@ def create_policy(
             auto_ban_enabled=body.auto_ban_enabled,
             ban_threshold=body.ban_threshold,
             ban_duration_seconds=body.ban_duration_seconds,
+            geoip_mode=body.geoip_mode,
+            geoip_countries=body.geoip_countries,
             created_by=current_user.id,
         )
     except PolicyNameAlreadyExistsError as error:
@@ -62,6 +65,11 @@ def create_policy(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Database integrity constraint violated",
+        ) from error
+    except PolicyGeoipConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
         ) from error
 
 
@@ -135,6 +143,11 @@ def update_policy(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Database integrity constraint violated",
+        ) from error
+    except PolicyGeoipConfigurationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(error),
         ) from error
 
 

--- a/src/backend/app/schemas/geoip.py
+++ b/src/backend/app/schemas/geoip.py
@@ -1,0 +1,14 @@
+"""Pydantic schemas for the GeoIP database refresh endpoint."""
+
+from pydantic import BaseModel
+
+
+class GeoipRefreshResponse(BaseModel):
+    """Result of a GeoIP database refresh run returned by POST /geoip/refresh."""
+
+    configured: bool
+    downloaded: bool
+    entries: int
+    changed: bool
+    reloaded: bool
+    message: str

--- a/src/backend/app/schemas/geoip.py
+++ b/src/backend/app/schemas/geoip.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 class GeoipRefreshResponse(BaseModel):
     """Result of a GeoIP database refresh run returned by POST /geoip/refresh."""
 
-    configured: bool
     downloaded: bool
     entries: int
     changed: bool

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -4,10 +4,32 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from app.models.policy import PolicyEnforcementMode
+from app.constants.countries import VALID_COUNTRY_CODES
+from app.models.policy import PolicyEnforcementMode, PolicyGeoipMode
 from app.schemas.custom_rule import CustomRuleResponse
 from app.schemas.rule_exclusion import RuleExclusionResponse
 from app.schemas.rule_override import RuleOverrideResponse
+
+
+def _normalize_and_validate_countries(codes: list[str]) -> list[str]:
+    """Uppercase/strip, drop empties, de-duplicate (first-seen order kept).
+
+    Raises ValueError for any code not in VALID_COUNTRY_CODES. "ZZ" is
+    explicitly rejected — it is an internal sentinel for unresolved GeoLite2
+    records, not an admin-selectable country.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in codes:
+        code = raw.strip().upper()
+        if not code:
+            continue
+        if code == "ZZ" or code not in VALID_COUNTRY_CODES:
+            raise ValueError(f"Unknown country code: {code}")
+        if code not in seen:
+            seen.add(code)
+            normalized.append(code)
+    return normalized
 
 
 class PolicyCreate(BaseModel):
@@ -26,6 +48,8 @@ class PolicyCreate(BaseModel):
     auto_ban_enabled: bool = False
     ban_threshold: int = Field(default=10, ge=1)
     ban_duration_seconds: int = Field(default=600, ge=1, le=86400)
+    geoip_mode: PolicyGeoipMode = PolicyGeoipMode.off
+    geoip_countries: list[str] = Field(default_factory=list, max_length=250)
 
     @field_validator("inbound_anomaly_threshold", "outbound_anomaly_threshold")
     @classmethod
@@ -34,6 +58,11 @@ class PolicyCreate(BaseModel):
         if v < 1:
             raise ValueError("Anomaly threshold must be at least 1")
         return v
+
+    @field_validator("geoip_countries")
+    @classmethod
+    def geoip_countries_valid(cls, v: list[str]) -> list[str]:
+        return _normalize_and_validate_countries(v)
 
 
 class PolicyUpdate(BaseModel):
@@ -56,6 +85,15 @@ class PolicyUpdate(BaseModel):
     auto_ban_enabled: bool | None = None
     ban_threshold: int | None = Field(default=None, ge=1)
     ban_duration_seconds: int | None = Field(default=None, ge=1, le=86400)
+    # geoip_mode/geoip_countries are validated independently here (format and
+    # known-code checks only). The cross-field rule "geoip_countries must be
+    # non-empty when geoip_mode != off" is intentionally NOT a schema
+    # validator: PATCH is partial and this schema cannot see the row's
+    # currently stored values, so that rule lives in
+    # app.services.policy_service._validate_geoip instead. Do not "fix" this
+    # by adding a model_validator here.
+    geoip_mode: PolicyGeoipMode | None = None
+    geoip_countries: list[str] | None = Field(default=None, max_length=250)
 
     @field_validator("inbound_anomaly_threshold", "outbound_anomaly_threshold")
     @classmethod
@@ -63,6 +101,13 @@ class PolicyUpdate(BaseModel):
         if v is not None and v < 1:
             raise ValueError("Anomaly threshold must be at least 1")
         return v
+
+    @field_validator("geoip_countries")
+    @classmethod
+    def geoip_countries_valid(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        return _normalize_and_validate_countries(v)
 
 
 class PolicyResponse(BaseModel):
@@ -85,6 +130,8 @@ class PolicyResponse(BaseModel):
     auto_ban_enabled: bool
     ban_threshold: int
     ban_duration_seconds: int
+    geoip_mode: PolicyGeoipMode
+    geoip_countries: list[str]
     created_by: int | None
     created_at: datetime
     updated_at: datetime

--- a/src/backend/app/schemas/policy.py
+++ b/src/backend/app/schemas/policy.py
@@ -15,8 +15,8 @@ def _normalize_and_validate_countries(codes: list[str]) -> list[str]:
     """Uppercase/strip, drop empties, de-duplicate (first-seen order kept).
 
     Raises ValueError for any code not in VALID_COUNTRY_CODES. "ZZ" is
-    explicitly rejected — it is an internal sentinel for unresolved GeoLite2
-    records, not an admin-selectable country.
+    explicitly rejected — it is an internal sentinel for unresolved GeoIP
+    database records, not an admin-selectable country.
     """
     normalized: list[str] = []
     seen: set[str] = set()

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -63,6 +63,7 @@ class ApplyResult:
 
 def apply(generated: GeneratedConfig) -> ApplyResult:
     """Validate and atomically activate generated runtime config."""
+    _ensure_geoip_map_file()
     correlation_id = uuid.uuid4().hex
     checksum = calculate_checksum(generated)
     runtime_root = Path(settings.runtime_generated_config_root).resolve()
@@ -268,6 +269,10 @@ def seed_runtime_config(generated: GeneratedConfig) -> str | None:
     was deployed via the last `POST /config/apply` before the most recent
     restart.
     """
+    # Must run before the "release already exists" early return below,
+    # otherwise an existing deployment upgrading into the GeoIP feature would
+    # never get the stub map file that keeps `haproxy -c` passing.
+    _ensure_geoip_map_file()
     runtime_root = Path(settings.runtime_generated_config_root).resolve()
     current_link = runtime_root / "current"
 
@@ -318,9 +323,25 @@ class CommandResult:
     output: str
 
 
+def _ensure_geoip_map_file() -> None:
+    """Best-effort stub-write so a read-only/missing runtime dir cannot break apply."""
+    from app.services import geoip_service
+
+    try:
+        geoip_service.ensure_map_file_exists()
+    except OSError as error:
+        logger.warning("failed to ensure GeoIP map file exists: %s", error)
+
+
+def reload_haproxy() -> CommandResult:
+    """Reload HAProxy without rewriting the release. Used by the GeoIP map refresh."""
+    return _reload_haproxy()
+
+
 def _write_candidate(
     candidate_dir: Path, generated: GeneratedConfig, certs_dir: Path
 ) -> None:
+    _ensure_geoip_map_file()
     candidate_dir.mkdir(parents=True, exist_ok=False)
     (candidate_dir / "haproxy.cfg").write_text(generated.haproxy_cfg, encoding="utf-8")
     (candidate_dir / "crs-setup.conf").write_text(

--- a/src/backend/app/services/config_apply.py
+++ b/src/backend/app/services/config_apply.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import socket
 import subprocess
+import threading
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -24,6 +25,11 @@ from app.config import settings
 from app.services.config_generator import GeneratedConfig
 
 logger = logging.getLogger(__name__)
+
+# Serialises everything that mutates the live HAProxy runtime: full applies
+# and the standalone reload the GeoIP map refresh performs. Reentrant so an
+# apply can still call the internal reload helper while holding it.
+_apply_lock = threading.RLock()
 
 # Anchored to the start of a line so common benign substrings such as
 # "no error", "failover ready", or "warning: bind ... failed for ipv6,
@@ -63,6 +69,11 @@ class ApplyResult:
 
 def apply(generated: GeneratedConfig) -> ApplyResult:
     """Validate and atomically activate generated runtime config."""
+    with _apply_lock:
+        return _apply_locked(generated)
+
+
+def _apply_locked(generated: GeneratedConfig) -> ApplyResult:
     _ensure_geoip_map_file()
     correlation_id = uuid.uuid4().hex
     checksum = calculate_checksum(generated)
@@ -334,8 +345,16 @@ def _ensure_geoip_map_file() -> None:
 
 
 def reload_haproxy() -> CommandResult:
-    """Reload HAProxy without rewriting the release. Used by the GeoIP map refresh."""
-    return _reload_haproxy()
+    """Reload HAProxy without rewriting the release. Used by the GeoIP map refresh.
+
+    Takes the same lock as `apply()`. The GeoIP refresh runs on its own
+    schedule and is serialised by a different lock in the router, so without
+    this a refresh could reload HAProxy midway through an apply's
+    validate/swap/rollback sequence and activate a release that apply is in
+    the middle of reverting.
+    """
+    with _apply_lock:
+        return _reload_haproxy()
 
 
 def _write_candidate(

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from app.config import settings
 from app.models.custom_rule import CustomRule
-from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy import Policy, PolicyEnforcementMode, PolicyGeoipMode
 from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion
 from app.models.rule_override import RuleOverride
@@ -16,6 +17,7 @@ from app.services.config_renderer import (
     CustomRuleRenderContext,
     HaproxyBackend,
     HaproxyDdos,
+    HaproxyGeoip,
     HaproxyRenderContext,
     HaproxyRoute,
     HaproxyServer,
@@ -25,6 +27,12 @@ from app.services.config_renderer import (
     render_haproxy_cfg_multi,
     render_rule_overrides,
 )
+
+# Stable, non-versioned path on the shared `generated_config` volume. The
+# backend writes it at <runtime_root>/geoip/country.map; HAProxy reads the
+# same file through /etc/haproxy/generated. Deliberately outside
+# releases/<id>/ because the map is refreshed on its own weekly schedule.
+HAPROXY_GEOIP_MAP_PATH = "/etc/haproxy/generated/geoip/country.map"
 
 
 @dataclass(frozen=True)
@@ -246,6 +254,20 @@ def _to_haproxy_context(
         if policy is not None and policy.ddos_protection_enabled
         else None
     )
+    # settings is imported only for geoip_fail_open; this is the only
+    # settings read in this module.
+    geoip = (
+        HaproxyGeoip(
+            mode=policy.geoip_mode.value,
+            countries=tuple(policy.geoip_countries),
+            map_path=HAPROXY_GEOIP_MAP_PATH,
+            fail_open=settings.geoip_fail_open,
+        )
+        if policy is not None
+        and policy.geoip_mode != PolicyGeoipMode.off
+        and policy.geoip_countries
+        else None
+    )
 
     return HaproxyRenderContext(
         routes=(
@@ -254,6 +276,7 @@ def _to_haproxy_context(
                 vhost_hosts=(vhost.domain,),
                 ssl_provider=vhost.ssl_provider if vhost.ssl_enabled else "none",
                 ddos=ddos,
+                geoip=geoip,
                 backend=HaproxyBackend(
                     name=f"be_{suffix}",
                     health_check_path=health_check_path,

--- a/src/backend/app/services/config_generator.py
+++ b/src/backend/app/services/config_generator.py
@@ -31,7 +31,7 @@ from app.services.config_renderer import (
 # Stable, non-versioned path on the shared `generated_config` volume. The
 # backend writes it at <runtime_root>/geoip/country.map; HAProxy reads the
 # same file through /etc/haproxy/generated. Deliberately outside
-# releases/<id>/ because the map is refreshed on its own weekly schedule.
+# releases/<id>/ because the map is refreshed on its own daily schedule.
 HAPROXY_GEOIP_MAP_PATH = "/etc/haproxy/generated/geoip/country.map"
 
 

--- a/src/backend/app/services/config_renderer.py
+++ b/src/backend/app/services/config_renderer.py
@@ -24,6 +24,8 @@ _HAPROXY_HOST_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 # HAProxy backend address (host:port): same allowlist as host values.
 _HAPROXY_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
 _HAPROXY_HEALTH_PATH_RE = re.compile(r"^[A-Za-z0-9_./:-]+$")
+_ISO_COUNTRY_RE = re.compile(r"^[A-Z]{2}$")
+_HAPROXY_MAP_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
 _MODSEC_LINE_BREAK_RE = re.compile(r"[\r\n]")
 _MODSEC_TARGET_VALUE_RE = re.compile(r"^[A-Za-z0-9_.:/@-]+$")
 _MODSEC_VARIABLES_RE = re.compile(r"^[A-Za-z0-9_.:|@-]+$")
@@ -186,6 +188,39 @@ class HaproxyDdos:
 
 
 @dataclass(frozen=True)
+class HaproxyGeoip:
+    """Per-vhost GeoIP country filtering settings.
+
+    ``map_path`` points at a generated CIDR -> ISO 3166-1 alpha-2 map file
+    that HAProxy reads natively via ``map_ip()`` (no Lua, no MMDB module).
+    """
+
+    mode: str  # "allowlist" | "blocklist"
+    countries: tuple[str, ...]
+    map_path: str
+    fail_open: bool = True
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("allowlist", "blocklist"):
+            raise ValueError(
+                f"HaproxyGeoip.mode {self.mode!r} must be 'allowlist' or 'blocklist'"
+            )
+        if not self.countries:
+            raise ValueError("HaproxyGeoip.countries must not be empty")
+        for code in self.countries:
+            if not _ISO_COUNTRY_RE.match(code):
+                raise ValueError(
+                    f"HaproxyGeoip.countries {code!r} must be an uppercase "
+                    "two-letter ISO 3166-1 alpha-2 code"
+                )
+        if not self.map_path or not _HAPROXY_MAP_PATH_RE.match(self.map_path):
+            raise ValueError(
+                f"HaproxyGeoip.map_path {self.map_path!r} must be a non-empty "
+                "absolute POSIX path"
+            )
+
+
+@dataclass(frozen=True)
 class HaproxyRoute:
     """Prepared HAProxy render input with no database behavior.
 
@@ -199,6 +234,7 @@ class HaproxyRoute:
     ssl_provider: str
     backend: HaproxyBackend
     ddos: HaproxyDdos | None = None
+    geoip: HaproxyGeoip | None = None
 
     def __post_init__(self) -> None:
         _validate_haproxy_identifier(
@@ -251,6 +287,9 @@ class HaproxyRenderContext:
             ),
             "HaproxyRenderContext.routes.ddos.ban_stick_table_name",
         )
+        # geoip introduces no new per-route identifiers (a single shared
+        # read-only var(txn.geoip_country) is used across all routes), so no
+        # uniqueness check is needed here.
 
 
 @dataclass(frozen=True)

--- a/src/backend/app/services/geoip_service.py
+++ b/src/backend/app/services/geoip_service.py
@@ -29,6 +29,7 @@ import ipaddress
 import json
 import logging
 import os
+import threading
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,9 +39,14 @@ import httpx
 import maxminddb
 
 from app.config import settings
-from app.constants.countries import VALID_COUNTRY_CODES
+from app.constants.countries import MAPPABLE_COUNTRY_CODES
 
 logger = logging.getLogger(__name__)
+
+# Serialises refreshes across the scheduled job and the API endpoint. Both go
+# through the same fixed temp paths, so this is what stops them from
+# clobbering each other's partial writes.
+_refresh_lock = threading.Lock()
 
 _STUB_HEADER = (
     "# Guard Proxy GeoIP map (CIDR -> ISO 3166-1 alpha-2).\n"
@@ -293,7 +299,7 @@ def generate_map_file(mmdb: Path | None = None) -> int:
             out.write(_STUB_HEADER)
             for network, record in reader:
                 code = _country_code(record)
-                if code is None or code not in VALID_COUNTRY_CODES:
+                if code is None or code not in MAPPABLE_COUNTRY_CODES:
                     skipped += 1
                     continue
                 if code != run_code or network.version != run_version:
@@ -339,34 +345,77 @@ def _country_code(record: object) -> str | None:
     return None
 
 
+def _failed_refresh(error: Exception) -> GeoipRefreshResult:
+    return GeoipRefreshResult(
+        downloaded=False,
+        entries=0,
+        changed=False,
+        reloaded=False,
+        message=f"GeoIP refresh failed: {error}",
+    )
+
+
+def try_refresh(force_reload: bool = True) -> GeoipRefreshResult | None:
+    """`refresh()` that gives up instead of waiting. Returns None when busy.
+
+    Used by the API endpoint so an admin gets an immediate 409 rather than
+    blocking on a refresh the scheduler already started.
+    """
+    if not _refresh_lock.acquire(blocking=False):
+        return None
+    try:
+        return _refresh_locked(force_reload)
+    finally:
+        _refresh_lock.release()
+
+
 def refresh(force_reload: bool = True) -> GeoipRefreshResult:
     """Refresh the GeoIP database and regenerate the HAProxy map.
 
     Single entry point shared by the scheduled daily job and the manual
-    `POST /geoip/refresh` endpoint. Never raises — network and filesystem
-    errors are all converted into a failed GeoipRefreshResult so a bad
-    refresh cannot crash the scheduler.
+    `POST /geoip/refresh` endpoint. Never raises — network, filesystem and
+    malformed-database errors are all converted into a failed
+    GeoipRefreshResult so a bad refresh cannot crash the scheduler.
+
+    Serialised on a module-level lock. Both callers write to the same fixed
+    temp paths (`.country.mmdb.tmp`, `.country.map.tmp`), so two concurrent
+    refreshes would interleave writes and each `finally: unlink()` would
+    delete the other's temp file before its `os.replace()` — publishing a
+    corrupt map into a live security filter.
     """
+    with _refresh_lock:
+        return _refresh_locked(force_reload)
+
+
+def _refresh_locked(force_reload: bool) -> GeoipRefreshResult:
     ensure_map_file_exists()
 
     before_digest = _map_digest()
 
     try:
         _mmdb, downloaded = download_database()
+    except (httpx.HTTPError, OSError, GeoipError) as error:
+        logger.exception("GeoIP refresh failed")
+        return _failed_refresh(error)
+
+    try:
         # Regenerate when the database changed, but also whenever the map is
         # still a stub — otherwise a 304 would report "up to date" while every
         # lookup misses and the filter silently fails open.
         regenerate = downloaded or _map_is_stub()
         entries = generate_map_file() if regenerate else 0
-    except (httpx.HTTPError, OSError, GeoipError) as error:
-        logger.exception("GeoIP refresh failed")
-        return GeoipRefreshResult(
-            downloaded=False,
-            entries=0,
-            changed=False,
-            reloaded=False,
-            message=f"GeoIP refresh failed: {error}",
-        )
+    except (OSError, GeoipError, maxminddb.InvalidDatabaseError) as error:
+        # The file on disk is not a usable database — a mirror answering 200
+        # with an HTML error page is the common case, and raise_for_status()
+        # cannot catch that. Its ETag/Last-Modified were already recorded by
+        # the successful download above, so leaving them would make every
+        # later refresh a 304 and the corruption permanent. Dropping the
+        # validators forces the next run to fetch in full.
+        # InvalidDatabaseError subclasses RuntimeError, so neither OSError nor
+        # GeoipError would catch it on their own.
+        _meta_path().unlink(missing_ok=True)
+        logger.exception("GeoIP refresh failed; dropped cache validators")
+        return _failed_refresh(error)
 
     after_digest = _map_digest()
     changed = before_digest != after_digest
@@ -401,7 +450,12 @@ def refresh(force_reload: bool = True) -> GeoipRefreshResult:
 
 
 def _map_digest() -> str | None:
+    """Hash the map file, streamed so an ~18 MB map is never held in memory."""
     path = map_file_path()
     if not path.exists():
         return None
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/backend/app/services/geoip_service.py
+++ b/src/backend/app/services/geoip_service.py
@@ -1,16 +1,20 @@
 """GeoIP database download and HAProxy map generation (issue #175).
 
-Pipeline: MaxMind GeoLite2-Country (MMDB) -> generated HAProxy map file
+Pipeline: ip66.dev country-level MMDB -> generated HAProxy map file
 (CIDR -> ISO 3166-1 alpha-2) -> `map_ip()` ACLs in haproxy.cfg.j2. This keeps
 country lookups native to HAProxy — no Lua, no HAProxy MMDB module — because
 the backend already owns the runtime config generation pipeline.
 
+The database is downloaded from ip66.dev (https://ip66.dev), a free,
+no-registration MMDB source licensed under CC BY 4.0 and rebuilt daily
+upstream. Attribution: GeoIP data provided by ip66.dev, licensed CC BY 4.0.
+
 Both the MMDB and the generated map file live on the shared
 `generated_config` volume, next to (but outside of) the versioned
 `releases/<id>/` directories used by config_apply, because the GeoIP data is
-refreshed on its own weekly schedule independent of config applies:
+refreshed on its own daily schedule independent of config applies:
 
-    <runtime_root>/geoip/GeoLite2-Country.mmdb
+    <runtime_root>/geoip/country.mmdb
     <runtime_root>/geoip/country.map
 
 The backend reaches this path via `settings.runtime_generated_config_root`;
@@ -21,11 +25,14 @@ HAProxy reads the same file through its `/etc/haproxy/generated` mount (see
 from __future__ import annotations
 
 import hashlib
+import ipaddress
+import json
 import logging
 import os
-import tarfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO, cast
 
 import httpx
 import maxminddb
@@ -35,34 +42,47 @@ from app.constants.countries import VALID_COUNTRY_CODES
 
 logger = logging.getLogger(__name__)
 
-_DOWNLOAD_URL = "https://download.maxmind.com/app/geoip_download"
-_EDITION_ID = "GeoLite2-Country"
-
 _STUB_HEADER = (
     "# Guard Proxy GeoIP map (CIDR -> ISO 3166-1 alpha-2).\n"
-    "# Regenerated from GeoLite2-Country; manual edits are overwritten.\n"
+    "# Regenerated from the ip66.dev country database; manual edits are\n"
+    "# overwritten. GeoIP data provided by https://ip66.dev, licensed CC BY 4.0.\n"
 )
 # RFC 5737 TEST-NET-1, never routed — keeps the file non-empty so HAProxy
-# always parses it even before any real GeoLite2 data has been downloaded.
+# always parses it even before any real ip66.dev data has been downloaded.
 _STUB_SENTINEL = "192.0.2.0/24 ZZ\n"
 
-_MMDB_FILENAME = "GeoLite2-Country.mmdb"
+_MMDB_FILENAME = "country.mmdb"
 _MAP_FILENAME = "country.map"
+_META_FILENAME = "country.mmdb.meta.json"
+
+# Iterating the database MUST go through maxminddb's C extension. The pure
+# Python reader (MODE_MEMORY / MODE_FILE) raises
+# "ValueError: ::1:0:0/0 has host bits set" partway through the real ip66.dev
+# database while rebuilding IPv6 networks from the search tree, so it cannot
+# enumerate this database at all. MODE_AUTO picks the extension when it is
+# available; `generate_map_file()` turns the fallback's failure into an
+# actionable GeoipError rather than an opaque crash.
+_READER_MODE = maxminddb.MODE_AUTO
+
+_STUB_BYTES = len((_STUB_HEADER + _STUB_SENTINEL).encode("utf-8"))
+
+# The upstream database uses a few codes that are not ISO 3166-1 alpha-2
+# assignments. "UK" is just the wrong spelling of "GB" (11 networks in the
+# July 2026 build) and is aliased so blocking GB also covers them. Everything
+# else is left unresolved on purpose and therefore fails open: "EU" (~90k
+# networks) marks Europe-wide allocations with no single country, "XK" is the
+# user-assigned code for Kosovo, and CS/YU/AN are withdrawn codes.
+_COUNTRY_ALIASES = {"UK": "GB"}
 
 
 class GeoipError(Exception):
     """Base class for GeoIP service errors."""
 
 
-class GeoipNotConfiguredError(GeoipError):
-    """Raised when a MaxMind license key has not been configured."""
-
-
 @dataclass(frozen=True)
 class GeoipRefreshResult:
     """Outcome of one `refresh()` run."""
 
-    configured: bool
     downloaded: bool
     entries: int
     changed: bool
@@ -76,13 +96,35 @@ def geoip_dir() -> Path:
 
 
 def mmdb_path() -> Path:
-    """Path to the downloaded GeoLite2-Country database."""
+    """Path to the downloaded ip66.dev country MMDB."""
     return geoip_dir() / _MMDB_FILENAME
 
 
 def map_file_path() -> Path:
     """Path to the generated HAProxy CIDR -> country map."""
     return geoip_dir() / _MAP_FILENAME
+
+
+def _meta_path() -> Path:
+    """Path to the sidecar file storing the last ETag / Last-Modified."""
+    return geoip_dir() / _META_FILENAME
+
+
+def _map_is_stub() -> bool:
+    """True when the map on disk is missing or still the placeholder stub.
+
+    Used so a "not modified" download does not leave a stub map in place: the
+    MMDB can be current while the map is not (first boot after an upgrade, a
+    wiped volume, or a map generation that failed last time). The size check
+    short-circuits the common case so a real ~20 MB map is never read back.
+    """
+    path = map_file_path()
+    try:
+        if path.stat().st_size != _STUB_BYTES:
+            return False
+        return path.read_text(encoding="utf-8") == _STUB_HEADER + _STUB_SENTINEL
+    except OSError:
+        return True
 
 
 def ensure_map_file_exists() -> Path:
@@ -105,66 +147,104 @@ def ensure_map_file_exists() -> Path:
     return path
 
 
-def download_database() -> Path:
-    """Download and extract the GeoLite2-Country MMDB.
+def _load_conditional_headers() -> dict[str, str]:
+    """Build If-None-Match / If-Modified-Since headers from the sidecar file."""
+    path = _meta_path()
+    if not path.exists():
+        return {}
+    try:
+        meta = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    headers: dict[str, str] = {}
+    etag = meta.get("etag")
+    if isinstance(etag, str) and etag:
+        headers["If-None-Match"] = etag
+    last_modified = meta.get("last_modified")
+    if isinstance(last_modified, str) and last_modified:
+        headers["If-Modified-Since"] = last_modified
+    return headers
 
-    No-op (returning the existing path, or raising GeoipNotConfiguredError if
-    none exists yet) when no license key is configured.
+
+def _store_conditional_headers(response: httpx.Response) -> None:
+    """Persist the ETag / Last-Modified validators next to the MMDB."""
+    meta = {
+        "etag": response.headers.get("ETag"),
+        "last_modified": response.headers.get("Last-Modified"),
+    }
+    _meta_path().write_text(json.dumps(meta), encoding="utf-8")
+
+
+def download_database() -> tuple[Path, bool]:
+    """Download the ip66.dev country MMDB, if it changed.
+
+    Issues a conditional GET using the stored ETag/Last-Modified validators
+    from the previous download. Returns `(path, downloaded)` where
+    `downloaded` is False when the server replied 304 Not Modified (or when
+    no download has ever run and one just succeeded, `downloaded` is True).
     """
-    if not settings.maxmind_license_key:
-        logger.warning(
-            "MAXMIND_LICENSE_KEY is not configured; skipping GeoIP database download"
-        )
-        path = mmdb_path()
-        if path.exists():
-            return path
-        raise GeoipNotConfiguredError(
-            "MAXMIND_LICENSE_KEY is not configured and no database "
-            "has been downloaded yet"
-        )
-
     directory = geoip_dir()
     directory.mkdir(parents=True, exist_ok=True)
-    tarball_path = directory / f".{_EDITION_ID}.tar.gz.tmp"
+    tmp_mmdb = directory / f".{_MMDB_FILENAME}.tmp"
 
+    headers = _load_conditional_headers() if mmdb_path().exists() else {}
+
+    logger.info("downloading GeoIP database from %s", settings.geoip_database_url)
     try:
-        # Never log params (they contain the license key) — only the URL.
-        logger.info("downloading GeoIP database from %s", _DOWNLOAD_URL)
-        response = httpx.get(
-            _DOWNLOAD_URL,
-            params={
-                "edition_id": _EDITION_ID,
-                "license_key": settings.maxmind_license_key,
-                "suffix": "tar.gz",
-            },
+        with httpx.stream(
+            "GET",
+            settings.geoip_database_url,
+            headers=headers,
             timeout=60.0,
             follow_redirects=True,
-        )
-        response.raise_for_status()
-        tarball_path.write_bytes(response.content)
+        ) as response:
+            if response.status_code == 304:
+                logger.info("GeoIP database not modified since last download")
+                return mmdb_path(), False
 
-        with tarfile.open(tarball_path, "r:gz") as archive:
-            member = next(
-                (m for m in archive.getmembers() if m.name.endswith(_MMDB_FILENAME)),
-                None,
-            )
-            if member is None:
-                raise GeoipError(
-                    f"{_MMDB_FILENAME} not found inside downloaded archive"
-                )
-            extracted = archive.extractfile(member)
-            if extracted is None:
-                raise GeoipError(f"Could not read {_MMDB_FILENAME} from archive")
+            response.raise_for_status()
 
-            tmp_mmdb = directory / f".{_MMDB_FILENAME}.tmp"
             with tmp_mmdb.open("wb") as out:
-                while chunk := extracted.read(65536):
+                for chunk in response.iter_bytes(65536):
                     out.write(chunk)
-            os.replace(tmp_mmdb, mmdb_path())
-    finally:
-        tarball_path.unlink(missing_ok=True)
 
-    return mmdb_path()
+            os.replace(tmp_mmdb, mmdb_path())
+            _store_conditional_headers(response)
+    finally:
+        tmp_mmdb.unlink(missing_ok=True)
+
+    return mmdb_path(), True
+
+
+_Network = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+def _write_run(out: TextIO, networks: list[_Network], code: str | None) -> int:
+    """Collapse one same-country run and write it out. Returns lines written.
+
+    A run is homogeneous by construction — the caller starts a new one
+    whenever the country code or the IP version changes — which both satisfies
+    `collapse_addresses()` (it rejects mixed families) and lets the two
+    branches below narrow the element type for the type checker.
+    """
+    if not networks or code is None:
+        return 0
+
+    collapsed: Iterator[_Network]
+    if networks[0].version == 4:
+        collapsed = ipaddress.collapse_addresses(
+            cast("list[ipaddress.IPv4Network]", networks)
+        )
+    else:
+        collapsed = ipaddress.collapse_addresses(
+            cast("list[ipaddress.IPv6Network]", networks)
+        )
+
+    written = 0
+    for network in collapsed:
+        out.write(f"{network} {code}\n")
+        written += 1
+    return written
 
 
 def generate_map_file(mmdb: Path | None = None) -> int:
@@ -172,6 +252,22 @@ def generate_map_file(mmdb: Path | None = None) -> int:
 
     Atomic (write to a temp file, then `os.replace()`), so HAProxy can keep
     reading the previous map file while this runs.
+
+    The upstream database splits blocks by ASN as well as by country, so
+    adjacent networks are merged with `ipaddress.collapse_addresses()` before
+    writing — that cuts roughly 1.3M raw networks down to ~1.0M lines.
+
+    The merge is done per *run* of consecutive same-country, same-version
+    networks rather than by first grouping every network by country. Both
+    produce identical output, because `collapse_addresses()` can only merge
+    networks that are adjacent in address space and the reader yields networks
+    in ascending address order — so any two mergeable networks are always in
+    the same run. Streaming this way keeps peak memory flat (one run at a
+    time); buffering all networks first cost ~780 MB on the real database,
+    which would not fit the backend container.
+
+    Note `collapse_addresses()` raises `TypeError` when IPv4 and IPv6 networks
+    are mixed in one call, which is why the IP version also breaks a run.
     """
     path = mmdb if mmdb is not None else mmdb_path()
     if not path.exists():
@@ -185,16 +281,39 @@ def generate_map_file(mmdb: Path | None = None) -> int:
 
     entries = 0
     skipped = 0
-    with maxminddb.open_database(str(path), maxminddb.MODE_MEMORY) as reader:
-        with tmp_map.open("w", encoding="utf-8") as out:
+    run: list[_Network] = []
+    run_code: str | None = None
+    run_version: int | None = None
+
+    try:
+        with (
+            maxminddb.open_database(str(path), _READER_MODE) as reader,
+            tmp_map.open("w", encoding="utf-8") as out,
+        ):
             out.write(_STUB_HEADER)
             for network, record in reader:
                 code = _country_code(record)
                 if code is None or code not in VALID_COUNTRY_CODES:
                     skipped += 1
                     continue
-                out.write(f"{network} {code}\n")
-                entries += 1
+                if code != run_code or network.version != run_version:
+                    entries += _write_run(out, run, run_code)
+                    run = []
+                    run_code = code
+                    run_version = network.version
+                run.append(network)
+            entries += _write_run(out, run, run_code)
+    except ValueError as error:
+        # The pure Python maxminddb reader cannot enumerate this database (see
+        # _READER_MODE). Surface it as an actionable error instead of letting a
+        # bare ValueError escape as a "GeoIP refresh failed" mystery.
+        tmp_map.unlink(missing_ok=True)
+        raise GeoipError(
+            "Could not enumerate the GeoIP database. This happens when the "
+            "maxminddb C extension is unavailable and the pure Python reader "
+            "is used as a fallback; install a maxminddb build with the "
+            f"extension. Underlying error: {error}"
+        ) from error
 
     os.replace(tmp_map, map_file_path())
     if skipped:
@@ -211,47 +330,37 @@ def _country_code(record: object) -> str | None:
     if isinstance(country, dict):
         code = country.get("iso_code")
         if isinstance(code, str) and code:
-            return code
+            return _COUNTRY_ALIASES.get(code, code)
     registered = record.get("registered_country")
     if isinstance(registered, dict):
         code = registered.get("iso_code")
         if isinstance(code, str) and code:
-            return code
+            return _COUNTRY_ALIASES.get(code, code)
     return None
 
 
 def refresh(force_reload: bool = True) -> GeoipRefreshResult:
     """Refresh the GeoIP database and regenerate the HAProxy map.
 
-    Single entry point shared by the scheduled weekly job and the manual
-    `POST /geoip/refresh` endpoint. Never raises — network, filesystem, and
-    archive errors are all converted into a failed GeoipRefreshResult so a
-    bad refresh cannot crash the scheduler.
+    Single entry point shared by the scheduled daily job and the manual
+    `POST /geoip/refresh` endpoint. Never raises — network and filesystem
+    errors are all converted into a failed GeoipRefreshResult so a bad
+    refresh cannot crash the scheduler.
     """
     ensure_map_file_exists()
-
-    if not settings.maxmind_license_key:
-        return GeoipRefreshResult(
-            configured=False,
-            downloaded=False,
-            entries=0,
-            changed=False,
-            reloaded=False,
-            message=(
-                "MAXMIND_LICENSE_KEY is not configured; "
-                "GeoIP filtering fails open."
-            ),
-        )
 
     before_digest = _map_digest()
 
     try:
-        download_database()
-        entries = generate_map_file()
-    except (httpx.HTTPError, OSError, tarfile.TarError, GeoipError) as error:
+        _mmdb, downloaded = download_database()
+        # Regenerate when the database changed, but also whenever the map is
+        # still a stub — otherwise a 304 would report "up to date" while every
+        # lookup misses and the filter silently fails open.
+        regenerate = downloaded or _map_is_stub()
+        entries = generate_map_file() if regenerate else 0
+    except (httpx.HTTPError, OSError, GeoipError) as error:
         logger.exception("GeoIP refresh failed")
         return GeoipRefreshResult(
-            configured=True,
             downloaded=False,
             entries=0,
             changed=False,
@@ -277,13 +386,17 @@ def refresh(force_reload: bool = True) -> GeoipRefreshResult:
                 reload_result.output,
             )
 
+    message = (
+        f"GeoIP database refreshed: {entries} entries written."
+        if regenerate
+        else "GeoIP database is already up to date."
+    )
     return GeoipRefreshResult(
-        configured=True,
-        downloaded=True,
+        downloaded=downloaded,
         entries=entries,
         changed=changed,
         reloaded=reloaded,
-        message=f"GeoIP database refreshed: {entries} entries written.",
+        message=message,
     )
 
 

--- a/src/backend/app/services/geoip_service.py
+++ b/src/backend/app/services/geoip_service.py
@@ -1,0 +1,294 @@
+"""GeoIP database download and HAProxy map generation (issue #175).
+
+Pipeline: MaxMind GeoLite2-Country (MMDB) -> generated HAProxy map file
+(CIDR -> ISO 3166-1 alpha-2) -> `map_ip()` ACLs in haproxy.cfg.j2. This keeps
+country lookups native to HAProxy — no Lua, no HAProxy MMDB module — because
+the backend already owns the runtime config generation pipeline.
+
+Both the MMDB and the generated map file live on the shared
+`generated_config` volume, next to (but outside of) the versioned
+`releases/<id>/` directories used by config_apply, because the GeoIP data is
+refreshed on its own weekly schedule independent of config applies:
+
+    <runtime_root>/geoip/GeoLite2-Country.mmdb
+    <runtime_root>/geoip/country.map
+
+The backend reaches this path via `settings.runtime_generated_config_root`;
+HAProxy reads the same file through its `/etc/haproxy/generated` mount (see
+`app.services.config_generator.HAPROXY_GEOIP_MAP_PATH`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import maxminddb
+
+from app.config import settings
+from app.constants.countries import VALID_COUNTRY_CODES
+
+logger = logging.getLogger(__name__)
+
+_DOWNLOAD_URL = "https://download.maxmind.com/app/geoip_download"
+_EDITION_ID = "GeoLite2-Country"
+
+_STUB_HEADER = (
+    "# Guard Proxy GeoIP map (CIDR -> ISO 3166-1 alpha-2).\n"
+    "# Regenerated from GeoLite2-Country; manual edits are overwritten.\n"
+)
+# RFC 5737 TEST-NET-1, never routed — keeps the file non-empty so HAProxy
+# always parses it even before any real GeoLite2 data has been downloaded.
+_STUB_SENTINEL = "192.0.2.0/24 ZZ\n"
+
+_MMDB_FILENAME = "GeoLite2-Country.mmdb"
+_MAP_FILENAME = "country.map"
+
+
+class GeoipError(Exception):
+    """Base class for GeoIP service errors."""
+
+
+class GeoipNotConfiguredError(GeoipError):
+    """Raised when a MaxMind license key has not been configured."""
+
+
+@dataclass(frozen=True)
+class GeoipRefreshResult:
+    """Outcome of one `refresh()` run."""
+
+    configured: bool
+    downloaded: bool
+    entries: int
+    changed: bool
+    reloaded: bool
+    message: str
+
+
+def geoip_dir() -> Path:
+    """Directory holding the MMDB and generated map, on the runtime volume."""
+    return Path(settings.runtime_generated_config_root) / "geoip"
+
+
+def mmdb_path() -> Path:
+    """Path to the downloaded GeoLite2-Country database."""
+    return geoip_dir() / _MMDB_FILENAME
+
+
+def map_file_path() -> Path:
+    """Path to the generated HAProxy CIDR -> country map."""
+    return geoip_dir() / _MAP_FILENAME
+
+
+def ensure_map_file_exists() -> Path:
+    """Guarantee `country.map` exists so HAProxy always has something to parse.
+
+    Idempotent and cheap: does nothing when the map already exists. Writes a
+    non-empty stub (all lookups miss -> fail open) when it does not. This is
+    the mechanism that guarantees `haproxy -c` never fails on a missing map
+    path, e.g. right after upgrading an existing deployment into this feature.
+    """
+    directory = geoip_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = map_file_path()
+    if not path.exists():
+        path.write_text(_STUB_HEADER + _STUB_SENTINEL, encoding="utf-8")
+        logger.warning(
+            "geoip map file missing; wrote empty stub "
+            "(all lookups will miss -> fail open)"
+        )
+    return path
+
+
+def download_database() -> Path:
+    """Download and extract the GeoLite2-Country MMDB.
+
+    No-op (returning the existing path, or raising GeoipNotConfiguredError if
+    none exists yet) when no license key is configured.
+    """
+    if not settings.maxmind_license_key:
+        logger.warning(
+            "MAXMIND_LICENSE_KEY is not configured; skipping GeoIP database download"
+        )
+        path = mmdb_path()
+        if path.exists():
+            return path
+        raise GeoipNotConfiguredError(
+            "MAXMIND_LICENSE_KEY is not configured and no database "
+            "has been downloaded yet"
+        )
+
+    directory = geoip_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    tarball_path = directory / f".{_EDITION_ID}.tar.gz.tmp"
+
+    try:
+        # Never log params (they contain the license key) — only the URL.
+        logger.info("downloading GeoIP database from %s", _DOWNLOAD_URL)
+        response = httpx.get(
+            _DOWNLOAD_URL,
+            params={
+                "edition_id": _EDITION_ID,
+                "license_key": settings.maxmind_license_key,
+                "suffix": "tar.gz",
+            },
+            timeout=60.0,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        tarball_path.write_bytes(response.content)
+
+        with tarfile.open(tarball_path, "r:gz") as archive:
+            member = next(
+                (m for m in archive.getmembers() if m.name.endswith(_MMDB_FILENAME)),
+                None,
+            )
+            if member is None:
+                raise GeoipError(
+                    f"{_MMDB_FILENAME} not found inside downloaded archive"
+                )
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                raise GeoipError(f"Could not read {_MMDB_FILENAME} from archive")
+
+            tmp_mmdb = directory / f".{_MMDB_FILENAME}.tmp"
+            with tmp_mmdb.open("wb") as out:
+                while chunk := extracted.read(65536):
+                    out.write(chunk)
+            os.replace(tmp_mmdb, mmdb_path())
+    finally:
+        tarball_path.unlink(missing_ok=True)
+
+    return mmdb_path()
+
+
+def generate_map_file(mmdb: Path | None = None) -> int:
+    """Regenerate the HAProxy map file from the MMDB. Returns entries written.
+
+    Atomic (write to a temp file, then `os.replace()`), so HAProxy can keep
+    reading the previous map file while this runs.
+    """
+    path = mmdb if mmdb is not None else mmdb_path()
+    if not path.exists():
+        logger.warning("GeoIP database %s is missing; cannot generate map", path)
+        ensure_map_file_exists()
+        return 0
+
+    directory = geoip_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    tmp_map = directory / f".{_MAP_FILENAME}.tmp"
+
+    entries = 0
+    skipped = 0
+    with maxminddb.open_database(str(path), maxminddb.MODE_MEMORY) as reader:
+        with tmp_map.open("w", encoding="utf-8") as out:
+            out.write(_STUB_HEADER)
+            for network, record in reader:
+                code = _country_code(record)
+                if code is None or code not in VALID_COUNTRY_CODES:
+                    skipped += 1
+                    continue
+                out.write(f"{network} {code}\n")
+                entries += 1
+
+    os.replace(tmp_map, map_file_path())
+    if skipped:
+        logger.warning(
+            "geoip map generation skipped %d entries with no country code", skipped
+        )
+    return entries
+
+
+def _country_code(record: object) -> str | None:
+    if not isinstance(record, dict):
+        return None
+    country = record.get("country")
+    if isinstance(country, dict):
+        code = country.get("iso_code")
+        if isinstance(code, str) and code:
+            return code
+    registered = record.get("registered_country")
+    if isinstance(registered, dict):
+        code = registered.get("iso_code")
+        if isinstance(code, str) and code:
+            return code
+    return None
+
+
+def refresh(force_reload: bool = True) -> GeoipRefreshResult:
+    """Refresh the GeoIP database and regenerate the HAProxy map.
+
+    Single entry point shared by the scheduled weekly job and the manual
+    `POST /geoip/refresh` endpoint. Never raises — network, filesystem, and
+    archive errors are all converted into a failed GeoipRefreshResult so a
+    bad refresh cannot crash the scheduler.
+    """
+    ensure_map_file_exists()
+
+    if not settings.maxmind_license_key:
+        return GeoipRefreshResult(
+            configured=False,
+            downloaded=False,
+            entries=0,
+            changed=False,
+            reloaded=False,
+            message=(
+                "MAXMIND_LICENSE_KEY is not configured; "
+                "GeoIP filtering fails open."
+            ),
+        )
+
+    before_digest = _map_digest()
+
+    try:
+        download_database()
+        entries = generate_map_file()
+    except (httpx.HTTPError, OSError, tarfile.TarError, GeoipError) as error:
+        logger.exception("GeoIP refresh failed")
+        return GeoipRefreshResult(
+            configured=True,
+            downloaded=False,
+            entries=0,
+            changed=False,
+            reloaded=False,
+            message=f"GeoIP refresh failed: {error}",
+        )
+
+    after_digest = _map_digest()
+    changed = before_digest != after_digest
+
+    reloaded = False
+    if changed and force_reload:
+        # Map files are only re-read on reload; the Runtime API `set map`
+        # command does not persist and would drift from disk, so a real
+        # reload is required.
+        from app.services.config_apply import reload_haproxy
+
+        reload_result = reload_haproxy()
+        reloaded = reload_result.ok
+        if not reload_result.ok:
+            logger.warning(
+                "GeoIP map changed but HAProxy reload failed: %s",
+                reload_result.output,
+            )
+
+    return GeoipRefreshResult(
+        configured=True,
+        downloaded=True,
+        entries=entries,
+        changed=changed,
+        reloaded=reloaded,
+        message=f"GeoIP database refreshed: {entries} entries written.",
+    )
+
+
+def _map_digest() -> str | None:
+    path = map_file_path()
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/src/backend/app/services/policy_service.py
+++ b/src/backend/app/services/policy_service.py
@@ -3,7 +3,7 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
-from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy import Policy, PolicyEnforcementMode, PolicyGeoipMode
 from app.models.policy_binding import PolicyBinding
 from app.models.vhost import VHost
 
@@ -21,6 +21,8 @@ NON_NULLABLE_PATCH_FIELDS = {
     "auto_ban_enabled",
     "ban_threshold",
     "ban_duration_seconds",
+    "geoip_mode",
+    "geoip_countries",
 }
 
 # description is intentionally included: it is nullable and may be set to None.
@@ -39,6 +41,8 @@ PATCHABLE_FIELDS = {
     "auto_ban_enabled",
     "ban_threshold",
     "ban_duration_seconds",
+    "geoip_mode",
+    "geoip_countries",
 }
 
 
@@ -78,6 +82,15 @@ class PolicyInUseError(PolicyError):
     """Raised when a policy is still assigned to a vhost or path binding."""
 
 
+class PolicyGeoipConfigurationError(PolicyError):
+    """Raised when geoip_mode is not 'off' but geoip_countries is empty."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "geoip_countries must not be empty when geoip_mode is not 'off'"
+        )
+
+
 class PolicyService:
     """Encapsulates policy CRUD business rules.
 
@@ -106,8 +119,11 @@ class PolicyService:
         auto_ban_enabled: bool = False,
         ban_threshold: int = 10,
         ban_duration_seconds: int = 600,
+        geoip_mode: PolicyGeoipMode = PolicyGeoipMode.off,
+        geoip_countries: list[str] | None = None,
     ) -> Policy:
         """Create and persist a new policy."""
+        self._validate_geoip(geoip_mode, geoip_countries or [])
         policy = Policy(
             name=name,
             description=description,
@@ -122,6 +138,8 @@ class PolicyService:
             auto_ban_enabled=auto_ban_enabled,
             ban_threshold=ban_threshold,
             ban_duration_seconds=ban_duration_seconds,
+            geoip_mode=geoip_mode,
+            geoip_countries=list(geoip_countries or []),
             is_active=True,
             created_by=created_by,
         )
@@ -182,6 +200,10 @@ class PolicyService:
         policy = self._get_policy_or_raise(policy_id)
         self._validate_patch_data(patch_data)
 
+        effective_mode = patch_data.get("geoip_mode", policy.geoip_mode)
+        effective_countries = patch_data.get("geoip_countries", policy.geoip_countries)
+        self._validate_geoip(effective_mode, effective_countries)
+
         for field, value in patch_data.items():
             setattr(policy, field, value)
 
@@ -235,6 +257,22 @@ class PolicyService:
         for field in NON_NULLABLE_PATCH_FIELDS:
             if field in patch_data and patch_data[field] is None:
                 raise PolicyFieldCannotBeNullError(field)
+
+    @staticmethod
+    def _validate_geoip(mode: object, countries: object) -> None:
+        """Enforce "geoip_countries must be non-empty unless mode is off".
+
+        Called with the *effective* mode/countries — for create() these are
+        simply the request values; for update() the caller merges the patch
+        onto the currently stored row before calling this, since geoip_mode
+        and geoip_countries can be patched independently.
+
+        When mode is toggled back to `off`, geoip_countries is intentionally
+        left as-is (not cleared, not rejected) so an admin can turn filtering
+        off and later back on without re-entering the country list.
+        """
+        if mode != PolicyGeoipMode.off and not countries:
+            raise PolicyGeoipConfigurationError
 
     @staticmethod
     def _is_policy_name_unique_violation(error: IntegrityError) -> bool:

--- a/src/backend/app/services/scheduler.py
+++ b/src/backend/app/services/scheduler.py
@@ -8,6 +8,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore
 from app.config import settings
 from app.database import SessionLocal
 from app.models.vhost import VHost
+from app.services import geoip_service
 from app.services.certbot_service import CertbotError, CertbotService
 from app.services.log_retention import purge_logs_older_than
 
@@ -81,10 +82,21 @@ def purge_old_logs() -> None:
             f"{settings.log_retention_days} days"
         )
 
+def refresh_geoip_database() -> None:
+    """Refresh the GeoLite2 country database and regenerate the HAProxy map."""
+    result = geoip_service.refresh()
+    logger.info("GeoIP refresh: %s", result.message)
+
 def start_scheduler() -> None:
     """Start the background scheduler."""
     scheduler.add_job(renew_certificates, 'interval', days=1, id='renew_certificates')
     scheduler.add_job(purge_old_logs, 'interval', days=1, id='purge_old_logs')
+    scheduler.add_job(
+        refresh_geoip_database,
+        'interval',
+        days=settings.geoip_refresh_interval_days,
+        id='refresh_geoip_database',
+    )
     scheduler.start()
     logger.info("Background scheduler started")
 

--- a/src/backend/app/services/scheduler.py
+++ b/src/backend/app/services/scheduler.py
@@ -83,7 +83,7 @@ def purge_old_logs() -> None:
         )
 
 def refresh_geoip_database() -> None:
-    """Refresh the GeoLite2 country database and regenerate the HAProxy map."""
+    """Refresh the ip66.dev country database and regenerate the HAProxy map."""
     result = geoip_service.refresh()
     logger.info("GeoIP refresh: %s", result.message)
 
@@ -91,11 +91,16 @@ def start_scheduler() -> None:
     """Start the background scheduler."""
     scheduler.add_job(renew_certificates, 'interval', days=1, id='renew_certificates')
     scheduler.add_job(purge_old_logs, 'interval', days=1, id='purge_old_logs')
+    # next_run_time fires an initial refresh shortly after boot instead of
+    # waiting a full interval. Without it the country map stays the empty stub
+    # for a whole interval after every start, silently failing open. The short
+    # delay keeps the download and map generation off the startup path.
     scheduler.add_job(
         refresh_geoip_database,
         'interval',
         days=settings.geoip_refresh_interval_days,
         id='refresh_geoip_database',
+        next_run_time=datetime.now(UTC) + timedelta(seconds=30),
     )
     scheduler.start()
     logger.info("Background scheduler started")

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -66,18 +66,32 @@ frontend fe_http
     # map_ip() is native (no Lua, no MMDB module). An IP absent from the map
     # leaves txn.geoip_country unset; with fail_open (the default) such
     # requests are allowed. The map file is always present on disk (a stub is
-    # written when no GeoLite2 data has been downloaded yet), so `haproxy -c`
+    # written when no GeoIP data has been downloaded yet), so `haproxy -c`
     # never fails because of a missing map.
-    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_health !is_acme
+    #
+    # Only ACME challenges are exempt: they must reach backend_acme for cert
+    # issuance and that backend is local. `is_health` is deliberately NOT
+    # exempt here — it is a host-independent path match with no use_backend of
+    # its own, so exempting it would let any request to /health on a protected
+    # vhost skip country filtering and reach the customer origin.
+    #
+    # Country codes are emitted in chunks as repeated ACLs of the same name
+    # (which HAProxy ORs together). HAProxy truncates any config line after 64
+    # words, so a single-line list of ~250 codes produces a fatally invalid
+    # config; 50 per line leaves room for the rest of the line.
+    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_acme
 {% for route in routes %}
 {% if route.geoip %}
+{% for chunk in route.geoip.countries | batch(50) %}
+    acl geoip_{{ route.vhost_acl_name }} var(txn.geoip_country) -m str {{ chunk | join(" ") }}
+{% endfor %}
 {% if route.geoip.mode == "allowlist" %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m found } !{ var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme { var(txn.geoip_country) -m found } !geoip_{{ route.vhost_acl_name }}
 {% else %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme geoip_{{ route.vhost_acl_name }}
 {% endif %}
 {% if not route.geoip.fail_open %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme !{ var(txn.geoip_country) -m found }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme !{ var(txn.geoip_country) -m found }
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -161,17 +175,21 @@ frontend fe_https
 
 {% set has_geoip_https = routes | selectattr("geoip") | list | length > 0 %}
 {% if has_geoip_https %}
-    # Country filtering via a generated CIDR -> ISO 3166-1 alpha-2 map (see fe_http).
-    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_health !is_acme
+    # Country filtering via a generated CIDR -> ISO 3166-1 alpha-2 map (see fe_http),
+    # including why /health is not exempt and why codes are chunked.
+    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_acme
 {% for route in routes %}
 {% if route.geoip %}
+{% for chunk in route.geoip.countries | batch(50) %}
+    acl geoip_{{ route.vhost_acl_name }} var(txn.geoip_country) -m str {{ chunk | join(" ") }}
+{% endfor %}
 {% if route.geoip.mode == "allowlist" %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m found } !{ var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme { var(txn.geoip_country) -m found } !geoip_{{ route.vhost_acl_name }}
 {% else %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme geoip_{{ route.vhost_acl_name }}
 {% endif %}
 {% if not route.geoip.fail_open %}
-    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme !{ var(txn.geoip_country) -m found }
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_acme !{ var(txn.geoip_country) -m found }
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/src/backend/app/templates/haproxy.cfg.j2
+++ b/src/backend/app/templates/haproxy.cfg.j2
@@ -60,6 +60,29 @@ frontend fe_http
     # cannot be bypassed by header spoofing.
     http-request set-header X-Forwarded-For %[src]
 
+{% set has_geoip_http = routes | selectattr("geoip") | list | length > 0 %}
+{% if has_geoip_http %}
+    # Country filtering via a generated CIDR -> ISO 3166-1 alpha-2 map.
+    # map_ip() is native (no Lua, no MMDB module). An IP absent from the map
+    # leaves txn.geoip_country unset; with fail_open (the default) such
+    # requests are allowed. The map file is always present on disk (a stub is
+    # written when no GeoLite2 data has been downloaded yet), so `haproxy -c`
+    # never fails because of a missing map.
+    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_health !is_acme
+{% for route in routes %}
+{% if route.geoip %}
+{% if route.geoip.mode == "allowlist" %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m found } !{ var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+{% else %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+{% endif %}
+{% if not route.geoip.fail_open %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme !{ var(txn.geoip_country) -m found }
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
 {% set has_ddos_http = routes | selectattr("ddos") | list | length > 0 %}
 {% if has_ddos_http %}
     # Per-vhost DDoS protection: request-rate limiting and connection
@@ -135,6 +158,24 @@ frontend fe_https
 
     http-request set-header X-Forwarded-For %[src]
     http-request set-header X-Forwarded-Proto https
+
+{% set has_geoip_https = routes | selectattr("geoip") | list | length > 0 %}
+{% if has_geoip_https %}
+    # Country filtering via a generated CIDR -> ISO 3166-1 alpha-2 map (see fe_http).
+    http-request set-var(txn.geoip_country) src,map_ip({{ (routes | selectattr("geoip") | first).geoip.map_path }}) if !is_health !is_acme
+{% for route in routes %}
+{% if route.geoip %}
+{% if route.geoip.mode == "allowlist" %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m found } !{ var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+{% else %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme { var(txn.geoip_country) -m str {{ route.geoip.countries | join(" ") }} }
+{% endif %}
+{% if not route.geoip.fail_open %}
+    http-request deny deny_status 403 if {{ route.vhost_acl_name }} !is_health !is_acme !{ var(txn.geoip_country) -m found }
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 {% set has_ddos_https = routes | selectattr("ddos") | list | length > 0 %}
 {% if has_ddos_https %}

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -20,13 +20,14 @@ dependencies = [
     "slowapi>=0.1.9",
     "cryptography>=42.0.0",
     "apscheduler>=3.10.4",
+    "maxminddb>=3.1.0",
+    "httpx>=0.28.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.0",
     "pytest-cov>=6.0.0",
-    "httpx>=0.28.0",
     "mypy>=1.13.0",
     "ruff>=0.8.0",
     "types-passlib>=1.7.7.20260211",

--- a/src/backend/tests/integration/test_geoip_router.py
+++ b/src/backend/tests/integration/test_geoip_router.py
@@ -26,9 +26,10 @@ def test_refresh_admin_returns_serialized_result(
     admin_token: dict[str, str],
     monkeypatch,
 ) -> None:
+    # Patch below the lock so try_refresh()'s real locking still runs.
     monkeypatch.setattr(
-        "app.services.geoip_service.refresh",
-        lambda: _fake_result(),
+        "app.services.geoip_service._refresh_locked",
+        lambda force_reload: _fake_result(),
     )
 
     resp = client.post("/geoip/refresh", headers=admin_token)
@@ -63,12 +64,14 @@ def test_refresh_concurrent_call_returns_409(
     started = threading.Event()
     release = threading.Event()
 
-    def _slow_refresh():
+    def _slow_refresh(force_reload):
         started.set()
         release.wait(timeout=5)
         return _fake_result()
 
-    monkeypatch.setattr("app.services.geoip_service.refresh", _slow_refresh)
+    # Patched below the lock, so this exercises the real service-level lock —
+    # the same one the scheduled job contends for.
+    monkeypatch.setattr("app.services.geoip_service._refresh_locked", _slow_refresh)
 
     first_call_result: dict[str, int] = {}
 

--- a/src/backend/tests/integration/test_geoip_router.py
+++ b/src/backend/tests/integration/test_geoip_router.py
@@ -11,7 +11,6 @@ def _fake_result(**overrides: object):
     from app.services.geoip_service import GeoipRefreshResult
 
     defaults: dict[str, object] = {
-        "configured": True,
         "downloaded": True,
         "entries": 42,
         "changed": True,
@@ -36,7 +35,6 @@ def test_refresh_admin_returns_serialized_result(
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["configured"] is True
     assert body["downloaded"] is True
     assert body["entries"] == 42
     assert body["changed"] is True
@@ -55,32 +53,6 @@ def test_refresh_viewer_returns_403(
     resp = client.post("/geoip/refresh", headers=viewer_token)
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Admin role required"
-
-
-def test_refresh_unconfigured_returns_503(
-    client: TestClient,
-    admin_token: dict[str, str],
-    monkeypatch,
-) -> None:
-    monkeypatch.setattr(
-        "app.services.geoip_service.refresh",
-        lambda: _fake_result(
-            configured=False,
-            downloaded=False,
-            entries=0,
-            changed=False,
-            reloaded=False,
-            message=(
-                "MAXMIND_LICENSE_KEY is not configured; "
-                "GeoIP filtering fails open."
-            ),
-        ),
-    )
-
-    resp = client.post("/geoip/refresh", headers=admin_token)
-
-    assert resp.status_code == 503
-    assert "MAXMIND_LICENSE_KEY" in resp.json()["detail"]
 
 
 def test_refresh_concurrent_call_returns_409(

--- a/src/backend/tests/integration/test_geoip_router.py
+++ b/src/backend/tests/integration/test_geoip_router.py
@@ -1,0 +1,118 @@
+"""Integration tests for POST /geoip/refresh (issue #175)."""
+
+from __future__ import annotations
+
+import threading
+
+from fastapi.testclient import TestClient
+
+
+def _fake_result(**overrides: object):
+    from app.services.geoip_service import GeoipRefreshResult
+
+    defaults: dict[str, object] = {
+        "configured": True,
+        "downloaded": True,
+        "entries": 42,
+        "changed": True,
+        "reloaded": True,
+        "message": "GeoIP database refreshed: 42 entries written.",
+    }
+    defaults.update(overrides)
+    return GeoipRefreshResult(**defaults)  # type: ignore[arg-type]
+
+
+def test_refresh_admin_returns_serialized_result(
+    client: TestClient,
+    admin_token: dict[str, str],
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.geoip_service.refresh",
+        lambda: _fake_result(),
+    )
+
+    resp = client.post("/geoip/refresh", headers=admin_token)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is True
+    assert body["downloaded"] is True
+    assert body["entries"] == 42
+    assert body["changed"] is True
+    assert body["reloaded"] is True
+    assert body["message"] == "GeoIP database refreshed: 42 entries written."
+
+
+def test_refresh_unauthenticated_returns_401(client: TestClient) -> None:
+    resp = client.post("/geoip/refresh")
+    assert resp.status_code == 401
+
+
+def test_refresh_viewer_returns_403(
+    client: TestClient, viewer_token: dict[str, str]
+) -> None:
+    resp = client.post("/geoip/refresh", headers=viewer_token)
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Admin role required"
+
+
+def test_refresh_unconfigured_returns_503(
+    client: TestClient,
+    admin_token: dict[str, str],
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.geoip_service.refresh",
+        lambda: _fake_result(
+            configured=False,
+            downloaded=False,
+            entries=0,
+            changed=False,
+            reloaded=False,
+            message=(
+                "MAXMIND_LICENSE_KEY is not configured; "
+                "GeoIP filtering fails open."
+            ),
+        ),
+    )
+
+    resp = client.post("/geoip/refresh", headers=admin_token)
+
+    assert resp.status_code == 503
+    assert "MAXMIND_LICENSE_KEY" in resp.json()["detail"]
+
+
+def test_refresh_concurrent_call_returns_409(
+    client: TestClient,
+    admin_token: dict[str, str],
+    monkeypatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_refresh():
+        started.set()
+        release.wait(timeout=5)
+        return _fake_result()
+
+    monkeypatch.setattr("app.services.geoip_service.refresh", _slow_refresh)
+
+    first_call_result: dict[str, int] = {}
+
+    def _run_first_call() -> None:
+        resp = client.post("/geoip/refresh", headers=admin_token)
+        first_call_result["status_code"] = resp.status_code
+
+    thread = threading.Thread(target=_run_first_call)
+    thread.start()
+    started.wait(timeout=5)
+
+    try:
+        second_resp = client.post("/geoip/refresh", headers=admin_token)
+        assert second_resp.status_code == 409
+    finally:
+        release.set()
+        thread.join(timeout=5)
+
+    assert first_call_result.get("status_code") == 200

--- a/src/backend/tests/integration/test_policies_router.py
+++ b/src/backend/tests/integration/test_policies_router.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.models.user import User
@@ -606,3 +607,188 @@ def test_delete_policy_not_found_returns_404(
     resp = client.delete("/policies/99999", headers=admin_token)
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Policy not found"
+
+
+# ---------------------------------------------------------------------------
+# GeoIP country filtering (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def test_create_policy_with_geoip_blocklist_returns_201(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    resp = client.post(
+        "/policies",
+        headers=admin_token,
+        json={
+            "name": "Geo blocklist",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+            "geoip_mode": "blocklist",
+            "geoip_countries": ["RU", "CN"],
+        },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["geoip_mode"] == "blocklist"
+    assert body["geoip_countries"] == ["RU", "CN"]
+
+
+def test_create_policy_without_geoip_fields_defaults_to_off(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    body = _create_policy(client, admin_token, name="Geo default")
+
+    assert body["geoip_mode"] == "off"
+    assert body["geoip_countries"] == []
+
+
+def test_create_policy_geoip_allowlist_with_empty_list_returns_422(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    resp = client.post(
+        "/policies",
+        headers=admin_token,
+        json={
+            "name": "Geo empty allowlist",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+            "geoip_mode": "allowlist",
+            "geoip_countries": [],
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("code", ["XX", "PLX"])
+def test_create_policy_geoip_invalid_code_returns_422(
+    client: TestClient, admin_token: dict[str, str], code: str
+) -> None:
+    resp = client.post(
+        "/policies",
+        headers=admin_token,
+        json={
+            "name": f"Geo invalid {code}",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+            "geoip_mode": "allowlist",
+            "geoip_countries": [code],
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_create_policy_geoip_lowercase_code_is_normalized_to_uppercase(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    """Country codes are case-insensitive: "pl" normalizes to "PL", not rejected."""
+    resp = client.post(
+        "/policies",
+        headers=admin_token,
+        json={
+            "name": "Geo lowercase code",
+            "paranoia_level": 2,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+            "geoip_mode": "allowlist",
+            "geoip_countries": ["pl"],
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["geoip_countries"] == ["PL"]
+
+
+def test_patch_policy_geoip_off_to_allowlist_persists(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    created = _create_policy(client, admin_token, name="Geo off to allowlist")
+
+    resp = client.patch(
+        f"/policies/{created['id']}",
+        headers=admin_token,
+        json={"geoip_mode": "allowlist", "geoip_countries": ["US", "CA"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["geoip_mode"] == "allowlist"
+    assert body["geoip_countries"] == ["US", "CA"]
+
+    resp_back = client.patch(
+        f"/policies/{created['id']}",
+        headers=admin_token,
+        json={"geoip_mode": "off"},
+    )
+    assert resp_back.status_code == 200
+    body_back = resp_back.json()
+    assert body_back["geoip_mode"] == "off"
+    assert body_back["geoip_countries"] == ["US", "CA"]
+
+
+@pytest.mark.parametrize(
+    "payload", [{"geoip_mode": None}, {"geoip_countries": None}]
+)
+def test_patch_policy_geoip_null_returns_422(
+    client: TestClient, admin_token: dict[str, str], payload: dict
+) -> None:
+    created = _create_policy(client, admin_token, name="Geo null patch")
+
+    resp = client.patch(
+        f"/policies/{created['id']}",
+        headers=admin_token,
+        json=payload,
+    )
+    assert resp.status_code == 422
+
+
+def test_get_and_list_policies_include_geoip_fields(
+    client: TestClient, admin_token: dict[str, str]
+) -> None:
+    created = _create_policy(client, admin_token, name="Geo visible")
+
+    detail_resp = client.get(f"/policies/{created['id']}", headers=admin_token)
+    assert detail_resp.status_code == 200
+    detail_body = detail_resp.json()
+    assert "geoip_mode" in detail_body
+    assert "geoip_countries" in detail_body
+
+    list_resp = client.get("/policies", headers=admin_token)
+    assert list_resp.status_code == 200
+    list_body = list_resp.json()
+    assert "geoip_mode" in list_body["items"][0]
+    assert "geoip_countries" in list_body["items"][0]
+
+
+def test_create_policy_with_geoip_viewer_forbidden(
+    client: TestClient, viewer_token: dict[str, str]
+) -> None:
+    resp = client.post(
+        "/policies",
+        headers=viewer_token,
+        json={
+            "name": "Geo viewer",
+            "paranoia_level": 1,
+            "inbound_anomaly_threshold": 5,
+            "outbound_anomaly_threshold": 5,
+            "geoip_mode": "blocklist",
+            "geoip_countries": ["RU"],
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_patch_policy_with_geoip_viewer_forbidden(
+    client: TestClient,
+    admin_token: dict[str, str],
+    viewer_token: dict[str, str],
+) -> None:
+    created = _create_policy(client, admin_token, name="Geo patch viewer")
+
+    resp = client.patch(
+        f"/policies/{created['id']}",
+        headers=viewer_token,
+        json={"geoip_mode": "blocklist", "geoip_countries": ["RU"]},
+    )
+    assert resp.status_code == 403

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -267,8 +267,8 @@ def test_geoip_defaults() -> None:
         JWT_SECRET_KEY="real-secret-value",
         LOG_INGEST_SHARED_SECRET="real-log-secret",
     )
-    assert getattr(s, "maxmind_license_key") == ""
-    assert getattr(s, "geoip_refresh_interval_days") == 7
+    assert getattr(s, "geoip_database_url") == "https://downloads.ip66.dev/db/ip66.mmdb"
+    assert getattr(s, "geoip_refresh_interval_days") == 1
     assert getattr(s, "geoip_fail_open") is True
 
 
@@ -284,10 +284,13 @@ def test_geoip_refresh_interval_days_zero_raises() -> None:
         )
 
 
-def test_maxmind_license_key_whitespace_only_normalises_to_empty() -> None:
-    s = _make_settings(
-        JWT_SECRET_KEY="real-secret-value",
-        LOG_INGEST_SHARED_SECRET="real-log-secret",
-        MAXMIND_LICENSE_KEY="   ",
-    )
-    assert getattr(s, "maxmind_license_key") == ""
+def test_geoip_database_url_empty_raises() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="GEOIP_DATABASE_URL must not be empty",
+    ):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            GEOIP_DATABASE_URL="   ",
+        )

--- a/src/backend/tests/unit/test_config.py
+++ b/src/backend/tests/unit/test_config.py
@@ -255,3 +255,39 @@ def test_settings_reject_non_positive_reload_timeout() -> None:
             LOG_INGEST_SHARED_SECRET="real-log-secret",
             HAPROXY_RELOAD_TIMEOUT_SECONDS="0",
         )
+
+
+# ---------------------------------------------------------------------------
+# GeoIP settings (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def test_geoip_defaults() -> None:
+    s = _make_settings(
+        JWT_SECRET_KEY="real-secret-value",
+        LOG_INGEST_SHARED_SECRET="real-log-secret",
+    )
+    assert getattr(s, "maxmind_license_key") == ""
+    assert getattr(s, "geoip_refresh_interval_days") == 7
+    assert getattr(s, "geoip_fail_open") is True
+
+
+def test_geoip_refresh_interval_days_zero_raises() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="GEOIP_REFRESH_INTERVAL_DAYS must be greater than zero",
+    ):
+        _make_settings(
+            JWT_SECRET_KEY="real-secret-value",
+            LOG_INGEST_SHARED_SECRET="real-log-secret",
+            GEOIP_REFRESH_INTERVAL_DAYS="0",
+        )
+
+
+def test_maxmind_license_key_whitespace_only_normalises_to_empty() -> None:
+    s = _make_settings(
+        JWT_SECRET_KEY="real-secret-value",
+        LOG_INGEST_SHARED_SECRET="real-log-secret",
+        MAXMIND_LICENSE_KEY="   ",
+    )
+    assert getattr(s, "maxmind_license_key") == ""

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -513,3 +513,71 @@ def test_apply_skips_rollback_reload_when_previous_no_longer_validates(
         if p.name != "previous" and p.resolve() == current_resolved
     ]
     assert candidates, "current should point at the new candidate after rollback skipped"
+
+
+# ---------------------------------------------------------------------------
+# GeoIP stub map file (issue #175) — must exist so `haproxy -c` never fails
+# on a missing map, including right after upgrading an existing deployment.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_creates_geoip_stub_map_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=True, output="valid"),
+    )
+    monkeypatch.setattr(
+        "app.services.config_apply._reload_haproxy",
+        lambda: CommandResult(ok=True, output="reload ok"),
+    )
+
+    apply(_sample_generated())
+
+    geoip_map = runtime_root / "geoip" / "country.map"
+    assert geoip_map.exists()
+    assert "192.0.2.0/24 ZZ" in geoip_map.read_text(encoding="utf-8")
+
+
+def test_seed_runtime_config_creates_geoip_stub_map_file_when_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime_root = tmp_path / "generated"
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: CommandResult(ok=True, output="valid"),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    geoip_map = runtime_root / "geoip" / "country.map"
+    assert geoip_map.exists()
+    assert "192.0.2.0/24 ZZ" in geoip_map.read_text(encoding="utf-8")
+
+
+def test_seed_runtime_config_creates_geoip_stub_map_file_on_early_return(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Regression: existing deployments upgrading into this feature must get
+    the stub map even when `current` already points at a release, since
+    seed_runtime_config's early-return path used to skip _ensure_geoip_map_file."""
+    runtime_root = tmp_path / "generated"
+    _seed_current_release(runtime_root)
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(runtime_root))
+    monkeypatch.setattr(
+        "app.services.config_apply._validate_haproxy",
+        lambda _: (_ for _ in ()).throw(AssertionError("should not validate")),
+    )
+
+    seed_runtime_config(_sample_generated())
+
+    geoip_map = runtime_root / "geoip" / "country.map"
+    assert geoip_map.exists()
+    assert "192.0.2.0/24 ZZ" in geoip_map.read_text(encoding="utf-8")

--- a/src/backend/tests/unit/test_config_apply.py
+++ b/src/backend/tests/unit/test_config_apply.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import pytest
+
 from app.config import settings
 from app.services.config_apply import (
     _RELOAD_ERROR_RE,
@@ -581,3 +583,26 @@ def test_seed_runtime_config_creates_geoip_stub_map_file_on_early_return(
     geoip_map = runtime_root / "geoip" / "country.map"
     assert geoip_map.exists()
     assert "192.0.2.0/24 ZZ" in geoip_map.read_text(encoding="utf-8")
+
+
+def test_ensure_geoip_map_file_swallows_oserror(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A read-only or missing runtime dir must not break a config apply.
+
+    The GeoIP map stub is a convenience so `haproxy -c` never trips over a
+    missing map path; failing to write it is worth a warning, not an aborted
+    apply.
+    """
+    from app.services import geoip_service
+    from app.services.config_apply import _ensure_geoip_map_file
+
+    def _raise() -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(geoip_service, "ensure_map_file_exists", _raise)
+
+    with caplog.at_level(logging.WARNING):
+        _ensure_geoip_map_file()
+
+    assert "failed to ensure GeoIP map file exists" in caplog.text

--- a/src/backend/tests/unit/test_config_generator.py
+++ b/src/backend/tests/unit/test_config_generator.py
@@ -4,14 +4,19 @@ from pathlib import Path
 
 import pytest
 
+from app.config import settings
 from app.models.custom_rule import CustomRule, RuleOperator, RulePhase
-from app.models.policy import Policy, PolicyEnforcementMode
+from app.models.policy import Policy, PolicyEnforcementMode, PolicyGeoipMode
 from app.models.policy_binding import PolicyBinding
 from app.models.rule_exclusion import RuleExclusion, TargetType
 from app.models.rule_override import RuleAction, RuleOverride
 from app.models.vhost import VHost
 from app.models.vhost_backend import VHostBackend
-from app.services.config_generator import generate
+from app.services.config_generator import (
+    HAPROXY_GEOIP_MAP_PATH,
+    _to_haproxy_context,
+    generate,
+)
 from app.services.config_renderer import (
     HaproxyBackend,
     HaproxyRenderContext,
@@ -313,6 +318,107 @@ def test_generate_one_vhost_with_ddos_protection_disabled_emits_nothing() -> Non
     assert "stick-table" not in generated.haproxy_cfg
     assert "track-sc0" not in generated.haproxy_cfg
     assert "deny_status 429" not in generated.haproxy_cfg
+
+
+# ---------------------------------------------------------------------------
+# GeoIP country filtering (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def _vhost_and_policy_for_geoip(
+    *,
+    geoip_mode: PolicyGeoipMode = PolicyGeoipMode.off,
+    geoip_countries: list[str] | None = None,
+) -> tuple[VHost, Policy]:
+    vhost = VHost(
+        id=7,
+        domain="geo.example.com",
+        backend_url="http://geo-backend:8000",
+        is_active=True,
+        ssl_enabled=False,
+        policy_id=10,
+    )
+    policy = Policy(
+        id=10,
+        name="Geo",
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=4,
+        enforcement_mode=PolicyEnforcementMode.block,
+        is_active=True,
+        geoip_mode=geoip_mode,
+        geoip_countries=geoip_countries or [],
+    )
+    return vhost, policy
+
+
+def test_to_haproxy_context_allowlist_produces_geoip_context() -> None:
+    vhost, policy = _vhost_and_policy_for_geoip(
+        geoip_mode=PolicyGeoipMode.allowlist,
+        geoip_countries=["PL", "DE"],
+    )
+
+    context = _to_haproxy_context(vhost, policy)
+    geoip = context.routes[0].geoip
+
+    assert geoip is not None
+    assert geoip.mode == "allowlist"
+    assert geoip.countries == ("PL", "DE")
+    assert geoip.map_path == HAPROXY_GEOIP_MAP_PATH
+
+
+def test_to_haproxy_context_off_mode_produces_no_geoip() -> None:
+    vhost, policy = _vhost_and_policy_for_geoip(
+        geoip_mode=PolicyGeoipMode.off,
+        geoip_countries=["PL"],
+    )
+
+    context = _to_haproxy_context(vhost, policy)
+
+    assert context.routes[0].geoip is None
+
+
+def test_to_haproxy_context_non_off_mode_with_empty_countries_produces_no_geoip() -> (
+    None
+):
+    """Defensive: a stored empty list must never render a deny with no patterns."""
+    vhost, policy = _vhost_and_policy_for_geoip(
+        geoip_mode=PolicyGeoipMode.allowlist,
+        geoip_countries=[],
+    )
+
+    context = _to_haproxy_context(vhost, policy)
+
+    assert context.routes[0].geoip is None
+
+
+def test_to_haproxy_context_geoip_fail_open_read_from_settings(
+    monkeypatch,
+) -> None:
+    vhost, policy = _vhost_and_policy_for_geoip(
+        geoip_mode=PolicyGeoipMode.blocklist,
+        geoip_countries=["RU"],
+    )
+
+    monkeypatch.setattr(settings, "geoip_fail_open", True)
+    context = _to_haproxy_context(vhost, policy)
+    assert context.routes[0].geoip.fail_open is True
+
+    monkeypatch.setattr(settings, "geoip_fail_open", False)
+    context = _to_haproxy_context(vhost, policy)
+    assert context.routes[0].geoip.fail_open is False
+
+
+def test_generate_with_geoip_allowlist_renders_deny_rule() -> None:
+    vhost, policy = _vhost_and_policy_for_geoip(
+        geoip_mode=PolicyGeoipMode.allowlist,
+        geoip_countries=["PL", "DE"],
+    )
+
+    generated = generate(vhosts=[vhost], policies=[policy], rule_overrides=[])
+
+    assert "geoip_country" in generated.haproxy_cfg
+    assert "-m str PL DE" in generated.haproxy_cfg
 
 
 def test_generated_haproxy_cfg_with_ddos_validates_with_haproxy(

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -7,6 +7,7 @@ import pytest
 from app.services.config_renderer import (
     HaproxyBackend,
     HaproxyDdos,
+    HaproxyGeoip,
     HaproxyRenderContext,
     HaproxyRoute,
     HaproxyServer,
@@ -662,6 +663,209 @@ def test_rendered_haproxy_template_with_auto_ban_validates_with_haproxy(
     )
 
     assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# GeoIP country filtering (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def _geoip(
+    mode: str = "allowlist",
+    countries: tuple[str, ...] = ("PL", "DE"),
+    map_path: str = "/etc/haproxy/generated/geoip/country.map",
+    fail_open: bool = True,
+) -> HaproxyGeoip:
+    return HaproxyGeoip(
+        mode=mode,
+        countries=countries,
+        map_path=map_path,
+        fail_open=fail_open,
+    )
+
+
+def test_haproxy_template_renders_allowlist_geoip_in_both_frontends() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="letsencrypt",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="allowlist", countries=("PL", "DE")),
+                ),
+            ),
+        )
+    )
+
+    set_var_line = (
+        "http-request set-var(txn.geoip_country) src,map_ip"
+        "(/etc/haproxy/generated/geoip/country.map) if !is_health !is_acme"
+    )
+    deny_line = (
+        "http-request deny deny_status 403 if host_api !is_health !is_acme "
+        "{ var(txn.geoip_country) -m found } "
+        "!{ var(txn.geoip_country) -m str PL DE }"
+    )
+    assert rendered.count(set_var_line) == 2
+    assert rendered.count(deny_line) == 2
+
+
+def test_haproxy_template_renders_blocklist_geoip_without_found_guard() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="blocklist", countries=("RU", "CN")),
+                ),
+            ),
+        )
+    )
+
+    deny_line = (
+        "http-request deny deny_status 403 if host_api !is_health !is_acme "
+        "{ var(txn.geoip_country) -m str RU CN }"
+    )
+    assert deny_line in rendered
+    assert "-m found } !{ var(txn.geoip_country)" not in rendered
+
+
+def test_haproxy_template_geoip_fail_closed_adds_extra_deny() -> None:
+    rendered_fail_open = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="blocklist", countries=("RU",), fail_open=True),
+                ),
+            ),
+        )
+    )
+    rendered_fail_closed = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="blocklist", countries=("RU",), fail_open=False),
+                ),
+            ),
+        )
+    )
+
+    fail_closed_deny = (
+        "http-request deny deny_status 403 if host_api !is_health !is_acme "
+        "!{ var(txn.geoip_country) -m found }"
+    )
+    assert fail_closed_deny not in rendered_fail_open
+    assert fail_closed_deny in rendered_fail_closed
+
+
+def test_haproxy_template_omits_geoip_lines_when_route_has_none() -> None:
+    rendered_plain = render_haproxy_cfg(_m1_reference_context())
+    rendered_with_geoip_field = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_app",
+                    vhost_hosts=("app.local", "localhost", "127.0.0.1"),
+                    ssl_provider="none",
+                    backend=_backend("be_app", "app", "backend:8000"),
+                    geoip=None,
+                ),
+            ),
+        )
+    )
+
+    assert "geoip_country" not in rendered_plain
+    assert "geoip_country" not in rendered_with_geoip_field
+    assert _normalise_config(rendered_plain) == _normalise_config(
+        rendered_with_geoip_field
+    )
+
+
+def test_haproxy_template_geoip_lines_precede_ddos_and_spoe() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    ddos=_ddos(stick_table_name="st_ddos_vhost_1"),
+                    geoip=_geoip(mode="blocklist", countries=("RU",)),
+                ),
+            ),
+        )
+    )
+
+    geoip_index = rendered.index("geoip_country")
+    ddos_index = rendered.index("track-sc0")
+    spoe_index = rendered.index("filter spoe engine coraza")
+
+    assert geoip_index < ddos_index < spoe_index
+
+
+def test_haproxy_template_geoip_rules_carry_health_and_acme_guards() -> None:
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="blocklist", countries=("RU",), fail_open=False),
+                ),
+            ),
+        )
+    )
+
+    geoip_lines = [
+        line
+        for line in rendered.splitlines()
+        if "geoip_country" in line and line.strip().startswith("http-request")
+    ]
+    assert geoip_lines, "expected at least one geoip-related line"
+    for line in geoip_lines:
+        assert "!is_health" in line
+        assert "!is_acme" in line
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"mode": "denylist"},
+        {"countries": ()},
+        {"countries": ("pl",)},
+        {"countries": ("POL",)},
+        {"countries": ("P L",)},
+        {"countries": ("PL\ndeny",)},
+        {"map_path": "relative/path.map"},
+        {"map_path": "/has space/country.map"},
+    ],
+)
+def test_haproxy_geoip_rejects_invalid_values(kwargs: dict) -> None:
+    base = {
+        "mode": "allowlist",
+        "countries": ("PL",),
+        "map_path": "/etc/haproxy/generated/geoip/country.map",
+        "fail_open": True,
+    }
+    base.update(kwargs)
+    with pytest.raises(ValueError):
+        HaproxyGeoip(**base)
 
 
 @pytest.mark.skipif(shutil.which("haproxy") is None, reason="haproxy is not installed")

--- a/src/backend/tests/unit/test_config_renderer_haproxy.py
+++ b/src/backend/tests/unit/test_config_renderer_haproxy.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from app.constants.countries import VALID_COUNTRY_CODES
 from app.services.config_renderer import (
     HaproxyBackend,
     HaproxyDdos,
@@ -701,14 +702,15 @@ def test_haproxy_template_renders_allowlist_geoip_in_both_frontends() -> None:
 
     set_var_line = (
         "http-request set-var(txn.geoip_country) src,map_ip"
-        "(/etc/haproxy/generated/geoip/country.map) if !is_health !is_acme"
+        "(/etc/haproxy/generated/geoip/country.map) if !is_acme"
     )
+    acl_line = "acl geoip_host_api var(txn.geoip_country) -m str PL DE"
     deny_line = (
-        "http-request deny deny_status 403 if host_api !is_health !is_acme "
-        "{ var(txn.geoip_country) -m found } "
-        "!{ var(txn.geoip_country) -m str PL DE }"
+        "http-request deny deny_status 403 if host_api !is_acme "
+        "{ var(txn.geoip_country) -m found } !geoip_host_api"
     )
     assert rendered.count(set_var_line) == 2
+    assert rendered.count(acl_line) == 2
     assert rendered.count(deny_line) == 2
 
 
@@ -727,12 +729,11 @@ def test_haproxy_template_renders_blocklist_geoip_without_found_guard() -> None:
         )
     )
 
-    deny_line = (
-        "http-request deny deny_status 403 if host_api !is_health !is_acme "
-        "{ var(txn.geoip_country) -m str RU CN }"
-    )
+    acl_line = "acl geoip_host_api var(txn.geoip_country) -m str RU CN"
+    deny_line = "http-request deny deny_status 403 if host_api !is_acme geoip_host_api"
+    assert acl_line in rendered
     assert deny_line in rendered
-    assert "-m found } !{ var(txn.geoip_country)" not in rendered
+    assert "-m found } !geoip_host_api" not in rendered
 
 
 def test_haproxy_template_geoip_fail_closed_adds_extra_deny() -> None:
@@ -764,7 +765,7 @@ def test_haproxy_template_geoip_fail_closed_adds_extra_deny() -> None:
     )
 
     fail_closed_deny = (
-        "http-request deny deny_status 403 if host_api !is_health !is_acme "
+        "http-request deny deny_status 403 if host_api !is_acme "
         "!{ var(txn.geoip_country) -m found }"
     )
     assert fail_closed_deny not in rendered_fail_open
@@ -817,7 +818,16 @@ def test_haproxy_template_geoip_lines_precede_ddos_and_spoe() -> None:
     assert geoip_index < ddos_index < spoe_index
 
 
-def test_haproxy_template_geoip_rules_carry_health_and_acme_guards() -> None:
+def test_haproxy_template_geoip_rules_exempt_acme_but_never_health() -> None:
+    """/health must not be a country-filter bypass.
+
+    `is_health` is a host-independent `path /health` match with no
+    `use_backend` of its own, so a request to /health on a protected vhost is
+    routed to the customer origin. Exempting it from the GeoIP rules would let
+    any blocked country reach that origin just by asking for /health. ACME is
+    different: `is_acme` has its own local `backend_acme` and must stay exempt
+    so certificate issuance keeps working.
+    """
     rendered = render_haproxy_cfg(
         HaproxyRenderContext(
             routes=(
@@ -835,12 +845,53 @@ def test_haproxy_template_geoip_rules_carry_health_and_acme_guards() -> None:
     geoip_lines = [
         line
         for line in rendered.splitlines()
-        if "geoip_country" in line and line.strip().startswith("http-request")
+        if "geoip" in line and line.strip().startswith("http-request")
     ]
     assert geoip_lines, "expected at least one geoip-related line"
     for line in geoip_lines:
-        assert "!is_health" in line
+        assert "!is_health" not in line
         assert "!is_acme" in line
+
+
+def test_haproxy_template_chunks_country_codes_to_survive_line_word_limit() -> None:
+    """HAProxy truncates a config line after 64 words, which is fatal.
+
+    A single-line list of every ISO code would blow past that, so codes are
+    emitted as repeated same-name ACLs (which HAProxy ORs together). Verified
+    against haproxy:3.0-alpine: 59 codes on an `acl` line is the real ceiling.
+    """
+    countries = tuple(sorted(code for code in VALID_COUNTRY_CODES if code != "ZZ"))
+    assert len(countries) > 60, "fixture must exceed the per-line word limit"
+
+    rendered = render_haproxy_cfg(
+        HaproxyRenderContext(
+            routes=(
+                HaproxyRoute(
+                    vhost_acl_name="host_api",
+                    vhost_hosts=("api.example.com",),
+                    ssl_provider="none",
+                    backend=_backend("be_api", "api", "api-backend:9000"),
+                    geoip=_geoip(mode="blocklist", countries=countries),
+                ),
+            ),
+        )
+    )
+
+    # Both frontends emit the same block; analyse fe_http's copy on its own.
+    fe_http = rendered.split("frontend fe_https", 1)[0]
+    acl_lines = [
+        line.strip()
+        for line in fe_http.splitlines()
+        if line.strip().startswith("acl geoip_host_api ")
+    ]
+    assert len(acl_lines) > 1, "expected the country list to be split across lines"
+    for line in acl_lines:
+        assert len(line.split()) <= 64
+
+    emitted: list[str] = []
+    for line in acl_lines:
+        emitted.extend(line.split("-m str ", 1)[1].split())
+    assert emitted == list(countries), "chunking must not drop or reorder codes"
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/unit/test_geoip_service.py
+++ b/src/backend/tests/unit/test_geoip_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for app.services.geoip_service (issue #175).
+
+No database, no HTTP layer — httpx and maxminddb are monkeypatched so these
+tests run offline and never touch the real MaxMind API.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tarfile
+from ipaddress import IPv4Network
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
+
+from app.config import settings  # noqa: E402
+from app.services import geoip_service  # noqa: E402
+
+
+class _FakeReader:
+    """Stand-in for the `maxminddb.open_database()` context manager."""
+
+    def __init__(self, entries: list[tuple[IPv4Network, dict]]) -> None:
+        self._entries = entries
+
+    def __enter__(self) -> _FakeReader:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    def __iter__(self):
+        return iter(self._entries)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "runtime_generated_config_root", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# ensure_map_file_exists
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_map_file_exists_creates_stub_when_absent() -> None:
+    path = geoip_service.ensure_map_file_exists()
+
+    assert path.exists()
+    content = path.read_text(encoding="utf-8")
+    assert "192.0.2.0/24 ZZ" in content
+
+
+def test_ensure_map_file_exists_is_noop_when_already_present() -> None:
+    path = geoip_service.map_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("custom content\n", encoding="utf-8")
+
+    geoip_service.ensure_map_file_exists()
+
+    assert path.read_text(encoding="utf-8") == "custom content\n"
+
+
+# ---------------------------------------------------------------------------
+# generate_map_file
+# ---------------------------------------------------------------------------
+
+
+def test_generate_map_file_writes_one_line_per_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mmdb = tmp_path / "fake.mmdb"
+    mmdb.write_bytes(b"not a real mmdb, just needs to exist")
+    entries = [
+        (IPv4Network("1.0.0.0/24"), {"country": {"iso_code": "PL"}}),
+        (IPv4Network("2.0.0.0/24"), {"registered_country": {"iso_code": "DE"}}),
+        (IPv4Network("3.0.0.0/24"), {}),
+        (IPv4Network("4.0.0.0/24"), {"country": {"iso_code": "XX"}}),
+    ]
+    monkeypatch.setattr(
+        geoip_service.maxminddb,
+        "open_database",
+        lambda *args, **kwargs: _FakeReader(entries),
+    )
+
+    entries_written = geoip_service.generate_map_file(mmdb)
+
+    assert entries_written == 2
+    content = geoip_service.map_file_path().read_text(encoding="utf-8")
+    assert "1.0.0.0/24 PL" in content
+    assert "2.0.0.0/24 DE" in content
+    assert "3.0.0.0/24" not in content
+    assert "4.0.0.0/24" not in content
+    # Atomic write: no leftover .tmp file.
+    leftover = list(geoip_service.geoip_dir().glob("*.tmp"))
+    assert leftover == []
+
+
+def test_generate_map_file_missing_mmdb_writes_stub_and_returns_zero(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="app.services.geoip_service")
+    missing = tmp_path / "does-not-exist.mmdb"
+
+    entries_written = geoip_service.generate_map_file(missing)
+
+    assert entries_written == 0
+    assert geoip_service.map_file_path().exists()
+    assert any("missing" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# download_database
+# ---------------------------------------------------------------------------
+
+
+def test_download_database_without_license_key_skips_http_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "")
+
+    def _fail_if_called(*args: object, **kwargs: object) -> None:
+        pytest.fail("httpx.get must not be called when unconfigured")
+
+    monkeypatch.setattr(httpx, "get", _fail_if_called)
+
+    with pytest.raises(geoip_service.GeoipNotConfiguredError):
+        geoip_service.download_database()
+
+
+def test_refresh_without_license_key_reports_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "")
+
+    def _fail_if_called(*args: object, **kwargs: object) -> None:
+        pytest.fail("httpx.get must not be called when unconfigured")
+
+    monkeypatch.setattr(httpx, "get", _fail_if_called)
+
+    result = geoip_service.refresh()
+
+    assert result.configured is False
+    assert result.downloaded is False
+
+
+def _build_tarball(mmdb_bytes: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        info = tarfile.TarInfo(
+            name="GeoLite2-Country_20260101/GeoLite2-Country.mmdb"
+        )
+        info.size = len(mmdb_bytes)
+        archive.addfile(info, io.BytesIO(mmdb_bytes))
+    return buffer.getvalue()
+
+
+def test_download_database_happy_path_extracts_mmdb(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "fake-license-key-abc123")
+    mmdb_bytes = b"fake mmdb payload"
+    tarball_bytes = _build_tarball(mmdb_bytes)
+
+    def _fake_get(url: str, params=None, timeout=None, follow_redirects=None):
+        return SimpleNamespace(
+            content=tarball_bytes,
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+    result_path = geoip_service.download_database()
+
+    assert result_path == geoip_service.mmdb_path()
+    assert result_path.read_bytes() == mmdb_bytes
+    leftover = list(geoip_service.geoip_dir().glob("*.tar.gz.tmp"))
+    assert leftover == []
+
+
+def test_download_database_never_logs_the_license_key(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    secret = "super-secret-license-99999"
+    monkeypatch.setattr(settings, "maxmind_license_key", secret)
+    caplog.set_level(logging.DEBUG)
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise httpx.HTTPError("network down")
+
+    monkeypatch.setattr(httpx, "get", _raise)
+
+    with pytest.raises(httpx.HTTPError):
+        geoip_service.download_database()
+
+    for record in caplog.records:
+        assert secret not in record.getMessage()
+        if record.exc_text:
+            assert secret not in record.exc_text
+
+
+# ---------------------------------------------------------------------------
+# refresh — reload triggering and error swallowing
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_reloads_haproxy_when_map_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: geoip_service.mmdb_path()
+    )
+
+    def _fake_generate(mmdb: Path | None = None) -> int:
+        path = geoip_service.map_file_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("changed content\n", encoding="utf-8")
+        return 1
+
+    monkeypatch.setattr(geoip_service, "generate_map_file", _fake_generate)
+    reload_mock = Mock(return_value=SimpleNamespace(ok=True, output="ok"))
+    monkeypatch.setattr("app.services.config_apply.reload_haproxy", reload_mock)
+
+    result = geoip_service.refresh()
+
+    assert result.changed is True
+    assert result.reloaded is True
+    reload_mock.assert_called_once()
+
+
+def test_refresh_does_not_reload_when_map_is_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: geoip_service.mmdb_path()
+    )
+    fixed_content = geoip_service._STUB_HEADER + "1.0.0.0/24 PL\n"
+
+    def _fake_generate(mmdb: Path | None = None) -> int:
+        path = geoip_service.map_file_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(fixed_content, encoding="utf-8")
+        return 1
+
+    monkeypatch.setattr(geoip_service, "generate_map_file", _fake_generate)
+    reload_mock = Mock(return_value=SimpleNamespace(ok=True, output="ok"))
+    monkeypatch.setattr("app.services.config_apply.reload_haproxy", reload_mock)
+
+    geoip_service.refresh()
+    reload_mock.reset_mock()
+
+    result = geoip_service.refresh()
+
+    assert result.changed is False
+    assert result.reloaded is False
+    reload_mock.assert_not_called()
+
+
+def test_refresh_swallows_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(geoip_service, "download_database", _raise)
+
+    result = geoip_service.refresh()
+
+    assert result.configured is True
+    assert result.downloaded is False
+    assert "GeoIP refresh failed" in result.message
+
+
+def test_refresh_swallows_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(geoip_service, "download_database", _raise)
+
+    result = geoip_service.refresh()
+
+    assert result.configured is True
+    assert result.downloaded is False
+    assert "GeoIP refresh failed" in result.message

--- a/src/backend/tests/unit/test_geoip_service.py
+++ b/src/backend/tests/unit/test_geoip_service.py
@@ -432,6 +432,80 @@ def test_generate_map_file_reports_unusable_reader(
         geoip_service.generate_map_file(mmdb)
 
 
+def test_generate_map_file_never_emits_the_zz_sentinel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ZZ must not reach the map as a resolved country.
+
+    In allowlist mode `var(txn.geoip_country) -m found` would then be true
+    while ZZ matched no allowed code, so the request would be denied — the
+    opposite of the documented fail-open behaviour for unresolvable IPs.
+    """
+    mmdb = tmp_path / "fake.mmdb"
+    mmdb.write_bytes(b"not a real mmdb, just needs to exist")
+    entries = [
+        (IPv4Network("1.0.0.0/24"), {"country": {"iso_code": "ZZ"}}),
+        (IPv4Network("2.0.0.0/24"), {"country": {"iso_code": "PL"}}),
+    ]
+    monkeypatch.setattr(
+        geoip_service.maxminddb,
+        "open_database",
+        lambda *args, **kwargs: _FakeReader(entries),
+    )
+
+    written = geoip_service.generate_map_file(mmdb)
+
+    assert written == 1
+    content = geoip_service.map_file_path().read_text(encoding="utf-8")
+    assert "1.0.0.0/24" not in content
+    assert "2.0.0.0/24 PL" in content
+
+
+def test_refresh_drops_cache_validators_when_database_is_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt download must not become permanent via a poisoned ETag.
+
+    download_database() records ETag/Last-Modified as soon as the transfer
+    succeeds, which happens before the file is known to be a valid MMDB (a
+    mirror answering 200 with an HTML error page passes raise_for_status()).
+    Keeping those validators would make every later refresh a 304.
+    """
+    meta = geoip_service._meta_path()
+    meta.parent.mkdir(parents=True, exist_ok=True)
+    meta.write_text(json.dumps({"etag": '"stale"'}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: (geoip_service.mmdb_path(), True)
+    )
+
+    def _raise() -> int:
+        raise geoip_service.maxminddb.InvalidDatabaseError("not an mmdb")
+
+    monkeypatch.setattr(geoip_service, "generate_map_file", _raise)
+
+    result = geoip_service.refresh(force_reload=False)
+
+    assert "GeoIP refresh failed" in result.message
+    assert not meta.exists(), (
+        "stale validators must be dropped so the next run refetches"
+    )
+
+
+def test_try_refresh_returns_none_while_another_refresh_holds_the_lock() -> None:
+    """The API and the scheduled job must contend for one lock.
+
+    Both write the same fixed temp paths, so a second concurrent refresh
+    would interleave writes and delete the other's temp file before its
+    os.replace(), publishing a corrupt map.
+    """
+    assert geoip_service._refresh_lock.acquire(blocking=False)
+    try:
+        assert geoip_service.try_refresh() is None
+    finally:
+        geoip_service._refresh_lock.release()
+
+
 def test_refresh_swallows_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def _raise(*args: object, **kwargs: object) -> None:
         raise httpx.HTTPError("boom")

--- a/src/backend/tests/unit/test_geoip_service.py
+++ b/src/backend/tests/unit/test_geoip_service.py
@@ -1,16 +1,15 @@
 """Unit tests for app.services.geoip_service (issue #175).
 
 No database, no HTTP layer — httpx and maxminddb are monkeypatched so these
-tests run offline and never touch the real MaxMind API.
+tests run offline and never touch the real ip66.dev database.
 """
 
 from __future__ import annotations
 
-import io
+import json
 import logging
 import os
-import tarfile
-from ipaddress import IPv4Network
+from ipaddress import IPv4Network, IPv6Network
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -27,7 +26,7 @@ from app.services import geoip_service  # noqa: E402
 class _FakeReader:
     """Stand-in for the `maxminddb.open_database()` context manager."""
 
-    def __init__(self, entries: list[tuple[IPv4Network, dict]]) -> None:
+    def __init__(self, entries: list[tuple[object, dict]]) -> None:
         self._entries = entries
 
     def __enter__(self) -> _FakeReader:
@@ -38,6 +37,35 @@ class _FakeReader:
 
     def __iter__(self):
         return iter(self._entries)
+
+
+class _FakeStreamResponse:
+    """Stand-in for the context manager returned by `httpx.stream()`."""
+
+    def __init__(
+        self,
+        status_code: int,
+        content: bytes = b"",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._content = content
+        self.headers = headers or {}
+
+    def __enter__(self) -> _FakeStreamResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "error", request=Mock(), response=Mock(status_code=self.status_code)
+            )
+
+    def iter_bytes(self, chunk_size: int):
+        yield self._content
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +131,53 @@ def test_generate_map_file_writes_one_line_per_network(
     assert leftover == []
 
 
+def test_generate_map_file_collapses_adjacent_networks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mmdb = tmp_path / "fake.mmdb"
+    mmdb.write_bytes(b"not a real mmdb, just needs to exist")
+    # Two adjacent /24s for the same country collapse into a single /23.
+    entries = [
+        (IPv4Network("10.0.0.0/24"), {"country": {"iso_code": "PL"}}),
+        (IPv4Network("10.0.1.0/24"), {"country": {"iso_code": "PL"}}),
+    ]
+    monkeypatch.setattr(
+        geoip_service.maxminddb,
+        "open_database",
+        lambda *args, **kwargs: _FakeReader(entries),
+    )
+
+    entries_written = geoip_service.generate_map_file(mmdb)
+
+    assert entries_written == 1
+    content = geoip_service.map_file_path().read_text(encoding="utf-8")
+    assert "10.0.0.0/23 PL" in content
+
+
+def test_generate_map_file_does_not_mix_ip_versions_when_collapsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mmdb = tmp_path / "fake.mmdb"
+    mmdb.write_bytes(b"not a real mmdb, just needs to exist")
+    entries = [
+        (IPv4Network("10.0.0.0/24"), {"country": {"iso_code": "PL"}}),
+        (IPv6Network("2001:db8::/32"), {"country": {"iso_code": "PL"}}),
+    ]
+    monkeypatch.setattr(
+        geoip_service.maxminddb,
+        "open_database",
+        lambda *args, **kwargs: _FakeReader(entries),
+    )
+
+    # Must not raise TypeError from mixing IPv4/IPv6 in collapse_addresses().
+    entries_written = geoip_service.generate_map_file(mmdb)
+
+    assert entries_written == 2
+    content = geoip_service.map_file_path().read_text(encoding="utf-8")
+    assert "10.0.0.0/24 PL" in content
+    assert "2001:db8::/32 PL" in content
+
+
 def test_generate_map_file_missing_mmdb_writes_stub_and_returns_zero(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -121,89 +196,103 @@ def test_generate_map_file_missing_mmdb_writes_stub_and_returns_zero(
 # ---------------------------------------------------------------------------
 
 
-def test_download_database_without_license_key_skips_http_call(
+def test_download_database_happy_path_writes_mmdb(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "")
-
-    def _fail_if_called(*args: object, **kwargs: object) -> None:
-        pytest.fail("httpx.get must not be called when unconfigured")
-
-    monkeypatch.setattr(httpx, "get", _fail_if_called)
-
-    with pytest.raises(geoip_service.GeoipNotConfiguredError):
-        geoip_service.download_database()
-
-
-def test_refresh_without_license_key_reports_unconfigured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "")
-
-    def _fail_if_called(*args: object, **kwargs: object) -> None:
-        pytest.fail("httpx.get must not be called when unconfigured")
-
-    monkeypatch.setattr(httpx, "get", _fail_if_called)
-
-    result = geoip_service.refresh()
-
-    assert result.configured is False
-    assert result.downloaded is False
-
-
-def _build_tarball(mmdb_bytes: bytes) -> bytes:
-    buffer = io.BytesIO()
-    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
-        info = tarfile.TarInfo(
-            name="GeoLite2-Country_20260101/GeoLite2-Country.mmdb"
-        )
-        info.size = len(mmdb_bytes)
-        archive.addfile(info, io.BytesIO(mmdb_bytes))
-    return buffer.getvalue()
-
-
-def test_download_database_happy_path_extracts_mmdb(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "fake-license-key-abc123")
     mmdb_bytes = b"fake mmdb payload"
-    tarball_bytes = _build_tarball(mmdb_bytes)
 
-    def _fake_get(url: str, params=None, timeout=None, follow_redirects=None):
-        return SimpleNamespace(
-            content=tarball_bytes,
-            raise_for_status=lambda: None,
+    def _fake_stream(
+        method: str, url: str, headers=None, timeout=None, follow_redirects=None
+    ):
+        assert method == "GET"
+        assert url == settings.geoip_database_url
+        assert headers == {}
+        return _FakeStreamResponse(
+            200, content=mmdb_bytes, headers={"ETag": '"abc123"'}
         )
 
-    monkeypatch.setattr(httpx, "get", _fake_get)
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
 
-    result_path = geoip_service.download_database()
+    result_path, downloaded = geoip_service.download_database()
 
+    assert downloaded is True
     assert result_path == geoip_service.mmdb_path()
     assert result_path.read_bytes() == mmdb_bytes
-    leftover = list(geoip_service.geoip_dir().glob("*.tar.gz.tmp"))
+    leftover = list(geoip_service.geoip_dir().glob("*.tmp"))
     assert leftover == []
 
 
-def test_download_database_never_logs_the_license_key(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def test_download_database_persists_conditional_headers(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    secret = "super-secret-license-99999"
-    monkeypatch.setattr(settings, "maxmind_license_key", secret)
-    caplog.set_level(logging.DEBUG)
+    def _fake_stream(
+        method: str, url: str, headers=None, timeout=None, follow_redirects=None
+    ):
+        return _FakeStreamResponse(
+            200,
+            content=b"payload",
+            headers={
+                "ETag": '"abc123"',
+                "Last-Modified": "Tue, 01 Jul 2026 00:00:00 GMT",
+            },
+        )
 
-    def _raise(*args: object, **kwargs: object) -> None:
-        raise httpx.HTTPError("network down")
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
 
-    monkeypatch.setattr(httpx, "get", _raise)
+    geoip_service.download_database()
+
+    meta = json.loads(geoip_service._meta_path().read_text(encoding="utf-8"))
+    assert meta["etag"] == '"abc123"'
+    assert meta["last_modified"] == "Tue, 01 Jul 2026 00:00:00 GMT"
+
+
+def test_download_database_sends_conditional_headers_on_second_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    geoip_service.mmdb_path().parent.mkdir(parents=True, exist_ok=True)
+    geoip_service.mmdb_path().write_bytes(b"old payload")
+    geoip_service._meta_path().write_text(
+        json.dumps(
+            {"etag": '"abc123"', "last_modified": "Tue, 01 Jul 2026 00:00:00 GMT"}
+        ),
+        encoding="utf-8",
+    )
+
+    captured_headers: dict[str, str] = {}
+
+    def _fake_stream(
+        method: str, url: str, headers=None, timeout=None, follow_redirects=None
+    ):
+        captured_headers.update(headers or {})
+        return _FakeStreamResponse(304)
+
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
+
+    result_path, downloaded = geoip_service.download_database()
+
+    assert downloaded is False
+    assert result_path == geoip_service.mmdb_path()
+    assert captured_headers["If-None-Match"] == '"abc123"'
+    assert captured_headers["If-Modified-Since"] == "Tue, 01 Jul 2026 00:00:00 GMT"
+    # The existing database is left untouched on a 304.
+    assert result_path.read_bytes() == b"old payload"
+
+
+def test_download_database_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_stream(
+        method: str, url: str, headers=None, timeout=None, follow_redirects=None
+    ):
+        return _FakeStreamResponse(500)
+
+    monkeypatch.setattr(httpx, "stream", _fake_stream)
 
     with pytest.raises(httpx.HTTPError):
         geoip_service.download_database()
 
-    for record in caplog.records:
-        assert secret not in record.getMessage()
-        if record.exc_text:
-            assert secret not in record.exc_text
+    leftover = list(geoip_service.geoip_dir().glob("*.tmp"))
+    assert leftover == []
 
 
 # ---------------------------------------------------------------------------
@@ -214,9 +303,8 @@ def test_download_database_never_logs_the_license_key(
 def test_refresh_reloads_haproxy_when_map_changed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
     monkeypatch.setattr(
-        geoip_service, "download_database", lambda: geoip_service.mmdb_path()
+        geoip_service, "download_database", lambda: (geoip_service.mmdb_path(), True)
     )
 
     def _fake_generate(mmdb: Path | None = None) -> int:
@@ -231,43 +319,120 @@ def test_refresh_reloads_haproxy_when_map_changed(
 
     result = geoip_service.refresh()
 
+    assert result.downloaded is True
     assert result.changed is True
     assert result.reloaded is True
     reload_mock.assert_called_once()
 
 
-def test_refresh_does_not_reload_when_map_is_byte_identical(
+def test_refresh_does_not_regenerate_or_reload_when_not_modified(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
-    monkeypatch.setattr(
-        geoip_service, "download_database", lambda: geoip_service.mmdb_path()
-    )
     fixed_content = geoip_service._STUB_HEADER + "1.0.0.0/24 PL\n"
+    geoip_service.map_file_path().parent.mkdir(parents=True, exist_ok=True)
+    geoip_service.map_file_path().write_text(fixed_content, encoding="utf-8")
 
-    def _fake_generate(mmdb: Path | None = None) -> int:
-        path = geoip_service.map_file_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(fixed_content, encoding="utf-8")
-        return 1
-
-    monkeypatch.setattr(geoip_service, "generate_map_file", _fake_generate)
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: (geoip_service.mmdb_path(), False)
+    )
+    generate_mock = Mock()
+    monkeypatch.setattr(geoip_service, "generate_map_file", generate_mock)
     reload_mock = Mock(return_value=SimpleNamespace(ok=True, output="ok"))
     monkeypatch.setattr("app.services.config_apply.reload_haproxy", reload_mock)
 
-    geoip_service.refresh()
-    reload_mock.reset_mock()
-
     result = geoip_service.refresh()
 
+    assert result.downloaded is False
     assert result.changed is False
     assert result.reloaded is False
+    generate_mock.assert_not_called()
     reload_mock.assert_not_called()
 
 
-def test_refresh_swallows_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
+def test_refresh_regenerates_when_map_is_still_a_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 304 must not leave a stub map in place.
 
+    The MMDB can be current while the map is not — first boot after an
+    upgrade, a wiped volume, or a generation that failed last run. Reporting
+    "up to date" there would leave every lookup missing, silently failing open.
+    """
+    geoip_service.ensure_map_file_exists()
+    assert geoip_service._map_is_stub()
+
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: (geoip_service.mmdb_path(), False)
+    )
+    generate_mock = Mock(return_value=7)
+    monkeypatch.setattr(geoip_service, "generate_map_file", generate_mock)
+
+    result = geoip_service.refresh(force_reload=False)
+
+    assert result.downloaded is False
+    generate_mock.assert_called_once()
+    assert result.entries == 7
+
+
+def test_refresh_reports_failed_reload_when_map_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    geoip_service.map_file_path().parent.mkdir(parents=True, exist_ok=True)
+    geoip_service.map_file_path().write_text(
+        geoip_service._STUB_HEADER + "1.0.0.0/24 PL\n", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        geoip_service, "download_database", lambda: (geoip_service.mmdb_path(), True)
+    )
+
+    def _generate() -> int:
+        geoip_service.map_file_path().write_text(
+            geoip_service._STUB_HEADER + "2.0.0.0/24 DE\n", encoding="utf-8"
+        )
+        return 1
+
+    monkeypatch.setattr(geoip_service, "generate_map_file", _generate)
+    reload_mock = Mock(return_value=SimpleNamespace(ok=False, output="reload failed"))
+    monkeypatch.setattr("app.services.config_apply.reload_haproxy", reload_mock)
+
+    result = geoip_service.refresh()
+
+    assert result.changed is True
+    assert result.reloaded is False
+    reload_mock.assert_called_once()
+
+
+def test_generate_map_file_reports_unusable_reader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The pure Python maxminddb reader cannot enumerate the real database.
+
+    It raises "ValueError: ::1:0:0/0 has host bits set" partway through, so
+    that must surface as an actionable GeoipError rather than an opaque crash.
+    """
+    mmdb = tmp_path / "country.mmdb"
+    mmdb.write_bytes(b"not-a-real-mmdb")
+
+    class _Reader:
+        def __enter__(self) -> _Reader:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def __iter__(self) -> object:
+            raise ValueError("::1:0:0/0 has host bits set")
+
+    monkeypatch.setattr(
+        geoip_service.maxminddb, "open_database", lambda *a, **kw: _Reader()
+    )
+
+    with pytest.raises(geoip_service.GeoipError, match="maxminddb C extension"):
+        geoip_service.generate_map_file(mmdb)
+
+
+def test_refresh_swallows_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def _raise(*args: object, **kwargs: object) -> None:
         raise httpx.HTTPError("boom")
 
@@ -275,14 +440,11 @@ def test_refresh_swallows_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
     result = geoip_service.refresh()
 
-    assert result.configured is True
     assert result.downloaded is False
     assert "GeoIP refresh failed" in result.message
 
 
 def test_refresh_swallows_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "maxmind_license_key", "key123")
-
     def _raise(*args: object, **kwargs: object) -> None:
         raise OSError("disk full")
 
@@ -290,6 +452,5 @@ def test_refresh_swallows_os_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
     result = geoip_service.refresh()
 
-    assert result.configured is True
     assert result.downloaded is False
     assert "GeoIP refresh failed" in result.message

--- a/src/backend/tests/unit/test_policy_service.py
+++ b/src/backend/tests/unit/test_policy_service.py
@@ -14,13 +14,18 @@ from sqlalchemy.orm import Session
 
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-pytest-onlyx")
 
-from app.models.policy import Policy, PolicyEnforcementMode  # noqa: E402
+from app.models.policy import (  # noqa: E402
+    Policy,
+    PolicyEnforcementMode,
+    PolicyGeoipMode,
+)
 from app.models.policy_binding import PolicyBinding  # noqa: E402
 from app.models.user import User  # noqa: E402
 from app.models.vhost import VHost  # noqa: E402
 from app.services.policy_service import (  # noqa: E402
     PolicyDisallowedFieldError,
     PolicyFieldCannotBeNullError,
+    PolicyGeoipConfigurationError,
     PolicyInUseError,
     PolicyNameAlreadyExistsError,
     PolicyNotFoundError,
@@ -479,6 +484,201 @@ def test_delete_policy_missing_raises_not_found(db: Session) -> None:
 
     with pytest.raises(PolicyNotFoundError):
         service.delete_policy(99999)
+
+
+# ---------------------------------------------------------------------------
+# GeoIP country filtering (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def test_create_policy_defaults_geoip_to_off_and_empty_list(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+
+    policy = service.create_policy(
+        name="Geo default",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    assert policy.geoip_mode == PolicyGeoipMode.off
+    assert policy.geoip_countries == []
+
+
+def test_create_policy_persists_geoip_fields(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+
+    policy = service.create_policy(
+        name="Geo blocklist",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+        geoip_mode=PolicyGeoipMode.blocklist,
+        geoip_countries=["RU", "CN"],
+    )
+
+    assert policy.geoip_mode == PolicyGeoipMode.blocklist
+    assert policy.geoip_countries == ["RU", "CN"]
+
+
+def test_create_policy_allowlist_with_empty_countries_raises(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+
+    with pytest.raises(PolicyGeoipConfigurationError):
+        service.create_policy(
+            name="Geo invalid",
+            description=None,
+            paranoia_level=2,
+            inbound_anomaly_threshold=5,
+            outbound_anomaly_threshold=5,
+            enforcement_mode=PolicyEnforcementMode.block,
+            created_by=admin_user.id,
+            geoip_mode=PolicyGeoipMode.allowlist,
+            geoip_countries=[],
+        )
+
+
+def test_update_policy_patches_geoip_fields(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo patch",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_policy(
+        created.id,
+        {"geoip_mode": PolicyGeoipMode.allowlist, "geoip_countries": ["US", "CA"]},
+    )
+
+    assert updated.geoip_mode == PolicyGeoipMode.allowlist
+    assert updated.geoip_countries == ["US", "CA"]
+
+
+def test_update_policy_geoip_mode_null_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo null mode",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyFieldCannotBeNullError):
+        service.update_policy(created.id, {"geoip_mode": None})
+
+
+def test_update_policy_geoip_countries_null_raises_error(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo null countries",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyFieldCannotBeNullError):
+        service.update_policy(created.id, {"geoip_countries": None})
+
+
+def test_update_policy_allowlist_with_empty_stored_list_raises(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo empty stored",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    with pytest.raises(PolicyGeoipConfigurationError):
+        service.update_policy(created.id, {"geoip_mode": PolicyGeoipMode.allowlist})
+
+
+def test_update_policy_allowlist_with_countries_in_same_patch_succeeds(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo same patch",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+    )
+
+    updated = service.update_policy(
+        created.id,
+        {"geoip_mode": PolicyGeoipMode.allowlist, "geoip_countries": ["FR"]},
+    )
+
+    assert updated.geoip_mode == PolicyGeoipMode.allowlist
+    assert updated.geoip_countries == ["FR"]
+
+
+def test_update_policy_geoip_off_leaves_stored_countries_untouched(
+    db: Session,
+    admin_user: User,
+) -> None:
+    service = PolicyService(db)
+    created = service.create_policy(
+        name="Geo toggle off",
+        description=None,
+        paranoia_level=2,
+        inbound_anomaly_threshold=5,
+        outbound_anomaly_threshold=5,
+        enforcement_mode=PolicyEnforcementMode.block,
+        created_by=admin_user.id,
+        geoip_mode=PolicyGeoipMode.allowlist,
+        geoip_countries=["JP"],
+    )
+
+    updated = service.update_policy(created.id, {"geoip_mode": PolicyGeoipMode.off})
+
+    assert updated.geoip_mode == PolicyGeoipMode.off
+    assert updated.geoip_countries == ["JP"]
 
 
 def test_update_policy_disallowed_field_raises_error(

--- a/src/backend/tests/unit/test_scheduler.py
+++ b/src/backend/tests/unit/test_scheduler.py
@@ -1,0 +1,71 @@
+"""Unit tests for the GeoIP parts of app.services.scheduler (issue #175)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import scheduler as scheduler_module
+
+
+def test_refresh_geoip_database_logs_the_result(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    result = SimpleNamespace(message="GeoIP database refreshed: 5 entries written.")
+    monkeypatch.setattr(
+        scheduler_module.geoip_service, "refresh", lambda: result, raising=True
+    )
+
+    with caplog.at_level(logging.INFO):
+        scheduler_module.refresh_geoip_database()
+
+    assert "GeoIP refresh: GeoIP database refreshed: 5 entries written." in caplog.text
+
+
+def test_refresh_geoip_database_does_not_swallow_scheduler_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`geoip_service.refresh()` is documented as never raising.
+
+    If that ever changes the job should surface the error to APScheduler
+    rather than the wrapper hiding it, so this pins the wrapper's behaviour.
+    """
+
+    def _boom() -> None:
+        raise RuntimeError("refresh exploded")
+
+    monkeypatch.setattr(scheduler_module.geoip_service, "refresh", _boom, raising=True)
+
+    with pytest.raises(RuntimeError, match="refresh exploded"):
+        scheduler_module.refresh_geoip_database()
+
+
+def test_start_scheduler_schedules_an_initial_geoip_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without next_run_time the map stays a stub for a whole interval.
+
+    An interval job's first run is one interval after start, so on every boot
+    the country map would remain the empty stub — silently failing open — for
+    a full refresh interval.
+    """
+    jobs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        scheduler_module.scheduler,
+        "add_job",
+        lambda *args, **kwargs: jobs.append((args, kwargs)),
+    )
+    monkeypatch.setattr(scheduler_module.scheduler, "start", lambda: None)
+
+    before = datetime.now(UTC)
+    scheduler_module.start_scheduler()
+
+    geoip_jobs = [kw for _, kw in jobs if kw.get("id") == "refresh_geoip_database"]
+    assert len(geoip_jobs) == 1
+    next_run_time = geoip_jobs[0]["next_run_time"]
+    assert isinstance(next_run_time, datetime)
+    assert next_run_time > before

--- a/src/backend/tests/unit/test_schemas.py
+++ b/src/backend/tests/unit/test_schemas.py
@@ -201,6 +201,54 @@ def test_policy_update_name_null_is_allowed_by_schema() -> None:
 
 
 # ---------------------------------------------------------------------------
+# PolicyCreate/PolicyUpdate: geoip_countries normalisation (issue #175)
+# ---------------------------------------------------------------------------
+
+
+def test_policy_create_geoip_countries_normalized() -> None:
+    p = PolicyCreate(
+        name="x",
+        geoip_mode="allowlist",
+        geoip_countries=[" pl ", "de", " pl "],
+    )
+    assert p.geoip_countries == ["PL", "DE"]
+
+
+def test_policy_create_geoip_countries_rejects_unknown_code() -> None:
+    with pytest.raises(ValidationError, match="Unknown country code"):
+        PolicyCreate(name="x", geoip_mode="allowlist", geoip_countries=["XX"])
+
+
+def test_policy_create_geoip_countries_rejects_zz_sentinel() -> None:
+    with pytest.raises(ValidationError, match="Unknown country code"):
+        PolicyCreate(name="x", geoip_mode="allowlist", geoip_countries=["ZZ"])
+
+
+def test_policy_create_geoip_countries_caps_at_250() -> None:
+    with pytest.raises(ValidationError):
+        PolicyCreate(
+            name="x",
+            geoip_mode="allowlist",
+            geoip_countries=[f"c{i}" for i in range(251)],
+        )
+
+
+def test_policy_update_geoip_countries_normalized() -> None:
+    p = PolicyUpdate(geoip_countries=[" pl ", "de", " pl "])
+    assert p.geoip_countries == ["PL", "DE"]
+
+
+def test_policy_update_geoip_countries_none_is_valid() -> None:
+    p = PolicyUpdate()
+    assert p.geoip_countries is None
+
+
+def test_policy_update_geoip_countries_rejects_unknown_code() -> None:
+    with pytest.raises(ValidationError, match="Unknown country code"):
+        PolicyUpdate(geoip_countries=["XX"])
+
+
+# ---------------------------------------------------------------------------
 # RuleOverride schemas
 # ---------------------------------------------------------------------------
 

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -370,7 +370,9 @@ dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "jinja2" },
+    { name = "maxminddb" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "psycopg2-binary" },
     { name = "pydantic", extra = ["email"] },
@@ -384,7 +386,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -399,8 +400,9 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=3.2.0,<4.0.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1.4" },
+    { name = "maxminddb", specifier = ">=3.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
@@ -630,6 +632,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "maxminddb"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/83/bcd7f2e7dfcf601258a4eab92155816218e8f8adf6608d5f7d39da7ba863/maxminddb-3.1.1.tar.gz", hash = "sha256:b19a938c481518f19a2c534ffdcb3bc59582f0fbbdcf9f81ac9adf912a0af686", size = 212410, upload-time = "2026-03-05T18:14:19.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/02/a26cfdb9feed1ec0e66d5adeb37ff1f6bbcf3bb6c26870ec6a4554cacb93/maxminddb-3.1.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:90df0298f6713711ecba893f16ca31c486014e6b1c86611660426e5537cbbe14", size = 37596, upload-time = "2026-03-05T18:13:23.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/0bf2b7f2443b71a1c90d9d0772cecd43af392b0d285b20ddae9de9bd57da/maxminddb-3.1.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:42c8dc32b09e5f7c8e2e3d354e5bf48d56bf6c12099dd02df1ceca3f13762d97", size = 38079, upload-time = "2026-03-05T18:13:24.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cd/a05c211da1c29eaa00f971e30338823872dccf7b6c4935fc71b8d12d6b34/maxminddb-3.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:13a6dba0e696e904773cd9c17a290dcab9ba4a26128811e087c46c2c2f700c13", size = 35280, upload-time = "2026-03-05T18:13:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/4e/0f4b34d9d9c5b79712d9616b00f3a683489a0b80ac2b61cb492d7d432977/maxminddb-3.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4d72b373930d95ac00db20a49b43eaac707cc633247f29a4c9a24000187505e9", size = 35823, upload-time = "2026-03-05T18:13:26.526Z" },
+    { url = "https://files.pythonhosted.org/packages/69/af/509eb9eeb119019f7f86a9e5bfdc1064e9bca590a07808adf9d4152221a6/maxminddb-3.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:afe667a377121a5234778ed0affb9b26bf9d23a0c50551541cc9e38e1c1d1400", size = 54236, upload-time = "2026-03-05T18:13:27.748Z" },
+    { url = "https://files.pythonhosted.org/packages/91/6e/09949370a413a7b5b791e8784f527bfa216539451c8c9b801ff06e61effe/maxminddb-3.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9a297da0042877a1eef457e238aa4df1707eb7e254aa96ecb1e17e935939a670", size = 36308, upload-time = "2026-03-05T18:13:28.773Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/01/0bff084d31b4441ec00e8ec84fa961efe5dffd3359d5318a557db8302a09/maxminddb-3.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5c31f5a1e388847b642d8e1b375abfb7b327d51cfd85e9c9f938a3258df7369", size = 36051, upload-time = "2026-03-05T18:13:30.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/31/136f4afed0202d4dbc114668068ba6ef99ab4d5cb3860e8bfc49208965a5/maxminddb-3.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7060e43d0788259b3a9bcc3d604360ebd7b17915300c97f8e254faeb27a70c34", size = 103470, upload-time = "2026-03-05T18:13:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1a/2593692d543498959b2836028ff26c36439343a2122f31a71202072f4e62/maxminddb-3.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbb195714caeb419b9a33b07b0b721d620c770210dd955018453fc588a4b7e42", size = 101290, upload-time = "2026-03-05T18:13:32.435Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/883b8961045ea624ac26ed04896bb7e0ccf911488695508bc20bf5cbe1ab/maxminddb-3.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b42f18cf17dfb3ff52ef8c97c41508d45cf23293d04779dce0fe2ca6f146e78", size = 100617, upload-time = "2026-03-05T18:13:33.74Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0a/bc52b27699601c235ccb973e5fbb0426520c8780f0404dd98e4d09b1ff88/maxminddb-3.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfcc3b074d4cfef4d15474368da70b47707df273cd89e1d6a92549f644852f5c", size = 99145, upload-time = "2026-03-05T18:13:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2c/01a3c975622add0f6f04336b400fcf4270c7054c0a35d8622b6bbd4e091b/maxminddb-3.1.1-cp313-cp313-win32.whl", hash = "sha256:3c9d50b5964c00e998ba5fdbad95b62abdf0ed9da5a55eab173f89e38a285e47", size = 35626, upload-time = "2026-03-05T18:13:36.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/27/a64da9ae7dea91d24a12a5649bd62a0eda49ad5ecf184075947971e523ad/maxminddb-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:19be24c36219779e65be57897b36fea340223cafdf3b128f3249e8603be7744d", size = 37330, upload-time = "2026-03-05T18:13:37.355Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f8/0523374a421b9816da20de42256c7c11e43ce0663decb8b675cf3c0f4561/maxminddb-3.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:6d01a791db367768aa2e15b9c2df5bb4a8d8c11713d872dec5f33dd3e818af26", size = 34222, upload-time = "2026-03-05T18:13:38.355Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f1/b5069070975602ad14e7898b883dda0b0785dab3c24f5750f5b7fa4e14c3/maxminddb-3.1.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:b2f859ff9ab56b8ce1c2033fdd978273d432ef1b03fbba24dd28d284bc9e2b41", size = 37401, upload-time = "2026-03-05T18:13:39.624Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b3/1816167dbf9e1373f32548d26c45a74215750680e6a61943355e0d2d157a/maxminddb-3.1.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:40116947ad235692dff2f1590269a844d8623036caf99310a0ea6833b04673ca", size = 37923, upload-time = "2026-03-05T18:13:41.153Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/6e3a1ea6586fa49f2c438dd48ef9f7e67352729583f9ac6552f0d7d110ad/maxminddb-3.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b83155134842f6dcd06f9ba9b661028a2154debc41bfc6b8d665d67267891153", size = 35248, upload-time = "2026-03-05T18:13:42.122Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3c/bab279d11b8225e283175be8f6250366d362f131e282723946052c09cc2a/maxminddb-3.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:c2aa82dbb882714071403fe19b301a87a750eb8b58af60fd794afebe9447c0fb", size = 35798, upload-time = "2026-03-05T18:13:43.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e2/95baf6f117f9bc35de7c83b061b3fd27a49d03e0cda6c4dc5432167ac06e/maxminddb-3.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:65cbeaf809aaeb464e6c89086c45e0e4b9f15b73a28825fea0c570cf6fae18b6", size = 54226, upload-time = "2026-03-05T18:13:44.757Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c7/bdcf8ca67c7d93007a4ed512cec61a0e13b43cf9abbb9dfdacd458dff049/maxminddb-3.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ebb79b06f94577c37206a2143e157f4f8e6baf4f4473734b16993e04e0b1fdd7", size = 36368, upload-time = "2026-03-05T18:13:45.778Z" },
+    { url = "https://files.pythonhosted.org/packages/da/71/a6cba811aa0ce539dff57400435643b2c05e607563f412c9138f50f14d34/maxminddb-3.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fac648527d83c4357f8f060f362a3c24f3aeb94bd458e2221522b7783dac5235", size = 36022, upload-time = "2026-03-05T18:13:47.02Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/c315b8e072663f77f928996fa6b8a084660d4130e00f092943fa9c892016/maxminddb-3.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d27c57d402cffae339e07224d04315ec1fd923a113dce5a9b2bf5894df8bdcfa", size = 103242, upload-time = "2026-03-05T18:13:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/13/7914f150c633e8acbbcde6e37b58a280f79888d5668ae5a50bd3846fde2b/maxminddb-3.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bf4df891b71bb30ef0583effb0e694f610649ace69212def73dd20cc4ae8038", size = 101080, upload-time = "2026-03-05T18:13:49.127Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a5/d856e34333b80594443a82a384eb383a64c06dd7047a81efb42d129a6412/maxminddb-3.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5fa302b97d205d32e950bb38907a253a76d8a0091f2db5921e6561dbfa8febd1", size = 100611, upload-time = "2026-03-05T18:13:50.667Z" },
+    { url = "https://files.pythonhosted.org/packages/19/56/bdc5bb7cdac55895aa69b76c4daa39c72c0bb9840439f08ba21e5b9f24c8/maxminddb-3.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3fa33c7e220106a3b9b24e5046c9573079730b62cad61b70897768f319d84323", size = 98959, upload-time = "2026-03-05T18:13:52.088Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ff/ef98fea99940ef8fc9e55607fcf1afbf37774a6e01815837f735427b29d7/maxminddb-3.1.1-cp314-cp314-win32.whl", hash = "sha256:16fa02b016f8d12e9d78a610a3abfe98510c7db2592cfebaaeb768067c10448f", size = 36291, upload-time = "2026-03-05T18:13:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f8/2866267b7728d6877930a22de42e771010f94e5832432a71c1bb0ce1c2e3/maxminddb-3.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:0fa73771e95a1fc4a2c5f3530191473da9eb39ec8301999bd18d9ac6a9becb79", size = 38050, upload-time = "2026-03-05T18:13:54.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/82/5b77a81e7ba8c8c83df1daa6cb701490589f5a17238a716d180a105ddf6d/maxminddb-3.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ad144247e94aca2e6f51408ce24ef9184f6bf440affce61090578382cdf69ffc", size = 34785, upload-time = "2026-03-05T18:13:56.232Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ef/72d6ef4f7acc428b8a8f3910f1acaacc33fcd55cd339029c33a234b6211f/maxminddb-3.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5334cee936368d43f7d99028bb37c864e8862465c6eac838e145d995e30707ec", size = 58136, upload-time = "2026-03-05T18:13:57.19Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/a7/9f925bc30b77107b32cad2cab23aa5c459544079de62d6bcd3558dfe9a90/maxminddb-3.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff7d739fbefe2529b76dce0362a165795e369ca2d79e04882b42035ab2c16e44", size = 38443, upload-time = "2026-03-05T18:13:58.229Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8d/80c53840f598d77c01b94c718cc9b66658d677cf09b41f84d92aa04d0f81/maxminddb-3.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5d0709dae06d6f242acc1dd02495b6e1668ea898e22431865f8afc95aa4e7d0", size = 37937, upload-time = "2026-03-05T18:13:59.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/25/6a6f9aaf1af7c8ba83ab84792a7999a442b260bdadd84687800fde56fc4a/maxminddb-3.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e61dca3fd6709817762940f25fc86279957883a00c409612893a168974aba9f1", size = 120046, upload-time = "2026-03-05T18:14:00.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/30/789efe80b43611cafa21bc130ae21c1b09ce7582c52a71d0f393ec69e868/maxminddb-3.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfb73a59ab7a3ccce1b00f048fdab982303253da26324943c831dd5d0f6db99b", size = 116454, upload-time = "2026-03-05T18:14:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/da72e8a106539b40777ea0c991a1f5b896fe1374fce5d6a0d16977d49a1a/maxminddb-3.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f7e7a0accc4011fd0528c9755010c9d4be06ee116cc0c2aff0ce0f63f792cb41", size = 116395, upload-time = "2026-03-05T18:14:02.689Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6d/e18a61f2c2ab08d92801525468be807c5e2f1fed5b817cd35d1c535669db/maxminddb-3.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3f5032043db990f159b0e8e2747468f4665a3b5b345e343f620fe71c91fb2631", size = 113548, upload-time = "2026-03-05T18:14:03.767Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ba/015d8608e8ab108b6c5e8c252f51155385a70224f439e898ae01cd3aeb67/maxminddb-3.1.1-cp314-cp314t-win32.whl", hash = "sha256:962edb5f23f9e8dfbdfc775d9e452e4017adae2fb12d1b0a955dbddb7747e781", size = 37499, upload-time = "2026-03-05T18:14:04.823Z" },
+    { url = "https://files.pythonhosted.org/packages/39/67/8da91c3a89530209057e27f314859e17f8d93244b73945d01036e89cf819/maxminddb-3.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6879a4d822b894d1717aeef20b3558fdf1d1f6cf1ce25a7ad46d0a43ed745f63", size = 39557, upload-time = "2026-03-05T18:14:06.334Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3e/36c6010a302f822d054fed7ed7009d39dd0ed662c17a01e36dce956787ca/maxminddb-3.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:9cc4eb1d2648c0188d7649babe8df1236d22972a753676db3b7487646a65b0c7", size = 35396, upload-time = "2026-03-05T18:14:07.281Z" },
 ]
 
 [[package]]

--- a/src/frontend/src/features/policies/PolicyFormModal.test.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.test.tsx
@@ -43,6 +43,8 @@ const editPolicy: Policy = {
   auto_ban_enabled: false,
   ban_threshold: 10,
   ban_duration_seconds: 600,
+  geoip_mode: "off",
+  geoip_countries: [],
   created_by: 1,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
@@ -221,5 +223,110 @@ describe("PolicyFormModal automatic IP banning fields", () => {
         ban_duration_seconds: 600,
       }),
     );
+  });
+});
+
+describe("PolicyFormModal GeoIP country filtering fields", () => {
+  it("hides the country input while mode is off", () => {
+    renderCreateModal();
+
+    expect(screen.queryByLabelText("Country codes")).not.toBeInTheDocument();
+  });
+
+  it("shows the country input once allowlist is selected", async () => {
+    renderCreateModal();
+
+    await userEvent.selectOptions(
+      screen.getByLabelText("GeoIP country filtering"),
+      "allowlist",
+    );
+
+    expect(screen.getByLabelText("Country codes")).toBeEnabled();
+  });
+
+  it("shows the country input once blocklist is selected", async () => {
+    renderCreateModal();
+
+    await userEvent.selectOptions(
+      screen.getByLabelText("GeoIP country filtering"),
+      "blocklist",
+    );
+
+    expect(screen.getByLabelText("Country codes")).toBeEnabled();
+  });
+
+  it("submits normalized country codes on create", async () => {
+    vi.mocked(api.createPolicy).mockResolvedValue({ ...editPolicy, id: 2 });
+
+    const onSuccess = vi.fn();
+    renderCreateModal(onSuccess);
+
+    await userEvent.type(screen.getByLabelText("Name"), "Geo policy");
+    await userEvent.selectOptions(
+      screen.getByLabelText("GeoIP country filtering"),
+      "allowlist",
+    );
+    await userEvent.type(screen.getByLabelText("Country codes"), "pl, de");
+
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+    expect(api.createPolicy).toHaveBeenCalledWith(
+      "test-token",
+      expect.objectContaining({
+        geoip_mode: "allowlist",
+        geoip_countries: ["PL", "DE"],
+      }),
+    );
+  });
+
+  it("shows an inline error and makes no API call for an unknown code", async () => {
+    vi.mocked(api.createPolicy).mockClear();
+    renderCreateModal();
+
+    await userEvent.type(screen.getByLabelText("Name"), "Geo policy");
+    await userEvent.selectOptions(
+      screen.getByLabelText("GeoIP country filtering"),
+      "allowlist",
+    );
+    await userEvent.type(screen.getByLabelText("Country codes"), "zz");
+
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByText(/Unknown country code/i)).toBeInTheDocument();
+    expect(api.createPolicy).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error and makes no API call for an empty list", async () => {
+    vi.mocked(api.createPolicy).mockClear();
+    renderCreateModal();
+
+    await userEvent.type(screen.getByLabelText("Name"), "Geo policy");
+    await userEvent.selectOptions(
+      screen.getByLabelText("GeoIP country filtering"),
+      "allowlist",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText(/Select at least one country code/i),
+    ).toBeInTheDocument();
+    expect(api.createPolicy).not.toHaveBeenCalled();
+  });
+
+  it("pre-populates the country input from policy.geoip_countries", () => {
+    render(
+      <AuthContext.Provider value={makeAuthContext()}>
+        <PolicyFormModal
+          mode="edit"
+          policy={{ ...editPolicy, geoip_mode: "blocklist", geoip_countries: ["RU", "CN"] }}
+          onSuccess={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </AuthContext.Provider>,
+    );
+
+    expect(screen.getByLabelText("Country codes")).toHaveValue("RU, CN");
   });
 });

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -94,7 +94,10 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
     setSubmitting(true);
     setServerError(null);
 
-    const parsedGeoipCountries = parseGeoipCountries();
+    // The country input is hidden while the mode is "off", so any leftover
+    // text in it is invisible to the user. Submitting it anyway would fail
+    // validation server-side with a 422 they can neither see nor fix.
+    const parsedGeoipCountries = geoipMode === "off" ? [] : parseGeoipCountries();
     if (geoipMode !== "off") {
       if (parsedGeoipCountries.length === 0) {
         setServerError("Select at least one country code.");

--- a/src/frontend/src/features/policies/PolicyFormModal.tsx
+++ b/src/frontend/src/features/policies/PolicyFormModal.tsx
@@ -13,7 +13,8 @@ import { ApiError } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
 
 import { createPolicy, updatePolicy } from "./api";
-import type { Policy } from "./types";
+import { COUNTRY_CODES_SET } from "./countries";
+import type { GeoipMode, Policy } from "./types";
 
 type CreateMode = { mode: "create" };
 type EditMode = { mode: "edit"; policy: Policy };
@@ -63,8 +64,28 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
   const [banDurationSeconds, setBanDurationSeconds] = useState<string>(
     String(initial?.ban_duration_seconds ?? 600),
   );
+  const [geoipMode, setGeoipMode] = useState<GeoipMode>(
+    initial?.geoip_mode ?? "off",
+  );
+  const [geoipCountries, setGeoipCountries] = useState<string>(
+    (initial?.geoip_countries ?? []).join(", "),
+  );
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
+
+  function parseGeoipCountries(): string[] {
+    const seen = new Set<string>();
+    const codes: string[] = [];
+    for (const raw of geoipCountries.split(",")) {
+      const code = raw.trim().toUpperCase();
+      if (!code) continue;
+      if (!seen.has(code)) {
+        seen.add(code);
+        codes.push(code);
+      }
+    }
+    return codes;
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -72,6 +93,23 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
 
     setSubmitting(true);
     setServerError(null);
+
+    const parsedGeoipCountries = parseGeoipCountries();
+    if (geoipMode !== "off") {
+      if (parsedGeoipCountries.length === 0) {
+        setServerError("Select at least one country code.");
+        setSubmitting(false);
+        return;
+      }
+      const unknown = parsedGeoipCountries.find(
+        (code) => !COUNTRY_CODES_SET.has(code),
+      );
+      if (unknown) {
+        setServerError(`Unknown country code: ${unknown}`);
+        setSubmitting(false);
+        return;
+      }
+    }
 
     try {
       if (props.mode === "edit") {
@@ -90,6 +128,8 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
           auto_ban_enabled: autoBanEnabled,
           ban_threshold: Number(banThreshold),
           ban_duration_seconds: Number(banDurationSeconds),
+          geoip_mode: geoipMode,
+          geoip_countries: parsedGeoipCountries,
         });
       } else {
         await createPolicy(accessToken, {
@@ -106,6 +146,8 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
           auto_ban_enabled: autoBanEnabled,
           ban_threshold: Number(banThreshold),
           ban_duration_seconds: Number(banDurationSeconds),
+          geoip_mode: geoipMode,
+          geoip_countries: parsedGeoipCountries,
         });
       }
       onSuccess();
@@ -322,6 +364,35 @@ export function PolicyFormModal(props: PolicyFormModalProps) {
                 )}
               </div>
             </>
+          )}
+        </div>
+
+        <div className="space-y-3 rounded-md border border-border p-3">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="policy-geoip-mode">GeoIP country filtering</Label>
+            <InfoTooltip label="Allowlist: only the listed countries may reach this vhost; everything else gets 403. Blocklist: the listed countries get 403. Requests whose country cannot be resolved are allowed by default." />
+          </div>
+          <Select
+            id="policy-geoip-mode"
+            value={geoipMode}
+            onChange={(e) => setGeoipMode(e.target.value as GeoipMode)}
+          >
+            <option value="off">Off</option>
+            <option value="allowlist">Allowlist</option>
+            <option value="blocklist">Blocklist</option>
+          </Select>
+
+          {geoipMode !== "off" && (
+            <div className="space-y-1.5">
+              <Label htmlFor="policy-geoip-countries">Country codes</Label>
+              <Input
+                id="policy-geoip-countries"
+                type="text"
+                value={geoipCountries}
+                onChange={(e) => setGeoipCountries(e.target.value)}
+                placeholder="e.g. US, CA, GB"
+              />
+            </div>
           )}
         </div>
 

--- a/src/frontend/src/features/policies/countries.ts
+++ b/src/frontend/src/features/policies/countries.ts
@@ -1,0 +1,34 @@
+// ISO 3166-1 alpha-2 country codes for GeoIP filtering (issue #175).
+// Same static list as the backend twin in
+// src/backend/app/constants/countries.py — keep the two in sync. The "ZZ"
+// internal sentinel is intentionally excluded here since it is not
+// admin-selectable.
+export const COUNTRY_CODES: readonly string[] = [
+  "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR",
+  "AS", "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE",
+  "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ",
+  "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD",
+  "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN", "CO", "CR",
+  "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM",
+  "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI",
+  "FJ", "FK", "FM", "FO", "FR", "GA", "GB", "GD", "GE", "GF",
+  "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS",
+  "GT", "GU", "GW", "GY", "HK", "HM", "HN", "HR", "HT", "HU",
+  "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT",
+  "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN",
+  "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK",
+  "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME",
+  "MF", "MG", "MH", "MK", "ML", "MM", "MN", "MO", "MP", "MQ",
+  "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA",
+  "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NU",
+  "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL", "PM",
+  "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS",
+  "RU", "RW", "SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI",
+  "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST", "SV",
+  "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK",
+  "TL", "TM", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA",
+  "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
+  "VN", "VU", "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW",
+];
+
+export const COUNTRY_CODES_SET: ReadonlySet<string> = new Set(COUNTRY_CODES);

--- a/src/frontend/src/features/policies/types.ts
+++ b/src/frontend/src/features/policies/types.ts
@@ -1,3 +1,5 @@
+export type GeoipMode = "off" | "allowlist" | "blocklist";
+
 export type Policy = {
   id: number;
   name: string;
@@ -14,6 +16,8 @@ export type Policy = {
   auto_ban_enabled: boolean;
   ban_threshold: number;
   ban_duration_seconds: number;
+  geoip_mode: GeoipMode;
+  geoip_countries: string[];
   created_by: number | null;
   created_at: string;
   updated_at: string;
@@ -159,6 +163,8 @@ export type PolicyCreate = {
   auto_ban_enabled?: boolean;
   ban_threshold?: number;
   ban_duration_seconds?: number;
+  geoip_mode?: GeoipMode;
+  geoip_countries?: string[];
 };
 
 export type PolicyUpdate = {
@@ -176,4 +182,6 @@ export type PolicyUpdate = {
   auto_ban_enabled?: boolean;
   ban_threshold?: number;
   ban_duration_seconds?: number;
+  geoip_mode?: GeoipMode;
+  geoip_countries?: string[];
 };

--- a/src/frontend/src/pages/policies/PoliciesPage.test.tsx
+++ b/src/frontend/src/pages/policies/PoliciesPage.test.tsx
@@ -47,6 +47,8 @@ const mockPolicies = [
     auto_ban_enabled: false,
     ban_threshold: 10,
     ban_duration_seconds: 600,
+    geoip_mode: "off" as const,
+    geoip_countries: [],
     created_by: 1,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",

--- a/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
+++ b/src/frontend/src/pages/policies/PolicyDetailPage.test.tsx
@@ -87,6 +87,8 @@ const mockPolicy: PolicyDetail = {
   auto_ban_enabled: false,
   ban_threshold: 10,
   ban_duration_seconds: 600,
+  geoip_mode: "off",
+  geoip_countries: [],
   created_by: 1,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-02T00:00:00Z",


### PR DESCRIPTION
## Summary

Adds country-level GeoIP filtering per policy (`geoip_mode` = `off` / `allowlist` / `blocklist`, plus `geoip_countries`), configurable on the existing policy create/edit screen.

The lookup is native to HAProxy: the backend converts a country-level MMDB into a plain `CIDR -> ISO code` map file and the template resolves `src` through `map_ip()`. No Lua, no HAProxy MMDB module, no new runtime dependency in the proxy.

**Database source is ip66.dev, not MaxMind GeoLite2.** It needs no license key and no registration, is rebuilt daily, and is CC BY 4.0 (attributed in `docs/architecture.md` and in the generated map header). Dropping the key also removed a leak path: `httpx` embeds the full request URL — query string included — in `HTTPStatusError` messages, which reached both the logs and the API response body. `GEOIP_DATABASE_URL` is configurable for mirrors and air-gapped installs.

### Operational notes for reviewers

- The generated map is ~920k lines / ~18 MB, and costs HAProxy about **280 MB RSS** to load (measured on `haproxy:3.0-alpine`). That is the main running cost of this feature.
- Map generation streams and collapses adjacent networks per run rather than buffering them all: identical output, ~70 MB peak instead of ~780 MB.
- Unresolved addresses **fail open** by default (`GEOIP_FAIL_OPEN`). Note ~306k networks carry no country and a further ~90k are labelled `EU`, which is not an ISO country — so an allowlist of `PL` alone still admits every `EU` network. Documented in `docs/architecture.md`.
- Refresh runs daily via APScheduler, plus `POST /geoip/refresh` on demand, and reloads HAProxy only when the map actually changed.

### Issues found and fixed before opening this PR

Review of the first implementation, plus verification against the real database and the real HAProxy image, turned up:

- **`/health` was a full bypass** — a host-independent path match with no `use_backend` of its own, so a blocked country could reach the customer origin just by requesting `/health`. It is no longer exempt; ACME still is, since it has its own local backend.
- **The config was fatally invalid with long country lists** — HAProxy truncates a config line after 64 words. Codes are now emitted as repeated same-name ACLs of 50.
- **Map generation could not run at all** — the pure-Python `maxminddb` reader raises `::1:0:0/0 has host bits set` partway through the real database, so `MODE_MEMORY` was unusable. Iteration goes through the C extension; a fallback raises an actionable error.
- **A 304 could leave a stub map in place**, so a current database sat behind an empty map that silently failed open.
- **`alembic upgrade head` failed on PostgreSQL** — the enum type was not created before the column referencing it.
- **A GeoIP refresh could reload HAProxy mid-apply**, activating a release that apply was rolling back; the refresh and apply now share one lock.
- **The map stayed a stub for a full day after every boot** — the interval job had no initial run.
- **`UK` vs `GB`** — the database labels a few networks `UK`, which blocking `GB` would have missed. Aliased.
- **The policy form submitted hidden country text** when the mode was `off`, producing a 422 the user could neither see nor fix.

## Test plan

- `uv run pytest --cov=app` — 683 passed, 6 skipped
- `uv run mypy app/` — clean
- `uv run ruff check app/` — clean
- `pnpm run type-check`, `pnpm run lint`, `pnpm test` — clean, 135 frontend tests pass
- `haproxy -c` against a rendered config carrying all 249 ISO codes, run in `haproxy:3.0-alpine` — valid; also started HAProxy with the real 920k-entry map to confirm it loads and to measure its memory
- New tests cover the reload-failure and stub-regeneration paths, the unusable reader, ACL chunking, the `/health` non-exemption, the map-file `OSError` branch, and the scheduler job, which previously had no coverage

Closes #175
